### PR TITLE
Add env vars for overriding GitHub / GitLab hostnames in the `.netrc` file.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `GITLAB_HOSTNAME` and `GITHUB_HOSTNAME` environment variables to allow overriding the default hostnames for GitLab and GitHub.
+
 ## [1.0.0] - 2024-10-01
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,6 +35,9 @@ ENV DATA_DIR=/data
 ENV CONFIG_PATH=$DATA_DIR/config.json
 ENV DATA_CACHE_DIR=$DATA_DIR/.sourcebot
 
+ENV GITHUB_HOSTNAME=github.com
+ENV GITLAB_HOSTNAME=gitlab.com
+
 # @note: This is also set in .env
 ENV NEXT_PUBLIC_POSTHOG_KEY=phc_VFn4CkEGHRdlVyOOw8mfkoj1DKVoG6y1007EClvzAnS
 

--- a/README.md
+++ b/README.md
@@ -176,6 +176,65 @@ docker run -p 3000:3000 --rm --name sourcebot -e <b>GITLAB_TOKEN=[your-gitlab-to
 
 </div>
 
+## Using a self-hosted GitLab / GitHub instance
+
+If you're using a self-hosted GitLab or GitHub instance with a custom domain, there is some additional config required:
+
+<div>
+<details>
+<summary>
+<picture>
+    <source media="(prefers-color-scheme: dark)" srcset=".github/images/github-favicon-inverted.png">
+    <img src="https://github.com/favicon.ico" width="16" height="16" alt="GitHub icon">
+</picture> GitHub
+</summary>
+
+1. In your config, add the `GitHubURL` field to point to your deployment's URL. For example:
+    ```json
+    {
+        "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/index.json",
+        "Configs": [
+            {
+                "Type": "github",
+                "GitHubUrl": "https://github.example.com"
+            }
+        ]
+    }
+
+2. Set the `GITHUB_HOSTNAME` environment variable to your deployment's hostname. For example:
+    <pre>
+    docker run -e <b>GITHUB_HOSTNAME=github.example.com</b> /* additional args */ ghcr.io/sourcebot-dev/sourcebot:latest
+    </pre>
+
+
+</details>
+
+<details>
+<summary><img src="https://gitlab.com/favicon.ico" width="16" height="16" /> GitLab</summary>
+
+
+1. In your config, add the `GitLabURL` field to point to your deployment's URL. For example:
+    ```json
+    {
+        "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/index.json",
+        "Configs": [
+            {
+                "Type": "gitlab",
+                "GitLabURL": "https://gitlab.example.com"
+            }
+        ]
+    }
+    ```
+
+2. Set the `GITLAB_HOSTNAME` environment variable to your deployment's hostname. For example:
+
+    <pre>
+    docker run -e <b>GITLAB_HOSTNAME=gitlab.example.com</b> /* additional args */ ghcr.io/sourcebot-dev/sourcebot:latest
+    </pre>
+
+</details>
+
+</div>
 
 ## Build from source
 >[!NOTE]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -47,10 +47,11 @@ if [ -n "$GITHUB_TOKEN" ]; then
     chmod 600 "$HOME/.github-token"
 
     # Configure Git with the provided GITHUB_TOKEN
-    echo "machine github.com
-       login oauth
-       password ${GITHUB_TOKEN}" >> "$HOME/.netrc"
-       chmod 600 "$HOME/.netrc"
+    echo -e "\e[34m[Info] Configuring GitHub credentials with hostname '$GITHUB_HOSTNAME'.\e[0m"
+    echo "machine ${GITHUB_HOSTNAME}
+    login oauth
+    password ${GITHUB_TOKEN}" >> "$HOME/.netrc"
+    chmod 600 "$HOME/.netrc"
 else
     echo -e "\e[34m[Info] Private GitHub repositories will not be indexed since GITHUB_TOKEN was not set.\e[0m"
 fi
@@ -60,11 +61,12 @@ if [ -n "$GITLAB_TOKEN" ]; then
     echo "$GITLAB_TOKEN" > "$HOME/.gitlab-token"
     chmod 600 "$HOME/.gitlab-token"
    
-       # Configure Git with the provided GITLAB_TOKEN
-       echo "machine gitlab.com
-       login oauth
-       password ${GITLAB_TOKEN}" >> "$HOME/.netrc"
-       chmod 600 "$HOME/.netrc"
+    # Configure Git with the provided GITLAB_TOKEN
+    echo -e "\e[34m[Info] Configuring GitLab credentials with hostname '$GITLAB_HOSTNAME'.\e[0m"
+    echo "machine ${GITLAB_HOSTNAME}
+    login oauth
+    password ${GITLAB_TOKEN}" >> "$HOME/.netrc"
+    chmod 600 "$HOME/.netrc"
 else
     echo -e "\e[34m[Info] GitLab repositories will not be indexed since GITLAB_TOKEN was not set.\e[0m"
 fi

--- a/example-config.json
+++ b/example-config.json
@@ -7,6 +7,12 @@
             "Type": "github",
             "GitHubOrg": "my-org"
         },
+        // Index all repos in self-hosted GitHub instance.
+        // @note: the environment variable GITHUB_HOSTNAME must be set. See README.
+        {
+            "Type": "github",
+            "GitHubUrl": "https://github.example.com"
+        },
         // Index all repos in user "my-user".
         {
             "Type":  "github",
@@ -56,10 +62,11 @@
             "Type": "gitlab"
         },
         // Index all repos visible to the GITLAB_TOKEN (custom GitLab URL).
+        // @note: the environment variable GITLAB_HOSTNAME must also be set. See README.
         {
             "Type": "gitlab",
-            "GitLabURL": "https://gitlab.example.com/api/v4/" /* default: https://gitlab.com/api/v4/ */
-        }
+            "GitLabURL": "https://gitlab.example.com"
+        },
         // Index all repos (public only) visible to the GITLAB_TOKEN.
         {
             "Type": "gitlab",


### PR DESCRIPTION
Adds override env vars `GITLAB_HOSTNAME` and `GITHUB_HOSTNAME` to support authenticating against self-hosted GitLab / GitHub instances.

Fixes #20 