### PR TITLE
fix: fix  javascript btoa function can not handle Unicode strings issue

### DIFF
--- a/src/app/search/components/codePreviewPanel/index.tsx
+++ b/src/app/search/components/codePreviewPanel/index.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { fetchFileSource } from "@/app/api/(client)/client";
-import { getCodeHostFilePreviewLink } from "@/lib/utils";
+import { getCodeHostFilePreviewLink, base64Decode } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { CodePreview, CodePreviewFile } from "./codePreview";
 import { SearchResultFile } from "@/lib/types";
@@ -32,7 +32,7 @@ export const CodePreviewPanel = ({
                     // @todo : refector this to use the templates provided by zoekt.
                     const link = getCodeHostFilePreviewLink(fileMatch.Repository, fileMatch.FileName)
 
-                    const decodedSource = atob(source);
+                    const decodedSource = base64Decode(source);
 
                     // Filter out filename matches
                     const filteredMatches = fileMatch.ChunkMatches.filter((match) => {

--- a/src/app/search/components/searchResultsPanel/fileMatch.tsx
+++ b/src/app/search/components/searchResultsPanel/fileMatch.tsx
@@ -3,6 +3,7 @@
 import { useMemo } from "react";
 import { CodePreview } from "./codePreview";
 import { SearchResultFile, SearchResultFileMatch } from "@/lib/types";
+import { base64Decode } from "@/lib/utils";
 
 
 interface FileMatchProps {
@@ -17,7 +18,7 @@ export const FileMatch = ({
     onOpen,
 }: FileMatchProps) => {
     const content = useMemo(() => {
-        return atob(match.Content);
+        return base64Decode(match.Content);
     }, [match.Content]);
 
     // If it's just the title, don't show a code preview

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -96,3 +96,9 @@ export const getEnvBoolean = (env: string | undefined, defaultValue: boolean) =>
 	}
 	return env === 'true' || env === '1';
 }
+
+// From https://developer.mozilla.org/en-US/docs/Glossary/Base64#the_unicode_problem
+export const base64Decode = (base64: string): string => {
+    const binString = atob(base64);
+    return Buffer.from(Uint8Array.from(binString, (m) => m.codePointAt(0)!).buffer).toString();
+}


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/c7d8c1a0-f6dc-4985-8043-f6a2143b542b)


see https://web.dev/articles/base64-encoding#strings_in_unicode_and_javascript

https://stackoverflow.com/questions/30106476/using-javascripts-atob-to-decode-base64-doesnt-properly-decode-utf-8-strings

https://stackoverflow.com/questions/8936984/uint8array-to-string-in-javascript
