### PR TITLE
[Fix] Change GitLab syncing behaviour for `groups` and `users` to include projects that are _not_ owned by the token

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue with GitLab projects that are not owned but still visible by the provided `token` _not_ being synchronized. ([#51](https://github.com/sourcebot-dev/sourcebot/pull/51))
+
 ## [2.1.0] - 2024-10-22
 
 ### Added

--- a/packages/backend/src/gitlab.ts
+++ b/packages/backend/src/gitlab.ts
@@ -25,7 +25,6 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
             logger.debug(`Fetching project info for group ${group}...`);
             const { durationMs, data } = await measure(() => api.Groups.allProjects(group, {
                 perPage: 100,
-                owned: true,
             }));
             logger.debug(`Found ${data.length} projects in group ${group} in ${durationMs}ms.`);
 
@@ -40,7 +39,6 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
             logger.debug(`Fetching project info for user ${user}...`);
             const { durationMs, data } = await measure(() => api.Users.allProjects(user, {
                 perPage: 100,
-                owned: true,
             }));
             logger.debug(`Found ${data.length} projects owned by user ${user} in ${durationMs}ms.`);
             return data;

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -80,7 +80,7 @@ export interface GitLabConfig {
    */
   url?: string;
   /**
-   * List of users to sync with. All personal projects that the user owns will be synced, unless explicitly defined in the `exclude` property.
+   * List of users to sync with. All projects owned by the user and visible to the provided `token` (if any) will be synced, unless explicitly defined in the `exclude` property.
    */
   users?: string[];
   /**

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -151,7 +151,7 @@
                     "items": {
                         "type": "string"
                     },
-                    "description": "List of users to sync with. All personal projects that the user owns will be synced, unless explicitly defined in the `exclude` property."
+                    "description": "List of users to sync with. All projects owned by the user and visible to the provided `token` (if any) will be synced, unless explicitly defined in the `exclude` property."
                 },
                 "groups": {
                     "type": "array",


### PR DESCRIPTION
Previously, we were using the `owned=true` query parameter for our requests to [GET /groups/:id/projects](https://docs.gitlab.com/ee/api/groups.html#list-projects) and [GET /users/:user_id/projects](https://docs.gitlab.com/ee/api/projects.html#list-a-users-projects) which "Limits by projects explicitly owned by the current user.". This becomes an issue when the provided access token isn't associated with a user with type `owner` for all projects in the group / user.

This PR removes this constraint.

Fixes #50 