### PR TITLE
Improve rendering performance of search results

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "dbaeumer.vscode-eslint"
+    ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -2,5 +2,10 @@
     "files.associations": {
         "*.json": "jsonc",
         "index.json": "json"
-    }
+    },
+    "eslint.workingDirectories": [
+        {
+            "pattern": "./packages/*/"
+        }
+    ]
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed issue with GitLab sub-projects not being included recursively. ([#54](https://github.com/sourcebot-dev/sourcebot/pull/54))
+- Fixed slow rendering performance when rendering a large number of results. ([#52](https://github.com/sourcebot-dev/sourcebot/pull/52))
 
 ## [2.1.1] - 2024-10-25
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,6 +38,8 @@
     "@replit/codemirror-vim": "^6.2.1",
     "@tanstack/react-query": "^5.53.3",
     "@tanstack/react-table": "^8.20.5",
+    "@tanstack/react-virtual": "^3.10.8",
+    "@uiw/codemirror-theme-basic": "^4.23.6",
     "@uiw/react-codemirror": "^4.23.0",
     "class-variance-authority": "^0.7.0",
     "client-only": "^0.0.1",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,6 @@
     "@tanstack/react-query": "^5.53.3",
     "@tanstack/react-table": "^8.20.5",
     "@tanstack/react-virtual": "^3.10.8",
-    "@uiw/codemirror-theme-basic": "^4.23.6",
     "@uiw/react-codemirror": "^4.23.0",
     "class-variance-authority": "^0.7.0",
     "client-only": "^0.0.1",

--- a/packages/web/src/app/search/components/codePreviewPanel/index.tsx
+++ b/packages/web/src/app/search/components/codePreviewPanel/index.tsx
@@ -59,5 +59,4 @@ export const CodePreviewPanel = ({
             onSelectedMatchIndexChange={onSelectedMatchIndexChange}
         />
     )
-
 }

--- a/packages/web/src/app/search/components/filterPanel/index.tsx
+++ b/packages/web/src/app/search/components/filterPanel/index.tsx
@@ -93,7 +93,7 @@ export const FilterPanel = ({
         );
 
         onFilterChanged(filteredMatches);
-    }, [matches, repos, languages]);
+    }, [matches, repos, languages, onFilterChanged]);
 
     return (
         <div className="p-3 flex flex-col gap-3">

--- a/packages/web/src/app/search/components/searchResultsPanel/codePreview.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/codePreview.tsx
@@ -1,12 +1,15 @@
 'use client';
 
 import { useExtensionWithDependency } from "@/hooks/useExtensionWithDependency";
+import { syntaxHighlighting as syntaxHighlightingExtension, defaultHighlightStyle } from "@codemirror/language";
 import { useSyntaxHighlightingExtension } from "@/hooks/useSyntaxHighlightingExtension";
 import { useThemeNormalized } from "@/hooks/useThemeNormalized";
 import { lineOffsetExtension } from "@/lib/extensions/lineOffsetExtension";
 import { SearchResultRange } from "@/lib/types";
-import CodeMirror, { Decoration, DecorationSet, EditorState, EditorView, ReactCodeMirrorRef, StateField, Transaction } from "@uiw/react-codemirror";
-import { useMemo, useRef } from "react";
+import { javascript } from "@codemirror/lang-javascript";
+import CodeMirror, { Decoration, DecorationSet, EditorState, EditorView, lineNumbers, ReactCodeMirrorRef, StateField, Transaction, useCodeMirror } from "@uiw/react-codemirror";
+import { basicLight, basicDark } from '@uiw/codemirror-theme-basic';
+import { useEffect, useMemo, useRef, useState } from "react";
 
 const markDecoration = Decoration.mark({
     class: "cm-searchMatch-selected"
@@ -25,101 +28,152 @@ export const CodePreview = ({
     ranges,
     lineOffset,
 }: CodePreviewProps) => {
-    const editorRef = useRef<ReactCodeMirrorRef>(null);
-    const { theme } = useThemeNormalized();
 
-    const syntaxHighlighting = useSyntaxHighlightingExtension(language, editorRef.current?.view);
+    // const editor = useRef<HTMLDivElement | null>(null);
+    // const { setContainer } = useCodeMirror({
+    //     container: editor.current,
+    //     extensions,
+    //     value: content,
+    //     theme: "dark"
+    // });
 
-    const rangeHighlighting = useExtensionWithDependency(editorRef.current?.view ?? null, () => {
-        return [
-            StateField.define<DecorationSet>({
-                create(editorState: EditorState) {
-                    const document = editorState.doc;
+    // useEffect(() => {
+    //     if (editor.current) {
+    //         setContainer(editor.current);
+    //     }
+    // }, [editor.current]);
 
-                    const decorations = ranges
-                        .sort((a, b) => {
-                            return a.Start.ByteOffset - b.Start.ByteOffset;
-                        })
-                        .filter(({ Start, End }) => {
-                            const startLine = Start.LineNumber - lineOffset;
-                            const endLine = End.LineNumber - lineOffset;
+    // return <div ref={editor} />;
 
-                            if (
-                                startLine < 1 ||
-                                endLine < 1 ||
-                                startLine > document.lines ||
-                                endLine > document.lines
-                            ) {
-                                return false;
-                            }
-                            return true;
-                        })
-                        .map(({ Start, End }) => {
-                            const startLine = Start.LineNumber - lineOffset;
-                            const endLine = End.LineNumber - lineOffset;
+    // const editorRef = useRef<ReactCodeMirrorRef>(null);
+    // const { theme } = useThemeNormalized();
 
-                            const from = document.line(startLine).from + Start.Column - 1;
-                            const to = document.line(endLine).from + End.Column - 1;
-                            return markDecoration.range(from, to);
-                        });
 
-                    return Decoration.set(decorations);
-                },
-                update(highlights: DecorationSet, _transaction: Transaction) {
-                    return highlights;
-                },
-                provide: (field) => EditorView.decorations.from(field),
-            }),
-        ];
-    }, [ranges, lineOffset]);
+    // const rangeHighlighting = useExtensionWithDependency(editorRef.current?.view ?? null, () => {
+    //     return [
+    //         StateField.define<DecorationSet>({
+    //             create(editorState: EditorState) {
+    //                 const document = editorState.doc;
 
-    const extensions = useMemo(() => {
-        return [
-            syntaxHighlighting,
-            EditorView.lineWrapping,
-            lineOffsetExtension(lineOffset),
-            rangeHighlighting,
-        ];
-    }, [syntaxHighlighting, lineOffset, rangeHighlighting]);
+    //                 const decorations = ranges
+    //                     .sort((a, b) => {
+    //                         return a.Start.ByteOffset - b.Start.ByteOffset;
+    //                     })
+    //                     .filter(({ Start, End }) => {
+    //                         const startLine = Start.LineNumber - lineOffset;
+    //                         const endLine = End.LineNumber - lineOffset;
+
+    //                         if (
+    //                             startLine < 1 ||
+    //                             endLine < 1 ||
+    //                             startLine > document.lines ||
+    //                             endLine > document.lines
+    //                         ) {
+    //                             return false;
+    //                         }
+    //                         return true;
+    //                     })
+    //                     .map(({ Start, End }) => {
+    //                         const startLine = Start.LineNumber - lineOffset;
+    //                         const endLine = End.LineNumber - lineOffset;
+
+    //                         const from = document.line(startLine).from + Start.Column - 1;
+    //                         const to = document.line(endLine).from + End.Column - 1;
+    //                         return markDecoration.range(from, to);
+    //                     });
+
+    //                 return Decoration.set(decorations);
+    //             },
+    //             update(highlights: DecorationSet, _transaction: Transaction) {
+    //                 return highlights;
+    //             },
+    //             provide: (field) => EditorView.decorations.from(field),
+    //         }),
+    //     ];
+    // }, [ranges, lineOffset]);
+
+    // const extensions = useMemo(() => {
+    //     return [
+    //         syntaxHighlighting,
+    //         // EditorView.lineWrapping,
+    //         lineOffsetExtension(lineOffset),
+    //         rangeHighlighting,
+    //     ];
+    // }, [syntaxHighlighting, lineOffset, rangeHighlighting]);
+
+
+    const editorRef2 = useRef<HTMLDivElement>(null);
+    // const syntaxHighlighting = useSyntaxHighlightingExtension(language, editorRef2.current?.view);
+
+    useEffect(() => {
+        const state = EditorState.create({
+            doc: content,
+            extensions: [
+                EditorView.editable.of(false),
+                // EditorView.lineWrapping,
+                basicDark,
+                syntaxHighlightingExtension(defaultHighlightStyle),
+                javascript(),
+                lineNumbers(),
+                lineOffsetExtension(lineOffset),
+                // rangeHighlighting,
+            ],
+        });
+
+        const view = new EditorView({
+            state,
+            parent: editorRef2.current!,
+        });
+
+        return () => {
+            view.destroy();
+        }
+    }, [lineOffset]);
 
     return (
-        <CodeMirror
-            ref={editorRef}
-            readOnly={true}
-            editable={false}
-            value={content}
-            theme={theme === "dark" ? "dark" : "light"}
-            basicSetup={{
-                lineNumbers: true,
-                syntaxHighlighting: true,
-
-                // Disable all this other stuff...
-                ... {
-                    foldGutter: false,
-                    highlightActiveLineGutter: false,
-                    highlightSpecialChars: false,
-                    history: false,
-                    drawSelection: false,
-                    dropCursor: false,
-                    allowMultipleSelections: false,
-                    indentOnInput: false,
-                    bracketMatching: false,
-                    closeBrackets: false,
-                    autocompletion: false,
-                    rectangularSelection: false,
-                    crosshairCursor: false,
-                    highlightActiveLine: false,
-                    highlightSelectionMatches: false,
-                    closeBracketsKeymap: false,
-                    defaultKeymap: false,
-                    searchKeymap: false,
-                    historyKeymap: false,
-                    foldKeymap: false,
-                    completionKeymap: false,
-                    lintKeymap: false,
-                }
-            }}
-            extensions={extensions}
+        <div
+            ref={editorRef2}
         />
     )
+
+    // return (
+    //     <CodeMirror
+    //         ref={editorRef}
+    //         readOnly={true}
+    //         editable={false}
+    //         value={content}
+    //         theme={theme === "dark" ? "dark" : "light"}
+    //         basicSetup={{
+    //             lineNumbers: true,
+    //             syntaxHighlighting: true,
+
+    //             // Disable all this other stuff...
+    //             ... {
+    //                 foldGutter: false,
+    //                 highlightActiveLineGutter: false,
+    //                 highlightSpecialChars: false,
+    //                 history: false,
+    //                 drawSelection: false,
+    //                 dropCursor: false,
+    //                 allowMultipleSelections: false,
+    //                 indentOnInput: false,
+    //                 bracketMatching: false,
+    //                 closeBrackets: false,
+    //                 autocompletion: false,
+    //                 rectangularSelection: false,
+    //                 crosshairCursor: false,
+    //                 highlightActiveLine: false,
+    //                 highlightSelectionMatches: false,
+    //                 closeBracketsKeymap: false,
+    //                 defaultKeymap: false,
+    //                 searchKeymap: false,
+    //                 historyKeymap: false,
+    //                 foldKeymap: false,
+    //                 completionKeymap: false,
+    //                 lintKeymap: false,
+    //             }
+    //         }}
+    //         extensions={extensions}
+    //     />
+    // )
 }

--- a/packages/web/src/app/search/components/searchResultsPanel/codePreview.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/codePreview.tsx
@@ -1,18 +1,19 @@
 'use client';
 
-import { SearchResultRange } from "@/lib/types";
-import { EditorState, StateField, Transaction } from "@codemirror/state";
-import { Decoration, DecorationSet, EditorView, lineNumbers } from "@codemirror/view";
-import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
-import { useEffect, useRef } from "react";
-import { lineOffsetExtension } from "@/lib/extensions/lineOffsetExtension";
 import { getSyntaxHighlightingExtension } from "@/hooks/useSyntaxHighlightingExtension";
+import { lineOffsetExtension } from "@/lib/extensions/lineOffsetExtension";
+import { SearchResultRange } from "@/lib/types";
+import { defaultHighlightStyle, syntaxHighlighting } from "@codemirror/language";
+import { EditorState, StateField, Transaction } from "@codemirror/state";
+import { defaultLightThemeOption, oneDarkHighlightStyle, oneDarkTheme } from "@uiw/react-codemirror";
+import { Decoration, DecorationSet, EditorView, lineNumbers } from "@codemirror/view";
+import { useMemo, useRef } from "react";
+import { LightweightCodeMirror, CodeMirrorRef } from "./lightweightCodeMirror";
 import { useThemeNormalized } from "@/hooks/useThemeNormalized";
 
 const markDecoration = Decoration.mark({
     class: "cm-searchMatch-selected"
 });
-
 
 interface CodePreviewProps {
     content: string,
@@ -27,78 +28,69 @@ export const CodePreview = ({
     ranges,
     lineOffset,
 }: CodePreviewProps) => {
-
-    const containerRef = useRef<HTMLDivElement | null>(null);
+    const editorRef = useRef<CodeMirrorRef>(null);
     const { theme } = useThemeNormalized();
 
-    useEffect(() => {
-        if (!containerRef.current) {
-            return;
-        }
-
-        const state = EditorState.create({
-            doc: content,
-            extensions: [
-                EditorView.editable.of(false),
-                lineNumbers(),
-                lineOffsetExtension(lineOffset),
+    const extensions = useMemo(() => {
+        return [
+            EditorView.editable.of(false),
+            ...(theme === 'dark' ? [
+                syntaxHighlighting(oneDarkHighlightStyle),
+                oneDarkTheme,
+            ] : [
                 syntaxHighlighting(defaultHighlightStyle),
-                getSyntaxHighlightingExtension(language),
-                StateField.define<DecorationSet>({
-                    create(editorState: EditorState) {
-                        const document = editorState.doc;
-    
-                        const decorations = ranges
-                            .sort((a, b) => {
-                                return a.Start.ByteOffset - b.Start.ByteOffset;
-                            })
-                            .filter(({ Start, End }) => {
-                                const startLine = Start.LineNumber - lineOffset;
-                                const endLine = End.LineNumber - lineOffset;
-    
-                                if (
-                                    startLine < 1 ||
-                                    endLine < 1 ||
-                                    startLine > document.lines ||
-                                    endLine > document.lines
-                                ) {
-                                    return false;
-                                }
-                                return true;
-                            })
-                            .map(({ Start, End }) => {
-                                const startLine = Start.LineNumber - lineOffset;
-                                const endLine = End.LineNumber - lineOffset;
-    
-                                const from = document.line(startLine).from + Start.Column - 1;
-                                const to = document.line(endLine).from + End.Column - 1;
-                                return markDecoration.range(from, to);
-                            });
-    
-                        return Decoration.set(decorations);
-                    },
-                    update(highlights: DecorationSet, _transaction: Transaction) {
-                        return highlights;
-                    },
-                    provide: (field) => EditorView.decorations.from(field),
-                }),
-                getSyntaxHighlightingExtension(language),
-            ],
-        });
+                defaultLightThemeOption,
+            ]),
+            lineNumbers(),
+            lineOffsetExtension(lineOffset),
+            getSyntaxHighlightingExtension(language),
+            StateField.define<DecorationSet>({
+                create(editorState: EditorState) {
+                    const document = editorState.doc;
 
-        const view = new EditorView({
-            state,
-            parent: containerRef.current,
-        });
+                    const decorations = ranges
+                        .sort((a, b) => {
+                            return a.Start.ByteOffset - b.Start.ByteOffset;
+                        })
+                        .filter(({ Start, End }) => {
+                            const startLine = Start.LineNumber - lineOffset;
+                            const endLine = End.LineNumber - lineOffset;
 
-        return () => {
-            view.destroy();
-        }
-    }, [content, language, lineOffset, theme]);
+                            if (
+                                startLine < 1 ||
+                                endLine < 1 ||
+                                startLine > document.lines ||
+                                endLine > document.lines
+                            ) {
+                                return false;
+                            }
+                            return true;
+                        })
+                        .map(({ Start, End }) => {
+                            const startLine = Start.LineNumber - lineOffset;
+                            const endLine = End.LineNumber - lineOffset;
+
+                            const from = document.line(startLine).from + Start.Column - 1;
+                            const to = document.line(endLine).from + End.Column - 1;
+                            return markDecoration.range(from, to);
+                        })
+                        .sort((a, b) => a.from - b.from);
+
+                    return Decoration.set(decorations);
+                },
+                update(highlights: DecorationSet, _transaction: Transaction) {
+                    return highlights;
+                },
+                provide: (field) => EditorView.decorations.from(field),
+            }),
+        ]
+    }, [language, lineOffset, ranges, theme]);
 
     return (
-        <div
-            ref={containerRef}
+        <LightweightCodeMirror
+            ref={editorRef}
+            value={content}
+            extensions={extensions}
         />
     )
 

--- a/packages/web/src/app/search/components/searchResultsPanel/fileMatch.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/fileMatch.tsx
@@ -29,7 +29,7 @@ export const FileMatch = ({
     return (
         <div
             tabIndex={0}
-            className="cursor-pointer p-1 focus:ring-inset focus:ring-4 bg-white dark:bg-[#282c34]"
+            className="cursor-pointer focus:ring-inset focus:ring-4 bg-white dark:bg-[#282c34]"
             onKeyDown={(e) => {
                 if (e.key !== "Enter") {
                     return;

--- a/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { getRepoCodeHostInfo } from "@/lib/utils";
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import Image from "next/image";
 import { DoubleArrowDownIcon, DoubleArrowUpIcon, FileIcon } from "@radix-ui/react-icons";
 import clsx from "clsx";
@@ -15,15 +15,18 @@ interface FileMatchContainerProps {
     file: SearchResultFile;
     onOpenFile: () => void;
     onMatchIndexChanged: (matchIndex: number) => void;
+    showAllMatches: boolean;
+    onShowAllMatchesButtonClicked: () => void;
 }
 
 export const FileMatchContainer = ({
     file,
     onOpenFile,
     onMatchIndexChanged,
+    showAllMatches,
+    onShowAllMatchesButtonClicked,
 }: FileMatchContainerProps) => {
 
-    const [showAll, setShowAll] = useState(false);
     const matchCount = useMemo(() => {
         return file.ChunkMatches.length;
     }, [file]);
@@ -33,12 +36,12 @@ export const FileMatchContainer = ({
             return a.ContentStart.LineNumber - b.ContentStart.LineNumber;
         });
 
-        if (!showAll) {
+        if (!showAllMatches) {
             return sortedMatches.slice(0, MAX_MATCHES_TO_PREVIEW);
         }
 
         return sortedMatches;
-    }, [file, showAll]);
+    }, [file, showAllMatches]);
 
     const fileNameRange = useMemo(() => {
         for (const match of matches) {
@@ -78,10 +81,6 @@ export const FileMatchContainer = ({
     const isMoreContentButtonVisible = useMemo(() => {
         return matchCount > MAX_MATCHES_TO_PREVIEW;
     }, [matchCount]);
-
-    const onShowMoreMatches = useCallback(() => {
-        setShowAll(!showAll);
-    }, [showAll]);
 
     const onOpenMatch = useCallback((index: number) => {
         const matchIndex = matches.slice(0, index).reduce((acc, match) => {
@@ -161,15 +160,15 @@ export const FileMatchContainer = ({
                         if (e.key !== "Enter") {
                             return;
                         }
-                        onShowMoreMatches();
+                        onShowAllMatchesButtonClicked();
                     }}
-                    onClick={onShowMoreMatches}
+                    onClick={onShowAllMatchesButtonClicked}
                 >
                     <p
                         className="text-blue-500 cursor-pointer text-sm flex flex-row items-center gap-2"
                     >
-                        {showAll ? <DoubleArrowUpIcon className="w-3 h-3" /> : <DoubleArrowDownIcon className="w-3 h-3" />}
-                        {showAll ? `Show fewer matches` : `Show ${matchCount - MAX_MATCHES_TO_PREVIEW} more matches`}
+                        {showAllMatches ? <DoubleArrowUpIcon className="w-3 h-3" /> : <DoubleArrowDownIcon className="w-3 h-3" />}
+                        {showAllMatches ? `Show fewer matches` : `Show ${matchCount - MAX_MATCHES_TO_PREVIEW} more matches`}
                     </p>
                 </div>
             )}

--- a/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
@@ -95,7 +95,7 @@ export const FileMatchContainer = ({
     return (
         <div>
             <div
-                className="sticky top-0 bg-cyan-200 dark:bg-cyan-900 primary-foreground px-2 py-0.5 flex flex-row items-center justify-between cursor-pointer z-10"
+                className="top-0 bg-cyan-200 dark:bg-cyan-900 primary-foreground px-2 py-0.5 flex flex-row items-center justify-between cursor-pointer"
                 onClick={() => {
                     onOpenFile();
                 }}

--- a/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/fileMatchContainer.tsx
@@ -9,7 +9,7 @@ import { Separator } from "@/components/ui/separator";
 import { SearchResultFile } from "@/lib/types";
 import { FileMatch } from "./fileMatch";
 
-const MAX_MATCHES_TO_PREVIEW = 3;
+export const MAX_MATCHES_TO_PREVIEW = 3;
 
 interface FileMatchContainerProps {
     file: SearchResultFile;
@@ -94,6 +94,7 @@ export const FileMatchContainer = ({
 
     return (
         <div>
+            {/* Title */}
             <div
                 className="top-0 bg-cyan-200 dark:bg-cyan-900 primary-foreground px-2 py-0.5 flex flex-row items-center justify-between cursor-pointer"
                 onClick={() => {
@@ -132,6 +133,8 @@ export const FileMatchContainer = ({
                     </div>
                 </div>
             </div>
+
+            {/* Matches */}
             {matches.map((match, index) => (
                 <div
                     key={index}
@@ -148,6 +151,8 @@ export const FileMatchContainer = ({
                     )}
                 </div>
             ))}
+
+            {/* Show more button */}
             {isMoreContentButtonVisible && (
                 <div
                     tabIndex={0}

--- a/packages/web/src/app/search/components/searchResultsPanel/index.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/index.tsx
@@ -2,6 +2,8 @@
 
 import { SearchResultFile } from "@/lib/types";
 import { FileMatchContainer } from "./fileMatchContainer";
+import { useVirtualizer } from "@tanstack/react-virtual";
+import { useEffect, useRef } from "react";
 
 interface SearchResultsPanelProps {
     fileMatches: SearchResultFile[];
@@ -14,16 +16,87 @@ export const SearchResultsPanel = ({
     onOpenFileMatch,
     onMatchIndexChanged,
 }: SearchResultsPanelProps) => {
-    return fileMatches.map((fileMatch, index) => (
-        <FileMatchContainer
-            key={index}
-            file={fileMatch}
-            onOpenFile={() => {
-                onOpenFileMatch(fileMatch);
+    const parentRef = useRef<HTMLDivElement>(null);
+
+    const virtualizer = useVirtualizer({
+        count: fileMatches.length,
+        getScrollElement: () => parentRef.current,
+        estimateSize: (index) => {
+            const match = fileMatches[index];
+            if (match.FileName) {
+                return 30;
+            }
+
+            return 150;
+        },
+        measureElement: (element, entry, instance) => {
+            // @see : https://github.com/TanStack/virtual/issues/659
+            const direction = instance.scrollDirection;
+            if (direction === "forward" || direction === null) {
+                return element.scrollHeight;
+            } else {
+                // don't remeasure if we are scrolling up
+                const indexKey = Number(element.getAttribute("data-index"));
+                const cacheMeasurement = instance.itemSizeCache.get(indexKey);
+                return cacheMeasurement;
+            }
+        },
+        enabled: true,
+        overscan: 10,
+    });
+
+    useEffect(() => {
+        virtualizer.scrollToIndex(0);
+        console.log('reset');
+        // virtualizer.elementsCache.clear();
+    }, [fileMatches]);
+
+    const items = virtualizer.getVirtualItems();
+    console.log(items.length);
+
+    return (
+        <div
+            ref={parentRef}
+            style={{
+                width: "100%",
+                height: "100%",
+                overflowY: 'auto',
+                contain: 'strict',
             }}
-            onMatchIndexChanged={(matchIndex) => {
-                onMatchIndexChanged(matchIndex);
-            }}
-        />
-    ))
+        >
+            <div
+                style={{
+                    height: virtualizer.getTotalSize(),
+                    width: "100%",
+                    position: "relative",
+                }}
+            >
+                {items.map((virtualRow) => (
+                    <div
+                        key={virtualRow.key}
+                        data-index={virtualRow.index}
+                        ref={virtualizer.measureElement}
+                        style={{
+                            position: 'absolute',
+                            top: 0,
+                            left: 0,
+                            width: '100%',
+                            transform: `translateY(${virtualRow.start}px)`,
+                        }}
+                    >
+                        <FileMatchContainer
+                            file={fileMatches[virtualRow.index]}
+                            onOpenFile={() => {
+                                onOpenFileMatch(fileMatches[virtualRow.index]);
+                            }}
+                            onMatchIndexChanged={(matchIndex) => {
+                                onMatchIndexChanged(matchIndex);
+                            }}
+                        />
+                    </div>
+                ))}
+            </div>
+            <p>Load more</p>
+        </div>
+    )
 }

--- a/packages/web/src/app/search/components/searchResultsPanel/lightweightCodeMirror.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/lightweightCodeMirror.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import { EditorState, Extension, StateEffect } from "@codemirror/state";
+import { EditorView } from "@codemirror/view";
+import { forwardRef, useEffect, useImperativeHandle, useRef, useState } from "react";
+
+interface CodeMirrorProps {
+    value?: string;
+    extensions?: Extension[];
+    className?: string;
+}
+
+export interface CodeMirrorRef {
+    editor: HTMLDivElement | null;
+    state?: EditorState;
+    view?: EditorView;
+}
+
+/**
+ * This component provides a lightweight CodeMirror component that has been optimized to
+ * render quickly in the search results panel. Why not use react-codemirror? For whatever reason,
+ * react-codemirror issues many StateEffects when first rendering, causing a stuttery scroll
+ * experience as new cells load. This component is a workaround for that issue and provides
+ * a minimal react wrapper around CodeMirror that avoids this issue.
+ */
+const LightweightCodeMirror = forwardRef<CodeMirrorRef, CodeMirrorProps>(({
+    value,
+    extensions,
+    className,
+}, ref) => {
+    const editor = useRef<HTMLDivElement | null>(null);
+    const [view, setView] = useState<EditorView>();
+    const [state, setState] = useState<EditorState>();
+
+    useImperativeHandle(ref, () => ({
+        editor: editor.current,
+        state,
+        view,
+    }), [editor, state, view]);
+
+    useEffect(() => {
+        if (!editor.current) {
+            return;
+        }
+
+        const state = EditorState.create({
+            extensions: [], /* extensions are explicitly left out here */
+            doc: value,
+        });
+        setState(state);
+
+        const view = new EditorView({
+            state,
+            parent: editor.current,
+        });
+        setView(view);
+
+        console.debug(`[CM] Editor created.`);
+
+        return () => {
+            view.destroy();
+            setView(undefined);
+            setState(undefined);
+            console.debug(`[CM] Editor destroyed.`);
+        }
+
+    }, [value]);
+
+    useEffect(() => {
+        if (view) {
+            view.dispatch({ effects: StateEffect.reconfigure.of(extensions ?? []) });
+            console.debug(`[CM] Editor reconfigured.`);
+        }
+    }, [extensions, view]);
+
+    return (
+        <div
+            className={className}
+            ref={editor}
+        />
+    )
+});
+
+LightweightCodeMirror.displayName = "LightweightCodeMirror";
+
+export { LightweightCodeMirror };

--- a/packages/web/src/app/search/components/searchResultsPanel/lightweightCodeMirror.tsx
+++ b/packages/web/src/app/search/components/searchResultsPanel/lightweightCodeMirror.tsx
@@ -55,13 +55,13 @@ const LightweightCodeMirror = forwardRef<CodeMirrorRef, CodeMirrorProps>(({
         });
         setView(view);
 
-        console.debug(`[CM] Editor created.`);
+        // console.debug(`[CM] Editor created.`);
 
         return () => {
             view.destroy();
             setView(undefined);
             setState(undefined);
-            console.debug(`[CM] Editor destroyed.`);
+            // console.debug(`[CM] Editor destroyed.`);
         }
 
     }, [value]);
@@ -69,7 +69,7 @@ const LightweightCodeMirror = forwardRef<CodeMirrorRef, CodeMirrorProps>(({
     useEffect(() => {
         if (view) {
             view.dispatch({ effects: StateEffect.reconfigure.of(extensions ?? []) });
-            console.debug(`[CM] Editor reconfigured.`);
+            // console.debug(`[CM] Editor reconfigured.`);
         }
     }, [extensions, view]);
 

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -243,7 +243,7 @@ const PanelGroup = ({
                 order={2}
             >
                 {filteredFileMatches.length > 0 ? (
-                    <ScrollArea
+                    <div
                         className="h-full"
                     >
                         <SearchResultsPanel
@@ -265,8 +265,7 @@ const PanelGroup = ({
                                 </span>
                             </div>
                         )}
-                        <Scrollbar orientation="vertical" />
-                    </ScrollArea>
+                    </div>
                 ) : (
                     <div className="flex flex-col items-center justify-center h-full">
                         <p className="text-sm text-muted-foreground">No results found</p>

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -25,7 +25,7 @@ import { FilterPanel } from "./components/filterPanel";
 import { SearchResultsPanel } from "./components/searchResultsPanel";
 import { ImperativePanelHandle } from "react-resizable-panels";
 
-const DEFAULT_MAX_MATCH_DISPLAY_COUNT = 200;
+const DEFAULT_MAX_MATCH_DISPLAY_COUNT = 2048;
 
 export default function SearchPage() {
     const router = useRouter();
@@ -243,29 +243,17 @@ const PanelGroup = ({
                 order={2}
             >
                 {filteredFileMatches.length > 0 ? (
-                    <div
-                        className="h-full"
-                    >
-                        <SearchResultsPanel
-                            fileMatches={filteredFileMatches}
-                            onOpenFileMatch={(fileMatch) => {
-                                setSelectedFile(fileMatch);
-                            }}
-                            onMatchIndexChanged={(matchIndex) => {
-                                setSelectedMatchIndex(matchIndex);
-                            }}
-                        />
-                        {isMoreResultsButtonVisible && (
-                            <div className="p-3">
-                                <span
-                                    className="cursor-pointer text-blue-500 hover:underline"
-                                    onClick={onLoadMoreResults}
-                                >
-                                    Load more results
-                                </span>
-                            </div>
-                        )}
-                    </div>
+                    <SearchResultsPanel
+                        fileMatches={filteredFileMatches}
+                        onOpenFileMatch={(fileMatch) => {
+                            setSelectedFile(fileMatch);
+                        }}
+                        onMatchIndexChanged={(matchIndex) => {
+                            setSelectedMatchIndex(matchIndex);
+                        }}
+                        isLoadMoreButtonVisible={!!isMoreResultsButtonVisible}
+                        onLoadMoreButtonClicked={onLoadMoreResults}
+                    />
                 ) : (
                     <div className="flex flex-col items-center justify-center h-full">
                         <p className="text-sm text-muted-foreground">No results found</p>

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -25,7 +25,7 @@ import { FilterPanel } from "./components/filterPanel";
 import { SearchResultsPanel } from "./components/searchResultsPanel";
 import { ImperativePanelHandle } from "react-resizable-panels";
 
-const DEFAULT_MAX_MATCH_DISPLAY_COUNT = 2048;
+const DEFAULT_MAX_MATCH_DISPLAY_COUNT = 10000;
 
 export default function SearchPage() {
     const router = useRouter();

--- a/packages/web/src/app/search/page.tsx
+++ b/packages/web/src/app/search/page.tsx
@@ -5,14 +5,12 @@ import {
     ResizablePanel,
     ResizablePanelGroup,
 } from "@/components/ui/resizable";
-import { ScrollArea } from "@/components/ui/scroll-area";
 import { Separator } from "@/components/ui/separator";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useNonEmptyQueryParam } from "@/hooks/useNonEmptyQueryParam";
 import { SearchQueryParams, SearchResultFile } from "@/lib/types";
 import { createPathWithQueryParams } from "@/lib/utils";
 import { SymbolIcon } from "@radix-ui/react-icons";
-import { Scrollbar } from "@radix-ui/react-scroll-area";
 import { useQuery } from "@tanstack/react-query";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
@@ -212,6 +210,10 @@ const PanelGroup = ({
         }
     }, [selectedFile]);
 
+    const onFilterChanged = useCallback((matches: SearchResultFile[]) => {
+        setFilteredFileMatches(matches);
+    }, []);
+
     return (
         <ResizablePanelGroup
             direction="horizontal"
@@ -227,9 +229,7 @@ const PanelGroup = ({
             >
                 <FilterPanel
                     matches={fileMatches}
-                    onFilterChanged={(filteredFileMatches) => {
-                        setFilteredFileMatches(filteredFileMatches)
-                    }}
+                    onFilterChanged={onFilterChanged}
                 />
             </ResizablePanel>
             <ResizableHandle

--- a/packages/web/src/hooks/useSyntaxHighlightingExtension.ts
+++ b/packages/web/src/hooks/useSyntaxHighlightingExtension.ts
@@ -21,46 +21,50 @@ export const useSyntaxHighlightingExtension = (language: string, view: EditorVie
     const extension = useExtensionWithDependency(
         view ?? null,
         () => {
-            switch (language.toLowerCase()) {
-                case "c":
-                case "c++":
-                    return cpp();
-                case "c#":
-                    return csharp();
-                case "json":
-                    return json();
-                case "java":
-                    return java();
-                case "rust":
-                    return rust();
-                case "go":
-                    return go();
-                case "sql":
-                    return sql();
-                case "php":
-                    return php();
-                case "html":
-                    return html();
-                case "css":
-                    return css();
-                case "jsx":
-                case "tsx":
-                case "typescript":
-                case "javascript":
-                    return javascript({
-                        jsx: true,
-                        typescript: true,
-                    });
-                case "python":
-                    return python();
-                case "markdown":
-                    return markdown();
-                default:
-                    return [];
-            }
+            return getSyntaxHighlightingExtension(language);
         },
         [language]
     );
 
     return extension;
+}
+
+export const getSyntaxHighlightingExtension = (language: string) => {
+    switch (language.toLowerCase()) {
+        case "c":
+        case "c++":
+            return cpp();
+        case "c#":
+            return csharp();
+        case "json":
+            return json();
+        case "java":
+            return java();
+        case "rust":
+            return rust();
+        case "go":
+            return go();
+        case "sql":
+            return sql();
+        case "php":
+            return php();
+        case "html":
+            return html();
+        case "css":
+            return css();
+        case "jsx":
+        case "tsx":
+        case "typescript":
+        case "javascript":
+            return javascript({
+                jsx: true,
+                typescript: true,
+            });
+        case "python":
+            return python();
+        case "markdown":
+            return markdown();
+        default:
+            return [];
+    }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1305,10 +1305,22 @@
   dependencies:
     "@tanstack/table-core" "8.20.5"
 
+"@tanstack/react-virtual@^3.10.8":
+  version "3.10.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/react-virtual/-/react-virtual-3.10.8.tgz#bf4b06f157ed298644a96ab7efc1a2b01ab36e3c"
+  integrity sha512-VbzbVGSsZlQktyLrP5nxE+vE1ZR+U0NFAWPbJLoG2+DKPwd2D7dVICTVIIaYlJqX1ZCEnYDbaOpmMwbsyhBoIA==
+  dependencies:
+    "@tanstack/virtual-core" "3.10.8"
+
 "@tanstack/table-core@8.20.5":
   version "8.20.5"
   resolved "https://registry.yarnpkg.com/@tanstack/table-core/-/table-core-8.20.5.tgz#3974f0b090bed11243d4107283824167a395cf1d"
   integrity sha512-P9dF7XbibHph2PFRz8gfBKEXEY/HJPOhym8CHmjF8y3q5mWpKx9xtZapXQUWCgkqvsK0R46Azuz+VaxD4Xl+Tg==
+
+"@tanstack/virtual-core@3.10.8":
+  version "3.10.8"
+  resolved "https://registry.yarnpkg.com/@tanstack/virtual-core/-/virtual-core-3.10.8.tgz#975446a667755222f62884c19e5c3c66d959b8b4"
+  integrity sha512-PBu00mtt95jbKFi6Llk9aik8bnR3tR/oQP1o3TSi+iG//+Q2RTIzCEgKkHG8BB86kxMNW6O8wku+Lmi+QFR6jA==
 
 "@types/argparse@^2.0.16":
   version "2.0.16"
@@ -1506,6 +1518,22 @@
     "@codemirror/language" "^6.0.0"
     "@codemirror/lint" "^6.0.0"
     "@codemirror/search" "^6.0.0"
+    "@codemirror/state" "^6.0.0"
+    "@codemirror/view" "^6.0.0"
+
+"@uiw/codemirror-theme-basic@^4.23.6":
+  version "4.23.6"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.23.6.tgz#8099d9dfa17d749d169e56f2e11cba85f841fde6"
+  integrity sha512-davfdPZV5xRIRSxM1Z1CQmR/rRfWyqdv9WS2hzIcwgjdeH7018I88+mGKyx5tWvgjHhjyTTTkLzDVo4+ygarVQ==
+  dependencies:
+    "@uiw/codemirror-themes" "4.23.6"
+
+"@uiw/codemirror-themes@4.23.6":
+  version "4.23.6"
+  resolved "https://registry.yarnpkg.com/@uiw/codemirror-themes/-/codemirror-themes-4.23.6.tgz#47a101733a9c4aa382696178bc4b7bc0ecf0e5fa"
+  integrity sha512-0dpuLQW+V6zrKvfvor/eo71V3tpr2L2Hsu8QZAdtSzksjWABxTOzH3ShaBRxCEsrz6sU9sa9o7ShwBMMDz59bQ==
+  dependencies:
+    "@codemirror/language" "^6.0.0"
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1521,22 +1521,6 @@
     "@codemirror/state" "^6.0.0"
     "@codemirror/view" "^6.0.0"
 
-"@uiw/codemirror-theme-basic@^4.23.6":
-  version "4.23.6"
-  resolved "https://registry.yarnpkg.com/@uiw/codemirror-theme-basic/-/codemirror-theme-basic-4.23.6.tgz#8099d9dfa17d749d169e56f2e11cba85f841fde6"
-  integrity sha512-davfdPZV5xRIRSxM1Z1CQmR/rRfWyqdv9WS2hzIcwgjdeH7018I88+mGKyx5tWvgjHhjyTTTkLzDVo4+ygarVQ==
-  dependencies:
-    "@uiw/codemirror-themes" "4.23.6"
-
-"@uiw/codemirror-themes@4.23.6":
-  version "4.23.6"
-  resolved "https://registry.yarnpkg.com/@uiw/codemirror-themes/-/codemirror-themes-4.23.6.tgz#47a101733a9c4aa382696178bc4b7bc0ecf0e5fa"
-  integrity sha512-0dpuLQW+V6zrKvfvor/eo71V3tpr2L2Hsu8QZAdtSzksjWABxTOzH3ShaBRxCEsrz6sU9sa9o7ShwBMMDz59bQ==
-  dependencies:
-    "@codemirror/language" "^6.0.0"
-    "@codemirror/state" "^6.0.0"
-    "@codemirror/view" "^6.0.0"
-
 "@uiw/react-codemirror@^4.23.0":
   version "4.23.5"
   resolved "https://registry.yarnpkg.com/@uiw/react-codemirror/-/react-codemirror-4.23.5.tgz#6a16c23062067732cba105ac33ad69cf8e5c2111"


### PR DESCRIPTION
This PR improves the perf of the search result list, resulting in a ~10x speedup for search results to render. This is achieved using [react-virtual](https://tanstack.com/virtual/latest), which allows us to only render the portion of the list that is visible (plus some buffer).