### PR TITLE
GitLab: include subgroups when filtering on groups

### DIFF
--- a/packages/backend/src/gitlab.ts
+++ b/packages/backend/src/gitlab.ts
@@ -25,6 +25,7 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
             logger.debug(`Fetching project info for group ${group}...`);
             const { durationMs, data } = await measure(() => api.Groups.allProjects(group, {
                 perPage: 100,
+                includeSubgroups: true
             }));
             logger.debug(`Found ${data.length} projects in group ${group} in ${durationMs}ms.`);
 


### PR DESCRIPTION
Refs #49 