### PR TITLE
Fix issue with empty branches

### DIFF
--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -54,7 +54,7 @@ export interface GitHubConfig {
      */
     archived?: boolean;
     /**
-     * List of individual repositories to exclude from syncing. Expected to be formatted as '{orgName}/{repoName}' or '{userName}/{repoName}'.
+     * List of individual repositories to exclude from syncing. Glob patterns are supported.
      */
     repos?: string[];
   };
@@ -115,7 +115,7 @@ export interface GitLabConfig {
      */
     archived?: boolean;
     /**
-     * List of individual projects to exclude from syncing. The project's namespace must be specified. See: https://docs.gitlab.com/ee/user/namespace/
+     * List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/
      */
     projects?: string[];
   };
@@ -163,7 +163,7 @@ export interface GiteaConfig {
      */
     archived?: boolean;
     /**
-     * List of individual repositories to exclude from syncing. Expected to be formatted as '{orgName}/{repoName}' or '{userName}/{repoName}'.
+     * List of individual repositories to exclude from syncing. Glob patterns are supported.
      */
     repos?: string[];
   };

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -10,7 +10,7 @@ export const indexGitRepository = async (repo: GitRepository, ctx: AppContext) =
         ...repo.tags ?? [],
     ];
 
-    const command = `zoekt-git-index -index ${ctx.indexPath} -branches ${revisions.join(',')} ${repo.path}`;
+    const command = `zoekt-git-index -allow_missing_branches -index ${ctx.indexPath} -branches ${revisions.join(',')} ${repo.path}`;
 
     return new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
         exec(command, (error, stdout, stderr) => {


### PR DESCRIPTION
Previously, indexing was failing for empty repositories with `getCommit("refs/heads/", "HEAD"): reference not found`. This PR adds the [allow_missing_branches](https://github.com/sourcebot-dev/zoekt/blob/6d9547e7d0e67da091f26d9b3e03b4d09ce9ad69/cmd/zoekt-git-index/main.go#L36) option to the `zoekt-git-index` call. This will make it s.t., a ref is skipped if it cannot be found.

Note for issue #59 : this might has the side-effect where if HEAD actually does reference something that exists, we will now silently fail (HEAD will not be indexed). We should follow up by raising a warning message when HEAD doesn't reference anything.