### PR TITLE
Add config param `all` to enable syncing all projects in GitLab instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added `DOMAIN_SUB_PATH` environment variable to allow overriding the default domain subpath. ([#74](https://github.com/sourcebot-dev/sourcebot/pull/74))
+- Added option `all` to the GitLab index schema, allowing for indexing all projects in a self-hosted GitLab instance. ([#84](https://github.com/sourcebot-dev/sourcebot/pull/84)) 
 
 ## [2.4.3] - 2024-11-18
 

--- a/configs/basic.json
+++ b/configs/basic.json
@@ -59,6 +59,15 @@
         {
             "type": "local",
             "path": "/path/to/local/repo"
+        },
+        // Index all projects in a self-hosted GitLab instance
+        // that are visible to the provided token.
+        // Note: this does not work with gitlab.com
+        {
+            "type": "gitlab",
+            "url": "https://gitlab.example.com",
+            "token": "my-token",
+            "all": true
         }
     ]
 }

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -94,6 +94,10 @@ export interface GitLabConfig {
    */
   url?: string;
   /**
+   * Sync all projects visible to the provided `token` (if any) in the GitLab instance. This option is ignored if `url` is either unset or set to https://gitlab.com .
+   */
+  all?: boolean;
+  /**
    * List of users to sync with. All projects owned by the user and visible to the provided `token` (if any) will be synced, unless explicitly defined in the `exclude` property.
    */
   users?: string[];

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -189,6 +189,11 @@
                     ],
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$"
                 },
+                "all": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Sync all projects visible to the provided `token` (if any) in the GitLab instance. This option is ignored if `url` is either unset or set to https://gitlab.com ."
+                },
                 "users": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
This PR adds the option `all` to the GitLab index config. When enabled, all projects within the GitLab instance that are visible to the provided `token` (if any) will be indexed.

Example:
```jsonc
{
    "$schema": "./schemas/v2/index.json",
    "repos": [
        {
            "type": "gitlab",
            "url": "https://gitlab.example.com",
            "token": {
                "env": "GITLAB_TOKEN"
            },
            "all": true
        }
    ]
}
```

Note: I've made this option no-op when using https://gitlab.com . I tested it, and if `all` is enabled, **all projects hosted on gitlab.com are fetched**, resulting in the get request never completing. We could use the `visibility` param of the [GET /projects](https://docs.gitlab.com/ee/api/projects.html#list-all-projects) api to limit things to just private or internal (limiting things to only the projects the token can see), but I will leave that as a future improvement if there are requests for it.

Fixes #49 
