### PR TITLE
fix: make gerrit repo fetching paginated

### DIFF
--- a/packages/backend/src/gerrit.ts
+++ b/packages/backend/src/gerrit.ts
@@ -35,6 +35,8 @@ export const getGerritReposFromConfig = async (config: GerritConfig, ctx: AppCon
    // exclude "All-Projects" and "All-Users" projects
    delete projects['All-Projects'];
    delete projects['All-Users'];
+   delete projects['All-Avatars']
+   delete projects['All-Archived-Projects']
 
    logger.debug(`Fetched ${Object.keys(projects).length} projects in ${durationMs}ms.`);
 

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -192,7 +192,6 @@ export interface GerritConfig {
      */
     projects?: string[];
   };
-  revisions?: GitRevisions;
 }
 export interface LocalConfig {
   /**


### PR DESCRIPTION
In some cases gerrit will limit the number of projects returned by /projects endpoint, forcing the client to paginate their request to get all projects.
This fulfills this requirement to get all projects