### PR TITLE
Add `topics` and `exclude.topics` to GitHub & GitLab config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added config support for filtering GitLab & GitHub repositories by topic. ([#121](https://github.com/sourcebot-dev/sourcebot/pull/121))
+
 ### Changed
 
 - Made language suggestions case insensitive. ([#124](https://github.com/sourcebot-dev/sourcebot/pull/124))

--- a/configs/filter.json
+++ b/configs/filter.json
@@ -63,5 +63,39 @@
                 ]
             }
         },
+        // Include all repos in my-org that have the topic
+        // "TypeScript" and do not have a topic that starts
+        // with "test-"
+        {
+            "type": "github",
+            "orgs": [
+                "my-org"
+            ],
+            "topics": [
+                "TypeScript"
+            ],
+            "exclude": {
+                "topics": [
+                    "test-**"
+                ]
+            }
+        },
+        // Include all repos in my-group that have the topic
+        // "TypeScript" and do not have a topic that starts
+        // with "test-"
+        {
+            "type": "gitlab",
+            "groups": [
+                "my-group"
+            ],
+            "topics": [
+                "TypeScript"
+            ],
+            "exclude": {
+                "topics": [
+                    "test-**"
+                ]
+            }
+        }
     ]
 }

--- a/packages/backend/src/gitlab.ts
+++ b/packages/backend/src/gitlab.ts
@@ -1,6 +1,6 @@
 import { Gitlab, ProjectSchema } from "@gitbeaker/rest";
 import { GitLabConfig } from "./schemas/v2.js";
-import { excludeArchivedRepos, excludeForkedRepos, excludeReposByName, getTokenFromConfig, marshalBool, measure } from "./utils.js";
+import { excludeArchivedRepos, excludeForkedRepos, excludeReposByName, excludeReposByTopic, getTokenFromConfig, includeReposByTopic, marshalBool, measure } from "./utils.js";
 import { createLogger } from "./logger.js";
 import { AppContext, GitRepository } from "./types.js";
 import path from 'path';
@@ -98,6 +98,7 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
                 isStale: false,
                 isFork,
                 isArchived: project.archived,
+                topics: project.topics ?? [],
                 gitConfigMetadata: {
                     'zoekt.web-url-type': 'gitlab',
                     'zoekt.web-url': project.web_url,
@@ -113,6 +114,10 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
             } satisfies GitRepository;
         });
 
+    if (config.topics) {
+        repos = includeReposByTopic(repos, config.topics, logger);
+    }
+
     if (config.exclude) {
         if (!!config.exclude.forks) {
             repos = excludeForkedRepos(repos, logger);
@@ -124,6 +129,10 @@ export const getGitLabReposFromConfig = async (config: GitLabConfig, ctx: AppCon
 
         if (config.exclude.projects) {
             repos = excludeReposByName(repos, config.exclude.projects, logger);
+        }
+
+        if (config.exclude.topics) {
+            repos = excludeReposByTopic(repos, config.exclude.topics, logger);
         }
     }
 

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -73,6 +73,9 @@ export interface GitHubConfig {
      * List of individual repositories to exclude from syncing. Glob patterns are supported.
      */
     repos?: string[];
+    /**
+     * List of repository topics to exclude when syncing. Repositories that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported.
+     */
     topics?: string[];
   };
   revisions?: GitRevisions;
@@ -126,6 +129,12 @@ export interface GitLabConfig {
    * List of individual projects to sync with. The project's namespace must be specified. See: https://docs.gitlab.com/ee/user/namespace/
    */
   projects?: string[];
+  /**
+   * List of project topics to include when syncing. Only projects that match at least one of the provided `topics` will be synced. If not specified, all projects will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported.
+   *
+   * @minItems 1
+   */
+  topics?: [string, ...string[]];
   exclude?: {
     /**
      * Exclude forked projects from syncing.
@@ -139,6 +148,10 @@ export interface GitLabConfig {
      * List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/
      */
     projects?: string[];
+    /**
+     * List of project topics to exclude when syncing. Projects that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported.
+     */
+    topics?: string[];
   };
   revisions?: GitRevisions;
 }

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -54,6 +54,12 @@ export interface GitHubConfig {
    * List of individual repositories to sync with. Expected to be formatted as '{orgName}/{repoName}' or '{userName}/{repoName}'.
    */
   repos?: string[];
+  /**
+   * List of repository topics to include when syncing. Only repositories that match at least one of the provided `topics` will be synced. If not specified, all repositories will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported.
+   *
+   * @minItems 1
+   */
+  topics?: [string, ...string[]];
   exclude?: {
     /**
      * Exclude forked repositories from syncing.
@@ -67,6 +73,7 @@ export interface GitHubConfig {
      * List of individual repositories to exclude from syncing. Glob patterns are supported.
      */
     repos?: string[];
+    topics?: string[];
   };
   revisions?: GitRevisions;
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -8,6 +8,7 @@ interface BaseRepository {
     isFork?: boolean;
     isArchived?: boolean;
     codeHost?: string;
+    topics?: string[];
 }
 
 export interface GitRepository extends BaseRepository {

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -20,7 +20,7 @@ export const marshalBool = (value?: boolean) => {
 export const excludeForkedRepos = <T extends Repository>(repos: T[], logger?: Logger) => {
     return repos.filter((repo) => {
         if (!!repo.isFork) {
-            logger?.debug(`Excluding repo ${repo.id}. Reason: exclude.forks is true`);
+            logger?.debug(`Excluding repo ${repo.id}. Reason: \`exclude.forks\` is true`);
             return false;
         }
         return true;
@@ -30,7 +30,7 @@ export const excludeForkedRepos = <T extends Repository>(repos: T[], logger?: Lo
 export const excludeArchivedRepos = <T extends Repository>(repos: T[], logger?: Logger) => {
     return repos.filter((repo) => {
         if (!!repo.isArchived) {
-            logger?.debug(`Excluding repo ${repo.id}. Reason: exclude.archived is true`);
+            logger?.debug(`Excluding repo ${repo.id}. Reason: \`exclude.archived\` is true`);
             return false;
         }
         return true;
@@ -41,7 +41,7 @@ export const excludeArchivedRepos = <T extends Repository>(repos: T[], logger?: 
 export const excludeReposByName = <T extends Repository>(repos: T[], excludedRepoNames: string[], logger?: Logger) => {
     return repos.filter((repo) => {
         if (micromatch.isMatch(repo.name, excludedRepoNames)) {
-            logger?.debug(`Excluding repo ${repo.id}. Reason: exclude.repos contains ${repo.name}`);
+            logger?.debug(`Excluding repo ${repo.id}. Reason: \`exclude.repos\` contains ${repo.name}`);
             return false;
         }
         return true;
@@ -51,10 +51,37 @@ export const excludeReposByName = <T extends Repository>(repos: T[], excludedRep
 export const includeReposByName = <T extends Repository>(repos: T[], includedRepoNames: string[], logger?: Logger) => {
     return repos.filter((repo) => {
         if (micromatch.isMatch(repo.name, includedRepoNames)) {
-            logger?.debug(`Including repo ${repo.id}. Reason: repos contain ${repo.name}`);
+            logger?.debug(`Including repo ${repo.id}. Reason: \`repos\` contain ${repo.name}`);
             return true;
         }
         return false;
+    });
+}
+
+export const includeReposByTopic = <T extends Repository>(repos: T[], includedRepoTopics: string[], logger?: Logger) => {
+    return repos.filter((repo) => {
+        const topics = repo.topics ?? [];
+        const matchingTopics = topics.filter((topic) => micromatch.isMatch(topic, includedRepoTopics));
+
+        if (matchingTopics.length > 0) {
+
+            logger?.debug(`Including repo ${repo.id}. Reason: \`topics\` matches the following topics: ${matchingTopics.join(', ')}`);
+            return true;
+        }
+        return false;
+    });
+}
+
+export const excludeReposByTopic = <T extends Repository>(repos: T[], excludedRepoTopics: string[], logger?: Logger) => {
+    return repos.filter((repo) => {
+        const topics = repo.topics ?? [];
+        const matchingTopics = topics.filter((topic) => micromatch.isMatch(topic, excludedRepoTopics));
+
+        if (matchingTopics.length > 0) {
+            logger?.debug(`Excluding repo ${repo.id}. Reason: \`exclude.topics\` matches the following topics: ${matchingTopics.join(', ')}`);
+            return false;
+        }
+        return true;
     });
 }
 

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -241,6 +241,14 @@
                     ],
                     "description": "List of individual projects to sync with. The project's namespace must be specified. See: https://docs.gitlab.com/ee/user/namespace/"
                 },
+                "topics": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "List of project topics to include when syncing. Only projects that match at least one of the provided `topics` will be synced. If not specified, all projects will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported."
+                },
                 "exclude": {
                     "type": "object",
                     "properties": {
@@ -266,6 +274,13 @@
                                 ]
                             ],
                             "description": "List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/"
+                        },
+                        "topics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "List of project topics to exclude when syncing. Projects that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported."
                         }
                     },
                     "additionalProperties": false

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -130,6 +130,14 @@
                     },
                     "description": "List of individual repositories to sync with. Expected to be formatted as '{orgName}/{repoName}' or '{userName}/{repoName}'."
                 },
+                "topics": {
+                    "type": "array",
+                    "items": {
+                        "type": "string"
+                    },
+                    "minItems": 1,
+                    "description": "List of repository topics to include when syncing. Only repositories that match at least one of the provided `topics` will be synced. If not specified, all repositories will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported."
+                },
                 "exclude": {
                     "type": "object",
                     "properties": {
@@ -150,6 +158,13 @@
                             },
                             "default": [],
                             "description": "List of individual repositories to exclude from syncing. Glob patterns are supported."
+                        },
+                        "topics": {
+                            "type": "array",
+                            "items": {
+                                "type": "string"
+                            },
+                            "description": "List of repository topics to exclude when syncing. Repositories that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported."
                         }
                     },
                     "additionalProperties": false

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -136,7 +136,10 @@
                         "type": "string"
                     },
                     "minItems": 1,
-                    "description": "List of repository topics to include when syncing. Only repositories that match at least one of the provided `topics` will be synced. If not specified, all repositories will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported."
+                    "description": "List of repository topics to include when syncing. Only repositories that match at least one of the provided `topics` will be synced. If not specified, all repositories will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported.",
+                    "examples": [
+                        ["docs", "core"]
+                    ]
                 },
                 "exclude": {
                     "type": "object",
@@ -164,7 +167,10 @@
                             "items": {
                                 "type": "string"
                             },
-                            "description": "List of repository topics to exclude when syncing. Repositories that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported."
+                            "description": "List of repository topics to exclude when syncing. Repositories that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported.",
+                            "examples": [
+                                ["tests", "ci"]
+                            ]
                         }
                     },
                     "additionalProperties": false
@@ -247,7 +253,10 @@
                         "type": "string"
                     },
                     "minItems": 1,
-                    "description": "List of project topics to include when syncing. Only projects that match at least one of the provided `topics` will be synced. If not specified, all projects will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported."
+                    "description": "List of project topics to include when syncing. Only projects that match at least one of the provided `topics` will be synced. If not specified, all projects will be synced, unless explicitly defined in the `exclude` property. Glob patterns are supported.",
+                    "examples": [
+                        ["docs", "core"]
+                    ]
                 },
                 "exclude": {
                     "type": "object",
@@ -280,7 +289,10 @@
                             "items": {
                                 "type": "string"
                             },
-                            "description": "List of project topics to exclude when syncing. Projects that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported."
+                            "description": "List of project topics to exclude when syncing. Projects that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported.",
+                            "examples": [
+                                ["tests", "ci"]
+                            ]
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
This PR adds the ability to filter what repos are indexed based on the topics that do/don't exist on a given repo. E.g.,:

```jsonc
{
    "$schema": "./schemas/v2/index.json",
    "repos": [
        {
            "type": "github",
            "orgs": [
                "sourcebot-dev"
            ],
            // Include repositories in `sourcebot-dev` that have at least one of these topics.
            "topics": [
                "hacktoberfest",
                "advent_of_code"
            ],
            "exclude": {
                // Explicitly exclude a topic from being indexed.
                "topics": [
                    "TypeScript"
                ]
            }
        }
    }
}
```

In the above case, a repo with the label `hacktoberfest` will be indexed, but a repo with both `hacktoberfest` and `TypeScript` will not be indexed.

Fixes #107 

TODO:
- Add usage examples