### PR TITLE
Add `reindexInterval` and `resyncInterval` to config settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added config option `settings.reindexInterval` and `settings.resyncInterval` to control how often the index should be re-indexed and re-synced. ([#134](https://github.com/sourcebot-dev/sourcebot/pull/134))
+
 ## [2.6.2] - 2024-12-13
 
 ### Added

--- a/demo-site-config.json
+++ b/demo-site-config.json
@@ -1,7 +1,9 @@
 {
     "$schema": "./schemas/v2/index.json",
     "settings": {
-        "autoDeleteStaleRepos": true
+        "autoDeleteStaleRepos": true,
+        "reindexInterval": 86400000, // 24 hours
+        "resyncInterval": 86400000 // 24 hours
     },
     "repos": [
         {

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -1,19 +1,11 @@
 import { Settings } from "./types.js";
 
 /**
- * The interval to reindex a given repository.
- */
-export const REINDEX_INTERVAL_MS = 1000 * 60 * 60;
-
-/**
- * The interval to re-sync the config.
- */
-export const RESYNC_CONFIG_INTERVAL_MS = 1000 * 60 * 60 * 24;
-
-/**
  * Default settings.
  */
 export const DEFAULT_SETTINGS: Settings = {
     maxFileSize: 2 * 1024 * 1024, // 2MB in bytes
     autoDeleteStaleRepos: true,
+    reindexInterval: 1000 * 60 * 60, // 1 hour in milliseconds
+    resyncInterval: 1000 * 60 * 60 * 24, // 1 day in milliseconds
 }

--- a/packages/backend/src/db.test.ts
+++ b/packages/backend/src/db.test.ts
@@ -1,5 +1,5 @@
 import { expect, test } from 'vitest';
-import { DEFAULT_DB_DATA, migration_addDeleteStaleRepos, migration_addMaxFileSize, migration_addSettings, Schema } from './db';
+import { DEFAULT_DB_DATA, migration_addDeleteStaleRepos, migration_addMaxFileSize, migration_addReindexInterval, migration_addResyncInterval, migration_addSettings, Schema } from './db';
 import { DEFAULT_SETTINGS } from './constants';
 import { DeepPartial } from './types';
 import { Low } from 'lowdb';
@@ -60,4 +60,66 @@ test('migration_addDeleteStaleRepos adds the `autoDeleteStaleRepos` field with t
             autoDeleteStaleRepos: DEFAULT_SETTINGS.autoDeleteStaleRepos,
         }
     });
+});
+
+test('migration_addReindexInterval adds the `reindexInterval` field with the default value if it does not exist', () => {
+    const schema: DeepPartial<Schema> = {
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            autoDeleteStaleRepos: DEFAULT_SETTINGS.autoDeleteStaleRepos,
+        },
+    }
+
+    const migratedSchema = migration_addReindexInterval(schema as Schema);
+    expect(migratedSchema).toStrictEqual({
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            autoDeleteStaleRepos: DEFAULT_SETTINGS.autoDeleteStaleRepos,
+            reindexInterval: DEFAULT_SETTINGS.reindexInterval,
+        }
+    });
+});
+
+test('migration_addReindexInterval preserves existing reindexInterval value if already set', () => {
+    const customInterval = 60;
+    const schema: DeepPartial<Schema> = {
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            reindexInterval: customInterval,
+        },
+    }
+
+    const migratedSchema = migration_addReindexInterval(schema as Schema);
+    expect(migratedSchema.settings.reindexInterval).toBe(customInterval);
+});
+
+test('migration_addResyncInterval adds the `resyncInterval` field with the default value if it does not exist', () => {
+    const schema: DeepPartial<Schema> = {
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            autoDeleteStaleRepos: DEFAULT_SETTINGS.autoDeleteStaleRepos,
+        },
+    }
+
+    const migratedSchema = migration_addResyncInterval(schema as Schema);
+    expect(migratedSchema).toStrictEqual({
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            autoDeleteStaleRepos: DEFAULT_SETTINGS.autoDeleteStaleRepos,
+            resyncInterval: DEFAULT_SETTINGS.resyncInterval,
+        }
+    });
+});
+
+test('migration_addResyncInterval preserves existing resyncInterval value if already set', () => {
+    const customInterval = 120;
+    const schema: DeepPartial<Schema> = {
+        settings: {
+            maxFileSize: DEFAULT_SETTINGS.maxFileSize,
+            resyncInterval: customInterval,
+        },
+    }
+
+    const migratedSchema = migration_addResyncInterval(schema as Schema);
+    expect(migratedSchema.settings.resyncInterval).toBe(customInterval);
 });

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -56,6 +56,8 @@ export const applyMigrations = async (db: Database) => {
         schema = migration_addSettings(schema, log);
         schema = migration_addMaxFileSize(schema, log);
         schema = migration_addDeleteStaleRepos(schema, log);
+        schema = migration_addReindexInterval(schema, log);
+        schema = migration_addResyncInterval(schema, log);
         return schema;
     });
 }
@@ -89,8 +91,32 @@ export const migration_addMaxFileSize = (schema: Schema, log?: (name: string) =>
  */
 export const migration_addDeleteStaleRepos = (schema: Schema, log?: (name: string) => void) => {
     if (schema.settings.autoDeleteStaleRepos === undefined) {
-        log?.("deleteStaleRepos");
+        log?.("addDeleteStaleRepos");
         schema.settings.autoDeleteStaleRepos = DEFAULT_SETTINGS.autoDeleteStaleRepos;
+    }
+
+    return schema;
+}
+
+/**
+ * @todo : add PR comment
+ */
+export const migration_addReindexInterval = (schema: Schema, log?: (name: string) => void) => {
+    if (schema.settings.reindexInterval === undefined) {
+        log?.("addReindexInterval");
+        schema.settings.reindexInterval = DEFAULT_SETTINGS.reindexInterval;
+    }
+
+    return schema;
+}
+
+/**
+ * @todo : add PR comment
+ */
+export const migration_addResyncInterval = (schema: Schema, log?: (name: string) => void) => {
+    if (schema.settings.resyncInterval === undefined) {
+        log?.("addResyncInterval");
+        schema.settings.resyncInterval = DEFAULT_SETTINGS.resyncInterval;
     }
 
     return schema;

--- a/packages/backend/src/db.ts
+++ b/packages/backend/src/db.ts
@@ -99,7 +99,7 @@ export const migration_addDeleteStaleRepos = (schema: Schema, log?: (name: strin
 }
 
 /**
- * @todo : add PR comment
+ * @see: https://github.com/sourcebot-dev/sourcebot/pull/134
  */
 export const migration_addReindexInterval = (schema: Schema, log?: (name: string) => void) => {
     if (schema.settings.reindexInterval === undefined) {
@@ -111,7 +111,7 @@ export const migration_addReindexInterval = (schema: Schema, log?: (name: string
 }
 
 /**
- * @todo : add PR comment
+ * @see: https://github.com/sourcebot-dev/sourcebot/pull/134
  */
 export const migration_addResyncInterval = (schema: Schema, log?: (name: string) => void) => {
     if (schema.settings.resyncInterval === undefined) {

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -25,6 +25,14 @@ export interface Settings {
    * Automatically delete stale repositories from the index. Defaults to true.
    */
   autoDeleteStaleRepos?: boolean;
+  /**
+   * The interval (in milliseconds) at which the indexer should re-index all repositories. Repositories are always indexed when first added. Defaults to 1 hour (3600000 milliseconds).
+   */
+  reindexInterval?: number;
+  /**
+   * The interval (in milliseconds) at which the configuration file should be re-synced. The configuration file is always synced on startup. Defaults to 24 hours (86400000 milliseconds).
+   */
+  resyncInterval?: number;
 }
 export interface GitHubConfig {
   /**

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -44,8 +44,22 @@ export type AppContext = {
 }
 
 export type Settings = {
+    /**
+     * The maximum size of a file (in bytes) to be indexed. Files that exceed this maximum will not be inexed.
+     */
     maxFileSize: number;
+    /**
+     * Automatically delete stale repositories from the index. Defaults to true.
+     */
     autoDeleteStaleRepos: boolean;
+    /**
+     * The interval (in milliseconds) at which the indexer should re-index all repositories.
+     */
+    reindexInterval: number;
+    /**
+     * The interval (in milliseconds) at which the configuration file should be re-synced.
+     */
+    resyncInterval: number;
 }
 
 // @see : https://stackoverflow.com/a/61132308

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -534,6 +534,18 @@
                     "type": "boolean",
                     "description": "Automatically delete stale repositories from the index. Defaults to true.",
                     "default": true
+                },
+                "reindexInterval": {
+                    "type": "integer",
+                    "description": "The interval (in milliseconds) at which the indexer should re-index all repositories. Repositories are always indexed when first added. Defaults to 1 hour (3600000 milliseconds).",
+                    "default": 3600000,
+                    "minimum": 1
+                },
+                "resyncInterval": {
+                    "type": "integer",
+                    "description": "The interval (in milliseconds) at which the configuration file should be re-synced. The configuration file is always synced on startup. Defaults to 24 hours (86400000 milliseconds).",
+                    "default": 86400000,
+                    "minimum": 1
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
This PR makes it s.t., the reindex interval and resync interval are configurable via `config.settings`:
```jsonc
{
    "$schema": "./schemas/v2/index.json",
    "settings": {
        "autoDeleteStaleRepos": true,
        "reindexInterval": 3600000,
        "resyncInterval": 86400000
    },
    ...
}
```