### PR TITLE
[GitHub] Add `exclude.size` property to the config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added config option `settings.reindexInterval` and `settings.resyncInterval` to control how often the index should be re-indexed and re-synced. ([#134](https://github.com/sourcebot-dev/sourcebot/pull/134))
+- Added `exclude.size` to the GitHub config to allow excluding repositories by size. ([#137](https://github.com/sourcebot-dev/sourcebot/pull/137))
 
 ## [2.6.2] - 2024-12-13
 

--- a/demo-site-config.json
+++ b/demo-site-config.json
@@ -11,6 +11,11 @@
             "token": {
                 "env": "GITHUB_TOKEN"
             },
+            "exclude": {
+                "size": {
+                    "max": 1000000000 // Limit to 1GB
+                }
+            },
             "repos": [
                 "torvalds/linux",
                 "pytorch/pytorch",

--- a/packages/backend/src/schemas/v2.ts
+++ b/packages/backend/src/schemas/v2.ts
@@ -89,6 +89,19 @@ export interface GitHubConfig {
      * List of repository topics to exclude when syncing. Repositories that match one of the provided `topics` will be excluded from syncing. Glob patterns are supported.
      */
     topics?: string[];
+    /**
+     * Exclude repositories based on their disk usage. Note: the disk usage is calculated by GitHub and may not reflect the actual disk usage when cloned.
+     */
+    size?: {
+      /**
+       * Minimum repository size (in bytes) to sync (inclusive). Repositories less than this size will be excluded from syncing.
+       */
+      min?: number;
+      /**
+       * Maximum repository size (in bytes) to sync (inclusive). Repositories greater than this size will be excluded from syncing.
+       */
+      max?: number;
+    };
   };
   revisions?: GitRevisions;
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -9,6 +9,7 @@ interface BaseRepository {
     isArchived?: boolean;
     codeHost?: string;
     topics?: string[];
+    sizeInBytes?: number;
 }
 
 export interface GitRepository extends BaseRepository {

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -171,6 +171,21 @@
                             "examples": [
                                 ["tests", "ci"]
                             ]
+                        },
+                        "size": {
+                            "type": "object",
+                            "description": "Exclude repositories based on their disk usage. Note: the disk usage is calculated by GitHub and may not reflect the actual disk usage when cloned.",
+                            "properties": {
+                                "min": {
+                                    "type": "integer",
+                                    "description": "Minimum repository size (in bytes) to sync (inclusive). Repositories less than this size will be excluded from syncing."
+                                },
+                                "max": {
+                                    "type": "integer",
+                                    "description": "Maximum repository size (in bytes) to sync (inclusive). Repositories greater than this size will be excluded from syncing."
+                                }
+                            },
+                            "additionalProperties": false
                         }
                     },
                     "additionalProperties": false


### PR DESCRIPTION
This PR adds the ability to exclude GitHub repositories based on their disk usage. E.g.,:
```jsonc
{
    "$schema": "./schemas/v2/index.json",
    "repos": [
        {
            "type": "github",
            "repos": [
                "sourcebot-dev/sourcebot"
            ],
            "exclude": {
                "size": {
                    "min": 16000, // 16 KB
                    "max": 1000000000 // 1GB
                }
            }
        }
    ]
}
```