### PR TITLE
Graceful error handling when calling code host apis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added config option `settings.reindexInterval` and `settings.resyncInterval` to control how often the index should be re-indexed and re-synced. ([#134](https://github.com/sourcebot-dev/sourcebot/pull/134))
 - Added `exclude.size` to the GitHub config to allow excluding repositories by size. ([#137](https://github.com/sourcebot-dev/sourcebot/pull/137))
 
+### Fixed
+
+- Fixed issue where config synchronization was failing entirely when a single api call fails. ([#142](https://github.com/sourcebot-dev/sourcebot/pull/142))
+
 ## [2.6.2] - 2024-12-13
 
 ### Added

--- a/packages/backend/src/gerrit.ts
+++ b/packages/backend/src/gerrit.ts
@@ -28,9 +28,18 @@ export const getGerritReposFromConfig = async (config: GerritConfig, ctx: AppCon
    const url = config.url.endsWith('/') ? config.url : `${config.url}/`;
    const hostname = new URL(config.url).hostname;
 
-   const { durationMs, data: projects } = await measure(() =>
-      fetchAllProjects(url)
-   );
+   const { durationMs, data: projects } = await measure(async () => {
+      try {
+         return fetchAllProjects(url)
+      } catch (err) {
+         logger.error(`Failed to fetch projects from ${url}`, err);
+         return null;
+      }
+   });
+
+   if (!projects) {
+      return [];
+   }
 
    // exclude "All-Projects" and "All-Users" projects
    delete projects['All-Projects'];

--- a/packages/backend/src/logger.ts
+++ b/packages/backend/src/logger.ts
@@ -5,7 +5,6 @@ const { combine, colorize, timestamp, prettyPrint, errors, printf, label: labelF
 
 const createLogger = (label: string) => {
     return winston.createLogger({
-        // @todo: Make log level configurable
         level: SOURCEBOT_LOG_LEVEL,
         format: combine(
             errors({ stack: true }),

--- a/packages/backend/src/main.ts
+++ b/packages/backend/src/main.ts
@@ -132,6 +132,11 @@ export const deleteStaleRepository = async (repo: Repository, db: Database, ctx:
     });
     
     logger.info(`Deleted stale repository ${repo.id}`);
+
+    captureEvent('repo_deleted', {
+        vcs: repo.vcs,
+        codeHost: repo.codeHost,
+    })
 }
 
 /**

--- a/packages/backend/src/posthogEvents.ts
+++ b/packages/backend/src/posthogEvents.ts
@@ -11,6 +11,10 @@ export type PosthogEventMap = {
         fetchDuration_s?: number;
         cloneDuration_s?: number;
         indexDuration_s?: number;
+    },
+    repo_deleted: {
+        vcs: string;
+        codeHost?: string;
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5527,16 +5527,8 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
+  name string-width-cjs
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5633,14 +5625,7 @@ string_decoder@^1.1.1, string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==


### PR DESCRIPTION
The following adds graceful error handling for code host api calls. When a api call fails, an error message is raised and the config synchronization continues. Fixes #140

The side-effect of this is that if an api experiences some transient error (e.g., network issue, rate limits, etc.), then repositories will be marked stale when they actually are not. If `autoDeleteStaleRepos` is enabled, then the repo & it's index will be deleted.

Two things we can do come to mind:
1. We add a delay between when a repo is marked stale and when it is deleted. This way, it gives the config a change to be re-synced again (and the transient issues gone).
2. We add retry mechanisms to api calls s.t., we retry on known failures.

