### PR TITLE
curl error handling in entrypoint.sh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Fixed issue where we crash on startup if the install / upgrade PostHog event fails to send. ([#159](https://github.com/sourcebot-dev/sourcebot/pull/159))
+
 ## [2.7.0] - 2025-01-10
 
 ### Added


### PR DESCRIPTION
This PR adds some error handling in `entrypoint.sh` s.t., we don't immediately crash if a curl command fails when sending a PostHog event for install / upgrade.

How tested:
- Manually tested success & failure case

Fixes #150
Fixes #100 