### PR TITLE
Syntax reference guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added a syntax reference guide. The guide can be opened using the hotkey "Cmd + /" ("Ctrl + /" on Windows). ([#169](https://github.com/sourcebot-dev/sourcebot/pull/169))
+
 ## [2.7.1] - 2025-01-15
 
 ### Fixed

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,6 +39,7 @@
     "@hookform/resolvers": "^3.9.0",
     "@iconify/react": "^5.1.0",
     "@iizukak/codemirror-lang-wgsl": "^0.3.0",
+    "@radix-ui/react-dialog": "^1.1.4",
     "@radix-ui/react-dropdown-menu": "^2.1.1",
     "@radix-ui/react-icons": "^1.3.0",
     "@radix-ui/react-label": "^2.1.0",

--- a/packages/web/src/app/components/fireHeader.tsx
+++ b/packages/web/src/app/components/fireHeader.tsx
@@ -31,7 +31,7 @@ export const FileHeader = ({
             {info?.icon ? (
                 <Image
                     src={info.icon}
-                    alt={info.costHostName}
+                    alt={info.codeHostName}
                     className={`w-4 h-4 ${info.iconClassName}`}
                 />
             ): (

--- a/packages/web/src/app/components/keyboardShortcutHint.tsx
+++ b/packages/web/src/app/components/keyboardShortcutHint.tsx
@@ -1,0 +1,16 @@
+import React from 'react'
+
+interface KeyboardShortcutHintProps {
+  shortcut: string
+  label?: string
+}
+
+export function KeyboardShortcutHint({ shortcut, label }: KeyboardShortcutHintProps) {
+  return (
+    <div className="inline-flex items-center" aria-label={label || `Keyboard shortcut: ${shortcut}`}>
+      <kbd className="px-2 py-1 text-xs font-semibold border rounded-md">
+        {shortcut}
+      </kbd>
+    </div>
+  )
+}

--- a/packages/web/src/app/components/repositoryCarousel.tsx
+++ b/packages/web/src/app/components/repositoryCarousel.tsx
@@ -63,7 +63,7 @@ const RepositoryBadge = ({
             return {
                 repoIcon: <Image
                     src={info.icon}
-                    alt={info.costHostName}
+                    alt={info.codeHostName}
                     className={`w-4 h-4 ${info.iconClassName}`}
                 />,
                 displayName: info.displayName,

--- a/packages/web/src/app/components/searchBar/searchBar.tsx
+++ b/packages/web/src/app/components/searchBar/searchBar.tsx
@@ -42,6 +42,7 @@ import { useSuggestionModeAndQuery } from "./useSuggestionModeAndQuery";
 import { Separator } from "@/components/ui/separator";
 import { Tooltip, TooltipTrigger, TooltipContent } from "@/components/ui/tooltip";
 import { Toggle } from "@/components/ui/toggle";
+import { KeyboardShortcutHint } from "../keyboardShortcutHint";
 
 interface SearchBarProps {
     className?: string;
@@ -71,7 +72,7 @@ const searchBarKeymap: readonly KeyBinding[] = ([
 ] as KeyBinding[]).concat(historyKeymap);
 
 const searchBarContainerVariants = cva(
-    "search-bar-container flex items-center py-0.5 px-1 border rounded-md relative",
+    "search-bar-container flex items-center justify-center py-0.5 px-2 border rounded-md relative",
     {
         variants: {
             size: {
@@ -264,6 +265,7 @@ export const SearchBar = ({
                 indentWithTab={false}
                 autoFocus={autoFocus ?? false}
             />
+            <KeyboardShortcutHint shortcut="/" />
             <SearchSuggestionsBox
                 ref={suggestionBoxRef}
                 query={query}

--- a/packages/web/src/app/components/searchBar/searchSuggestionsBox.tsx
+++ b/packages/web/src/app/components/searchBar/searchSuggestionsBox.tsx
@@ -16,6 +16,7 @@ import { IconType } from "react-icons/lib";
 import { VscFile, VscFilter, VscRepo, VscSymbolMisc } from "react-icons/vsc";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Separator } from "@/components/ui/separator";
+import { KeyboardShortcutHint } from "../keyboardShortcutHint";
 
 export type Suggestion = {
     value: string;
@@ -337,7 +338,7 @@ const SearchSuggestionsBox = forwardRef(({
             onFocus={onFocus}
             onBlur={onBlur}
         >
-            <p className="text-muted-foreground text-sm mb-1">
+            <p className="text-muted-foreground text-sm mb-2">
                 {suggestionModeText}
             </p>
             {isLoadingSuggestions ? (
@@ -385,19 +386,29 @@ const SearchSuggestionsBox = forwardRef(({
                     )}
                 </div>
             ))}
-            {isFocused && (
-                <>
-                    <Separator
-                        orientation="horizontal"
-                        className="my-2"
-                    />
-                    <div className="flex flex-row items-center justify-end mt-1">
-                        <span className="text-muted-foreground text-xs">
-                            Press <kbd className="font-mono text-xs font-bold">Enter</kbd> to select
-                        </span>
+            <Separator
+                orientation="horizontal"
+                className="my-2"
+            />
+            <div className="flex flex-row items-center justify-between mt-1">
+                <div className="flex flex-row gap-1.5 items-center">
+                    <p className="text-muted-foreground text-sm">
+                        Syntax help:
+                    </p>
+                    <div className="flex flex-row gap-0.5 items-center">
+                        <KeyboardShortcutHint shortcut="⌘" />
+                        <KeyboardShortcutHint shortcut="/" />
                     </div>
-                </>
-            )}
+                </div>
+                {isFocused && (
+                    <span className="flex flex-row gap-1.5 items-center">
+                        <KeyboardShortcutHint shortcut="↵" />
+                        <span className="text-muted-foreground text-sm font-medium">
+                            to select
+                        </span>
+                    </span>
+                )}
+            </div>
         </div>
     )
 });

--- a/packages/web/src/app/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/components/syntaxReferenceGuide.tsx
@@ -1,8 +1,7 @@
 'use client';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
-import { useState } from "react";
-import { useHotkeys } from "react-hotkeys-hook";
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Separator } from "@/components/ui/separator";
 import {
     Table,
     TableBody,
@@ -10,28 +9,56 @@ import {
     TableHead,
     TableHeader,
     TableRow,
-} from "@/components/ui/table"
-import { Separator } from "@/components/ui/separator";
+} from "@/components/ui/table";
 import clsx from "clsx";
 import Link from "next/link";
+import { useCallback, useRef, useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
 
 const LINGUIST_LINK = "https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml";
 const CTAGS_LINK = "https://ctags.io/";
 
 export const SyntaxReferenceGuide = () => {
     const [isOpen, setIsOpen] = useState(false);
+    const previousFocusedElement = useRef<HTMLElement | null>(null);
+
+    const openDialog = useCallback(() => {
+        previousFocusedElement.current = document.activeElement as HTMLElement;
+        setIsOpen(true);
+    }, []);
+
+    const closeDialog = useCallback(() => {
+        console.log(previousFocusedElement);
+        setIsOpen(false);
+
+        // @note: Without requestAnimationFrame, focus was not being returned
+        // to codemirror elements for some reason.
+        requestAnimationFrame(() => {
+            previousFocusedElement.current?.focus();
+        });
+    }, []);
+
+    const handleOpenChange = useCallback((isOpen: boolean) => {
+        if (isOpen) {
+            openDialog();
+        } else {
+            closeDialog();
+        }
+    }, []);
 
     useHotkeys("mod+/", (event) => {
         event.preventDefault();
-        setIsOpen(!isOpen);
+        handleOpenChange(!isOpen);
+    }, {
+        enableOnFormTags: true,
+        enableOnContentEditable: true,
+        description: "Open Syntax Reference Guide",
     });
 
     return (
         <Dialog
             open={isOpen}
-            onOpenChange={(isOpen) => {
-                setIsOpen(isOpen);
-            }}
+            onOpenChange={handleOpenChange}
         >
             <DialogContent
                 className="max-h-[80vh] max-w-[700px] overflow-scroll"

--- a/packages/web/src/app/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/components/syntaxReferenceGuide.tsx
@@ -43,7 +43,7 @@ export const SyntaxReferenceGuide = () => {
         } else {
             closeDialog();
         }
-    }, []);
+    }, [closeDialog, openDialog]);
 
     useHotkeys("mod+/", (event) => {
         event.preventDefault();
@@ -61,13 +61,11 @@ export const SyntaxReferenceGuide = () => {
         >
             <DialogContent
                 className="max-h-[80vh] max-w-[700px] overflow-scroll"
-                aria-description="Syntax Reference Guide"
-                aria-describedby="syntax-reference-guide"
             >
                 <DialogHeader>
                     <DialogTitle>Syntax Reference Guide</DialogTitle>
                     <DialogDescription className="text-sm text-foreground">
-                        Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>""</Code> combines them. By default, a file must have at least one match for each expression to be included.
+                        Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>{`""`}</Code> combines them. By default, a file must have at least one match for each expression to be included.
                     </DialogDescription>
                 </DialogHeader>
                 <Table>
@@ -87,7 +85,7 @@ export const SyntaxReferenceGuide = () => {
                             <TableCell className="py-2">Match files with regex <Code>/foo/</Code> <b>and</b> <Code>/bar/</Code></TableCell>
                         </TableRow>
                         <TableRow>
-                            <TableCell className="py-2"><Code>"foo bar"</Code></TableCell>
+                            <TableCell className="py-2"><Code>{`"foo bar"`}</Code></TableCell>
                             <TableCell className="py-2">Match files with regex <Code>/foo bar/</Code></TableCell>
                         </TableRow>
                     </TableBody>
@@ -95,7 +93,7 @@ export const SyntaxReferenceGuide = () => {
 
                 <Separator className="my-2"/>
                 <p className="text-sm">
-                    Multiple expressions can be or'd together with <Code>or</Code>, negated with <Code>-</Code>, or grouped with <Code>()</Code>.
+                    {`Multiple expressions can be or'd together with `}<Code>or</Code>, negated with <Code>-</Code>, or grouped with <Code>()</Code>.
                 </p>
                 <Table>
                     <TableHeader>
@@ -147,7 +145,7 @@ export const SyntaxReferenceGuide = () => {
                                     <Code
                                         title="Filter results to filepaths that match regex /my file/"
                                     >
-                                        <Highlight>file:</Highlight>"my file"
+                                        <Highlight>file:</Highlight>{`"my file"`}
                                     </Code>
                                     <Code
                                         title="Ignore results from filepaths match regex /test\.ts$/"

--- a/packages/web/src/app/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/components/syntaxReferenceGuide.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
+import { Dialog, DialogContent, DialogDescription, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Separator } from "@/components/ui/separator";
 import {
     Table,
@@ -28,7 +28,6 @@ export const SyntaxReferenceGuide = () => {
     }, []);
 
     const closeDialog = useCallback(() => {
-        console.log(previousFocusedElement);
         setIsOpen(false);
 
         // @note: Without requestAnimationFrame, focus was not being returned
@@ -62,13 +61,15 @@ export const SyntaxReferenceGuide = () => {
         >
             <DialogContent
                 className="max-h-[80vh] max-w-[700px] overflow-scroll"
+                aria-description="Syntax Reference Guide"
+                aria-describedby="syntax-reference-guide"
             >
                 <DialogHeader>
                     <DialogTitle>Syntax Reference Guide</DialogTitle>
+                    <DialogDescription className="text-sm text-foreground">
+                        Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>""</Code> combines them. By default, a file must have at least one match for each expression to be included.
+                    </DialogDescription>
                 </DialogHeader>
-                <p className="text-sm">
-                    Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>""</Code> combines them. By default, a file must have at least one match for each expression to be included.
-                </p>
                 <Table>
                     <TableHeader>
                         <TableRow>

--- a/packages/web/src/app/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/components/syntaxReferenceGuide.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog"
+import { useState } from "react";
+import { useHotkeys } from "react-hotkeys-hook";
+import {
+    Table,
+    TableBody,
+    TableCell,
+    TableHead,
+    TableHeader,
+    TableRow,
+} from "@/components/ui/table"
+import { Separator } from "@/components/ui/separator";
+import clsx from "clsx";
+import Link from "next/link";
+
+const LINGUIST_LINK = "https://github.com/github-linguist/linguist/blob/main/lib/linguist/languages.yml";
+const CTAGS_LINK = "https://ctags.io/";
+
+export const SyntaxReferenceGuide = () => {
+    const [isOpen, setIsOpen] = useState(false);
+
+    useHotkeys("mod+/", (event) => {
+        event.preventDefault();
+        setIsOpen(!isOpen);
+    });
+
+    return (
+        <Dialog
+            open={isOpen}
+            onOpenChange={(isOpen) => {
+                setIsOpen(isOpen);
+            }}
+        >
+            <DialogContent
+                className="max-h-[80vh] max-w-[700px] overflow-scroll"
+            >
+                <DialogHeader>
+                    <DialogTitle>Syntax Reference Guide</DialogTitle>
+                </DialogHeader>
+                <p className="text-sm">
+                    Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>""</Code> combines them. By default, a file must have at least one match for each expression to be included.
+                </p>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="py-2">Example</TableHead>
+                            <TableHead className="py-2">Explanation</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>foo</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo/</Code></TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>foo bar</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo/</Code> <b>and</b> <Code>/bar/</Code></TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>"foo bar"</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo bar/</Code></TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+
+                <Separator className="my-2"/>
+                <p className="text-sm">
+                    Multiple expressions can be or'd together with <Code>or</Code>, negated with <Code>-</Code>, or grouped with <Code>()</Code>.
+                </p>
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="py-2">Example</TableHead>
+                            <TableHead className="py-2">Explanation</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>foo <Highlight>or</Highlight> bar</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo/</Code> <b>or</b> <Code>/bar/</Code></TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>foo -bar</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo/</Code> but <b>not</b> <Code>/bar/</Code></TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code>foo (bar <Highlight>or</Highlight> baz)</Code></TableCell>
+                            <TableCell className="py-2">Match files with regex <Code>/foo/</Code> <b>and</b> either <Code>/bar/</Code> <b>or</b> <Code>/baz/</Code></TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+
+                <Separator className="my-2"/>
+                <p className="text-sm">
+                    Expressions can be prefixed with certain keywords to modify search behavior. Some keywords can be negated using the <Code>-</Code> prefix.
+                </p>
+
+                <Table>
+                    <TableHeader>
+                        <TableRow>
+                            <TableHead className="py-2">Prefix</TableHead>
+                            <TableHead className="py-2">Description</TableHead>
+                            <TableHead className="py-2 w-[175px]">Example</TableHead>
+                        </TableRow>
+                    </TableHeader>
+                    <TableBody>
+                        <TableRow>
+                            <TableCell className="py-2"><Code><Highlight>file:</Highlight></Code></TableCell>
+                            <TableCell className="py-2">Filter results from filepaths that match the regex. By default all files are searched.</TableCell>
+                            <TableCell className="py-2">
+                                <div className="flex flex-col gap-1">
+                                    <Code
+                                        title="Filter results to filepaths that match regex /README/"
+                                    >
+                                        <Highlight>file:</Highlight>README
+                                    </Code>
+                                    <Code
+                                        title="Filter results to filepaths that match regex /my file/"
+                                    >
+                                        <Highlight>file:</Highlight>"my file"
+                                    </Code>
+                                    <Code
+                                        title="Ignore results from filepaths match regex /test\.ts$/"
+                                    >
+                                        <Highlight>-file:</Highlight>test\.ts$
+                                    </Code>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code><Highlight>repo:</Highlight></Code></TableCell>
+                            <TableCell className="py-2">Filter results from repos that match the regex. By default all repos are searched.</TableCell>
+                            <TableCell className="py-2">
+                                <div className="flex flex-col gap-1">
+                                    <Code
+                                        title="Filter results to repos that match regex /linux/"
+                                    >
+                                        <Highlight>repo:</Highlight>linux
+                                    </Code>
+                                    <Code
+                                        title="Ignore results from repos that match regex /^web\/.*/"
+                                    >
+                                        <Highlight>-repo:</Highlight>^web/.*
+                                    </Code>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code><Highlight>rev:</Highlight></Code></TableCell>
+                            <TableCell className="py-2">Filter results from a specific branch or tag. By default <b>only</b> the default branch is searched.</TableCell>
+                            <TableCell className="py-2">
+                                <div className="flex flex-col gap-1">
+                                    <Code
+                                        title="Filter results to branches that match regex /beta/"
+                                    >
+                                        <Highlight>rev:</Highlight>beta
+                                    </Code>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code><Highlight>lang:</Highlight></Code></TableCell>
+                            <TableCell className="py-2">Filter results by language (as defined by <Link className="text-blue-500" href={LINGUIST_LINK}>linguist</Link>). By default all languages are searched.</TableCell>
+                            <TableCell className="py-2">
+                                <div className="flex flex-col gap-1">
+                                    <Code
+                                        title="Filter results to TypeScript files"
+                                    >
+                                        <Highlight>lang:</Highlight>TypeScript
+                                    </Code>
+                                    <Code
+                                        title="Ignore results from YAML files"
+                                    >
+                                        <Highlight>-lang:</Highlight>YAML
+                                    </Code>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                        <TableRow>
+                            <TableCell className="py-2"><Code><Highlight>sym:</Highlight></Code></TableCell>
+                            <TableCell className="py-2">Match symbol definitions created by <Link className="text-blue-500" href={CTAGS_LINK}>universal ctags</Link> at index time.</TableCell>
+                            <TableCell className="py-2">
+                                <div className="flex flex-col gap-1">
+                                    <Code
+                                        title="Filter results to symbols that match regex /\bmain\b/"
+                                    >
+                                        <Highlight>sym:</Highlight>\bmain\b
+                                    </Code>
+                                </div>
+                            </TableCell>
+                        </TableRow>
+                    </TableBody>
+                </Table>
+            </DialogContent>
+        </Dialog>
+    )
+}
+
+const Code = ({ children, className, title }: { children: React.ReactNode, className?: string, title?: string }) => {
+    return (
+        <code
+            className={clsx("bg-gray-100 dark:bg-gray-700 w-fit rounded-md font-mono px-2 py-0.5", className)}
+            title={title}
+        >
+            {children}
+        </code>
+    )
+}
+
+const Highlight = ({ children }: { children: React.ReactNode }) => {
+    return (
+        <span className="text-highlight">
+            {children}
+        </span>
+    )
+}

--- a/packages/web/src/app/layout.tsx
+++ b/packages/web/src/app/layout.tsx
@@ -6,6 +6,7 @@ import { QueryClientProvider } from "./queryClientProvider";
 import { PHProvider } from "./posthogProvider";
 import { Toaster } from "@/components/ui/toaster";
 import { TooltipProvider } from "@/components/ui/tooltip";
+import { SyntaxReferenceGuide } from "./components/syntaxReferenceGuide";
 
 export const metadata: Metadata = {
     title: "Sourcebot",
@@ -41,6 +42,7 @@ export default function RootLayout({
                                 <Suspense>
                                     {children}
                                 </Suspense>
+                                <SyntaxReferenceGuide />
                             </TooltipProvider>
                         </QueryClientProvider>
                     </ThemeProvider>

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -11,7 +11,7 @@ import { Separator } from "@/components/ui/separator";
 import { SymbolIcon } from "@radix-ui/react-icons";
 import { UpgradeToast } from "./components/upgradeToast";
 import Link from "next/link";
-
+import { KeyboardShortcutHint } from "./components/keyboardShortcutHint";
 
 export default async function Home() {
     return (
@@ -95,6 +95,9 @@ export default async function Home() {
                                 <Query query="content:README"><Highlight>content:</Highlight>README</Query> <QueryExplanation>(search content only)</QueryExplanation>
                             </QueryExample>
                         </HowToSection>
+                    </div>
+                    <div className="text-sm">
+                        <span className="dark:text-gray-300">Reference guide: </span><KeyboardShortcutHint shortcut="⌘" /> <KeyboardShortcutHint shortcut="/" />
                     </div>
                 </div>
             </div>

--- a/packages/web/src/app/search/components/filterPanel/index.tsx
+++ b/packages/web/src/app/search/components/filterPanel/index.tsx
@@ -33,7 +33,7 @@ export const FilterPanel = ({
                 const Icon = info ? (
                     <Image
                         src={info.icon}
-                        alt={info.costHostName}
+                        alt={info.codeHostName}
                         className={cn('w-4 h-4 flex-shrink-0', info.iconClassName)}
                     />
                 ) : (

--- a/packages/web/src/components/ui/dialog.tsx
+++ b/packages/web/src/components/ui/dialog.tsx
@@ -1,0 +1,122 @@
+"use client"
+
+import * as React from "react"
+import * as DialogPrimitive from "@radix-ui/react-dialog"
+import { X } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+
+const Dialog = DialogPrimitive.Root
+
+const DialogTrigger = DialogPrimitive.Trigger
+
+const DialogPortal = DialogPrimitive.Portal
+
+const DialogClose = DialogPrimitive.Close
+
+const DialogOverlay = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Overlay>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Overlay
+    ref={ref}
+    className={cn(
+      "fixed inset-0 z-50 bg-black/80  data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+      className
+    )}
+    {...props}
+  />
+))
+DialogOverlay.displayName = DialogPrimitive.Overlay.displayName
+
+const DialogContent = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Content>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Content>
+>(({ className, children, ...props }, ref) => (
+  <DialogPortal>
+    <DialogOverlay />
+    <DialogPrimitive.Content
+      ref={ref}
+      className={cn(
+        "fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg",
+        className
+      )}
+      {...props}
+    >
+      {children}
+      <DialogPrimitive.Close className="absolute right-4 top-4 rounded-sm opacity-70 ring-offset-background transition-opacity hover:opacity-100 focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 disabled:pointer-events-none data-[state=open]:bg-accent data-[state=open]:text-muted-foreground">
+        <X className="h-4 w-4" />
+        <span className="sr-only">Close</span>
+      </DialogPrimitive.Close>
+    </DialogPrimitive.Content>
+  </DialogPortal>
+))
+DialogContent.displayName = DialogPrimitive.Content.displayName
+
+const DialogHeader = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col space-y-1.5 text-center sm:text-left",
+      className
+    )}
+    {...props}
+  />
+)
+DialogHeader.displayName = "DialogHeader"
+
+const DialogFooter = ({
+  className,
+  ...props
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn(
+      "flex flex-col-reverse sm:flex-row sm:justify-end sm:space-x-2",
+      className
+    )}
+    {...props}
+  />
+)
+DialogFooter.displayName = "DialogFooter"
+
+const DialogTitle = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Title>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Title>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Title
+    ref={ref}
+    className={cn(
+      "text-lg font-semibold leading-none tracking-tight",
+      className
+    )}
+    {...props}
+  />
+))
+DialogTitle.displayName = DialogPrimitive.Title.displayName
+
+const DialogDescription = React.forwardRef<
+  React.ElementRef<typeof DialogPrimitive.Description>,
+  React.ComponentPropsWithoutRef<typeof DialogPrimitive.Description>
+>(({ className, ...props }, ref) => (
+  <DialogPrimitive.Description
+    ref={ref}
+    className={cn("text-sm text-muted-foreground", className)}
+    {...props}
+  />
+))
+DialogDescription.displayName = DialogPrimitive.Description.displayName
+
+export {
+  Dialog,
+  DialogPortal,
+  DialogOverlay,
+  DialogClose,
+  DialogTrigger,
+  DialogContent,
+  DialogHeader,
+  DialogFooter,
+  DialogTitle,
+  DialogDescription,
+}

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -34,7 +34,7 @@ export const createPathWithQueryParams = (path: string, ...queryParams: [string,
 type CodeHostInfo = {
     type: "github" | "gitlab" | "gitea" | "gerrit";
     displayName: string;
-    costHostName: string;
+    codeHostName: string;
     repoLink: string;
     icon: string;
     iconClassName?: string;
@@ -57,7 +57,7 @@ export const getRepoCodeHostInfo = (repo?: Repository): CodeHostInfo | undefined
             return {
                 type: "github",
                 displayName: displayName,
-                costHostName: "GitHub",
+                codeHostName: "GitHub",
                 repoLink: repo.URL,
                 icon: githubLogo,
                 iconClassName: "dark:invert",
@@ -66,7 +66,7 @@ export const getRepoCodeHostInfo = (repo?: Repository): CodeHostInfo | undefined
             return {
                 type: "gitlab",
                 displayName: displayName,
-                costHostName: "GitLab",
+                codeHostName: "GitLab",
                 repoLink: repo.URL,
                 icon: gitlabLogo,
             }
@@ -74,7 +74,7 @@ export const getRepoCodeHostInfo = (repo?: Repository): CodeHostInfo | undefined
             return {
                 type: "gitea",
                 displayName: displayName,
-                costHostName: "Gitea",
+                codeHostName: "Gitea",
                 repoLink: repo.URL,
                 icon: giteaLogo,
             }
@@ -82,7 +82,7 @@ export const getRepoCodeHostInfo = (repo?: Repository): CodeHostInfo | undefined
             return {
                 type: "gerrit",
                 displayName: displayName,
-                costHostName: "Gerrit",
+                codeHostName: "Gerrit",
                 repoLink: repo.URL,
                 icon: gerritLogo,
             }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1250,6 +1250,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.0.tgz#42ef83b3b56dccad5d703ae8c42919a68798bbe2"
   integrity sha512-4Z8dn6Upk0qk4P74xBhZ6Hd/w0mPEzOOLxy4xiPXOXqjF7jZS0VAKk7/x/H6FyY2zCkYJqePf1G5KmkmNJ4RBA==
 
+"@radix-ui/primitive@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/primitive/-/primitive-1.1.1.tgz#fc169732d755c7fbad33ba8d0cd7fd10c90dc8e3"
+  integrity sha512-SJ31y+Q/zAyShtXJc8x83i9TYdbAfHZ++tUZnvjJJqFjzsdUnKsxPL6IEtBlxKkU7yzer//GQtZSV4GbldL3YA==
+
 "@radix-ui/react-arrow@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-arrow/-/react-arrow-1.1.0.tgz#744f388182d360b86285217e43b6c63633f39e7a"
@@ -1272,6 +1277,11 @@
   resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.0.tgz#656432461fc8283d7b591dcf0d79152fae9ecc74"
   integrity sha512-b4inOtiaOnYf9KWyO3jAeeCG6FeyfY6ldiEPanbUjWd+xIk5wZeHa8yVwmrJ2vderhu/BQvzCrJI0lHd+wIiqw==
 
+"@radix-ui/react-compose-refs@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.1.tgz#6f766faa975f8738269ebb8a23bad4f5a8d2faec"
+  integrity sha512-Y9VzoRDSJtgFMUCoiZBDVo084VQ5hfpXxVE+NgkdNsjiDBByiImMZKKhxMwCbdHvhlENG6a833CbFkOQvTricw==
+
 "@radix-ui/react-context@1.1.0":
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.0.tgz#6df8d983546cfd1999c8512f3a8ad85a6e7fcee8"
@@ -1281,6 +1291,26 @@
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-context/-/react-context-1.1.1.tgz#82074aa83a472353bb22e86f11bcbd1c61c4c71a"
   integrity sha512-UASk9zi+crv9WteK/NU4PLvOoL3OuE6BWVKNF6hPRBtYBDXQ2u5iu3O59zUlJiTVvkyuycnqrztsHVJwcK9K+Q==
+
+"@radix-ui/react-dialog@^1.1.4":
+  version "1.1.4"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dialog/-/react-dialog-1.1.4.tgz#d68e977acfcc0d044b9dab47b6dd2c179d2b3191"
+  integrity sha512-Ur7EV1IwQGCyaAuyDRiOLA5JIUZxELJljF+MbM/2NC0BYwfuRrbpS30BiQBJrVruscgUkieKkqXYDOoByaxIoA==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-context" "1.1.1"
+    "@radix-ui/react-dismissable-layer" "1.1.3"
+    "@radix-ui/react-focus-guards" "1.1.1"
+    "@radix-ui/react-focus-scope" "1.1.1"
+    "@radix-ui/react-id" "1.1.0"
+    "@radix-ui/react-portal" "1.1.3"
+    "@radix-ui/react-presence" "1.1.2"
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-slot" "1.1.1"
+    "@radix-ui/react-use-controllable-state" "1.1.0"
+    aria-hidden "^1.1.1"
+    react-remove-scroll "^2.6.1"
 
 "@radix-ui/react-direction@1.1.0":
   version "1.1.0"
@@ -1295,6 +1325,17 @@
     "@radix-ui/primitive" "1.1.0"
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+    "@radix-ui/react-use-escape-keydown" "1.1.0"
+
+"@radix-ui/react-dismissable-layer@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.3.tgz#4ee0f0f82d53bf5bd9db21665799bb0d1bad5ed8"
+  integrity sha512-onrWn/72lQoEucDmJnr8uczSNTujT0vJnA/X5+3AkChVPowr8n1yvIKIabhWyMQeMvvmdpsvcyDqx3X1LEXCPg==
+  dependencies:
+    "@radix-ui/primitive" "1.1.1"
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
     "@radix-ui/react-use-callback-ref" "1.1.0"
     "@radix-ui/react-use-escape-keydown" "1.1.0"
 
@@ -1323,6 +1364,15 @@
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-primitive" "2.0.0"
+    "@radix-ui/react-use-callback-ref" "1.1.0"
+
+"@radix-ui/react-focus-scope@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.1.tgz#5c602115d1db1c4fcfa0fae4c3b09bb8919853cb"
+  integrity sha512-01omzJAYRxXdG2/he/+xy+c8a8gCydoQ1yOxnWNcRhrrBW5W+RQJ22EK1SaO8tb3WoUsuEw7mJjBozPzihDFjA==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-primitive" "2.0.1"
     "@radix-ui/react-use-callback-ref" "1.1.0"
 
 "@radix-ui/react-icons@^1.3.0":
@@ -1412,6 +1462,14 @@
     "@radix-ui/react-primitive" "2.0.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-portal@1.1.3":
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-portal/-/react-portal-1.1.3.tgz#b0ea5141103a1671b715481b13440763d2ac4440"
+  integrity sha512-NciRqhXnGojhT93RPyDaMPfLH3ZSl4jjIFbZQ1b/vxvZEdHsBZ49wP9w8L3HzUQwep01LcWtkUvm0OVB5JAHTw==
+  dependencies:
+    "@radix-ui/react-primitive" "2.0.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-presence@1.1.1":
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.1.tgz#98aba423dba5e0c687a782c0669dcd99de17f9b1"
@@ -1420,12 +1478,27 @@
     "@radix-ui/react-compose-refs" "1.1.0"
     "@radix-ui/react-use-layout-effect" "1.1.0"
 
+"@radix-ui/react-presence@1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-presence/-/react-presence-1.1.2.tgz#bb764ed8a9118b7ec4512da5ece306ded8703cdc"
+  integrity sha512-18TFr80t5EVgL9x1SwF/YGtfG+l0BS0PRAlCWBDoBEiDQjeKgnNZRVJp/oVBl24sr3Gbfwc/Qpj4OcWTQMsAEg==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
+    "@radix-ui/react-use-layout-effect" "1.1.0"
+
 "@radix-ui/react-primitive@2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.0.tgz#fe05715faa9203a223ccc0be15dc44b9f9822884"
   integrity sha512-ZSpFm0/uHa8zTvKBDjLFWLo8dkr4MBsiDLz0g3gMUwqgLHz9rTaRRGYDgvZPtBJgYCBKXkS9fzmoySgr8CO6Cw==
   dependencies:
     "@radix-ui/react-slot" "1.1.0"
+
+"@radix-ui/react-primitive@2.0.1":
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-primitive/-/react-primitive-2.0.1.tgz#6d9efc550f7520135366f333d1e820cf225fad9e"
+  integrity sha512-sHCWTtxwNn3L3fH8qAfnF3WbUZycW93SM1j3NFDzXBiz8D6F5UTTy8G1+WFEaiCdvCVRJWj6N2R4Xq6HdiHmDg==
+  dependencies:
+    "@radix-ui/react-slot" "1.1.1"
 
 "@radix-ui/react-roving-focus@1.1.0":
   version "1.1.0"
@@ -1470,6 +1543,13 @@
   integrity sha512-FUCf5XMfmW4dtYl69pdS4DbxKy8nj4M7SafBgPllysxmdachynNflAdp/gCsnYWNDnge6tI9onzMp5ARYc1KNw==
   dependencies:
     "@radix-ui/react-compose-refs" "1.1.0"
+
+"@radix-ui/react-slot@1.1.1":
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-slot/-/react-slot-1.1.1.tgz#ab9a0ffae4027db7dc2af503c223c978706affc3"
+  integrity sha512-RApLLOcINYJA+dMVbOju7MYv1Mb2EBp2nH4HdDzXTSyaR5optlm6Otrz1euW3HbdOR8UmmFK06TD+A9frYWv+g==
+  dependencies:
+    "@radix-ui/react-compose-refs" "1.1.1"
 
 "@radix-ui/react-toast@^1.2.2":
   version "1.2.2"
@@ -5078,6 +5158,14 @@ react-remove-scroll-bar@^2.3.6:
     react-style-singleton "^2.2.1"
     tslib "^2.0.0"
 
+react-remove-scroll-bar@^2.3.7:
+  version "2.3.8"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz#99c20f908ee467b385b68a3469b4a3e750012223"
+  integrity sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==
+  dependencies:
+    react-style-singleton "^2.2.2"
+    tslib "^2.0.0"
+
 react-remove-scroll@2.6.0:
   version "2.6.0"
   resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.0.tgz#fb03a0845d7768a4f1519a99fdb84983b793dc07"
@@ -5087,6 +5175,17 @@ react-remove-scroll@2.6.0:
     react-style-singleton "^2.2.1"
     tslib "^2.1.0"
     use-callback-ref "^1.3.0"
+    use-sidecar "^1.1.2"
+
+react-remove-scroll@^2.6.1:
+  version "2.6.2"
+  resolved "https://registry.yarnpkg.com/react-remove-scroll/-/react-remove-scroll-2.6.2.tgz#2518d2c5112e71ea8928f1082a58459b5c7a2a97"
+  integrity sha512-KmONPx5fnlXYJQqC62Q+lwIeAk64ws/cUw6omIumRzMRPqgnYqhSSti99nbj0Ry13bv7dF+BKn7NB+OqkdZGTw==
+  dependencies:
+    react-remove-scroll-bar "^2.3.7"
+    react-style-singleton "^2.2.1"
+    tslib "^2.1.0"
+    use-callback-ref "^1.3.3"
     use-sidecar "^1.1.2"
 
 react-resizable-panels@^2.1.1:
@@ -5101,6 +5200,14 @@ react-style-singleton@^2.2.1:
   dependencies:
     get-nonce "^1.0.0"
     invariant "^2.2.4"
+    tslib "^2.0.0"
+
+react-style-singleton@^2.2.2:
+  version "2.2.3"
+  resolved "https://registry.yarnpkg.com/react-style-singleton/-/react-style-singleton-2.2.3.tgz#4265608be69a4d70cfe3047f2c6c88b2c3ace388"
+  integrity sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==
+  dependencies:
+    get-nonce "^1.0.0"
     tslib "^2.0.0"
 
 react@^18:
@@ -5536,16 +5643,7 @@ string-argv@^0.3.1:
   resolved "https://registry.yarnpkg.com/string-argv/-/string-argv-0.3.2.tgz#2b6d0ef24b656274d957d54e0a4bbf6153dc02b6"
   integrity sha512-aqD2Q0144Z+/RqG52NeHEkZauTAUWJO8c6yTftGJKO3Tja5tUgIfmIl6kExvhtxSDP7fXB6DvzkfMpCd/F3G+Q==
 
-"string-width-cjs@npm:string-width@^4.2.0":
-  version "4.2.3"
-  resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
-  integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
-  dependencies:
-    emoji-regex "^8.0.0"
-    is-fullwidth-code-point "^3.0.0"
-    strip-ansi "^6.0.1"
-
-string-width@^4.1.0:
+"string-width-cjs@npm:string-width@^4.2.0", string-width@^4.1.0:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"
   integrity sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==
@@ -5642,14 +5740,7 @@ string_decoder@^1.1.1, string_decoder@^1.3.0:
   dependencies:
     safe-buffer "~5.2.0"
 
-"strip-ansi-cjs@npm:strip-ansi@^6.0.1":
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
-  integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
-  dependencies:
-    ansi-regex "^5.0.1"
-
-strip-ansi@^6.0.0, strip-ansi@^6.0.1:
+"strip-ansi-cjs@npm:strip-ansi@^6.0.1", strip-ansi@^6.0.0, strip-ansi@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/strip-ansi/-/strip-ansi-6.0.1.tgz#9e26c63d30f53443e9489495b2105d37b67a85d9"
   integrity sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==
@@ -6019,6 +6110,13 @@ use-callback-ref@^1.3.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.2.tgz#6134c7f6ff76e2be0b56c809b17a650c942b1693"
   integrity sha512-elOQwe6Q8gqZgDA8mrh44qRTQqpIHDcZ3hXTLjBe1i4ph8XpNJnO+aQf3NaG+lriLopI4HMx9VjQLfPQ6vhnoA==
+  dependencies:
+    tslib "^2.0.0"
+
+use-callback-ref@^1.3.3:
+  version "1.3.3"
+  resolved "https://registry.yarnpkg.com/use-callback-ref/-/use-callback-ref-1.3.3.tgz#98d9fab067075841c5b2c6852090d5d0feabe2bf"
+  integrity sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==
   dependencies:
     tslib "^2.0.0"
 


### PR DESCRIPTION
This PR adds a reference guide for the query syntax that can be brought up anywhere in the app by using the hotkey "cmd+/" (or "ctr+/" on windows).

<img width="761" alt="image" src="https://github.com/user-attachments/assets/ea1b25b7-afd3-44dd-9566-45d2a43869c4" />

TODO:
- [x] Fix shortcut behaviour when search box is focused
- [x] Surface "Syntax Tips" link is various places (e.g., search suggestions box, maybe as a "?" icon in the search bar)