### PR TITLE
enforce tenancy on search and repo listing endpoints

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,11 @@
         "build": "yarn workspaces run build",
         "test": "yarn workspaces run test",
         "dev": "cross-env SOURCEBOT_TENANT_MODE=single npm-run-all --print-label dev:start",
-        "dev:mt": "cross-env SOURCEBOT_TENANT_MODE=multi npm-run-all --print-label dev:start",
+        "dev:mt": "cross-env SOURCEBOT_TENANT_MODE=multi npm-run-all --print-label dev:start:mt",
         "dev:start": "yarn workspace @sourcebot/db prisma:migrate:dev && cross-env npm-run-all --print-label --parallel dev:zoekt dev:backend dev:web",
+        "dev:start:mt": "yarn workspace @sourcebot/db prisma:migrate:dev && cross-env npm-run-all --print-label --parallel dev:zoekt:mt dev:backend dev:web",
         "dev:zoekt": "export PATH=\"$PWD/bin:$PATH\" && export SRC_TENANT_ENFORCEMENT_MODE=none && zoekt-webserver -index .sourcebot/index -rpc",
+        "dev:zoekt:mt": "export PATH=\"$PWD/bin:$PATH\" && export SRC_TENANT_ENFORCEMENT_MODE=strict && zoekt-webserver -index .sourcebot/index -rpc",
         "dev:backend": "yarn workspace @sourcebot/backend dev:watch",
         "dev:web": "yarn workspace @sourcebot/web dev"
     },

--- a/packages/web/src/app/api/(server)/repos/route.ts
+++ b/packages/web/src/app/api/(server)/repos/route.ts
@@ -1,8 +1,15 @@
 'use server';
 
 import { listRepositories } from "@/lib/server/searchService";
+import { getCurrentUserOrg } from "../../../../auth";
+import { isServiceError } from "@/lib/utils";
 
 export const GET = async () => {
-    const response = await listRepositories();
+    const orgId = await getCurrentUserOrg();
+    if (isServiceError(orgId)) {
+        return orgId;
+    }
+
+    const response = await listRepositories(orgId);
     return Response.json(response);
 }

--- a/packages/web/src/app/api/(server)/search/route.ts
+++ b/packages/web/src/app/api/(server)/search/route.ts
@@ -15,10 +15,7 @@ export const POST = async (request: NextRequest) => {
 
     console.log(`Searching for org ${orgId}`);
     const body = await request.json();
-    const parsed = await searchRequestSchema.safeParseAsync({
-        ...body,
-        ...({orgId: orgId}),
-    });
+    const parsed = await searchRequestSchema.safeParseAsync(body);
     if (!parsed.success) {
         return serviceErrorResponse(
             schemaValidationError(parsed.error)
@@ -26,7 +23,7 @@ export const POST = async (request: NextRequest) => {
     }
 
 
-    const response = await search(parsed.data);
+    const response = await search(parsed.data, orgId);
     if (isServiceError(response)) {
         return serviceErrorResponse(response);
     }

--- a/packages/web/src/app/api/(server)/search/route.ts
+++ b/packages/web/src/app/api/(server)/search/route.ts
@@ -5,18 +5,19 @@ import { searchRequestSchema } from "@/lib/schemas";
 import { schemaValidationError, serviceErrorResponse } from "@/lib/serviceError";
 import { isServiceError } from "@/lib/utils";
 import { NextRequest } from "next/server";
+import { getCurrentUserOrg } from "../../../../auth";
 
 export const POST = async (request: NextRequest) => {
+    const orgId = await getCurrentUserOrg();
+    if (isServiceError(orgId)) {
+        return orgId;
+    }
+
+    console.log(`Searching for org ${orgId}`);
     const body = await request.json();
-    const tenantId = request.headers.get("X-Tenant-ID");
-
-    console.log(`Search request received. Tenant ID: ${tenantId}`);
-
     const parsed = await searchRequestSchema.safeParseAsync({
         ...body,
-        ...(tenantId ? {
-            tenantId: parseInt(tenantId)
-        } : {}),
+        ...({orgId: orgId}),
     });
     if (!parsed.success) {
         return serviceErrorResponse(

--- a/packages/web/src/app/api/(server)/source/route.ts
+++ b/packages/web/src/app/api/(server)/source/route.ts
@@ -5,10 +5,19 @@ import { getFileSource } from "@/lib/server/searchService";
 import { schemaValidationError, serviceErrorResponse } from "@/lib/serviceError";
 import { isServiceError } from "@/lib/utils";
 import { NextRequest } from "next/server";
+import { getCurrentUserOrg } from "@/auth";
 
 export const POST = async (request: NextRequest) => {
+    const orgId = await getCurrentUserOrg();
+    if (isServiceError(orgId)) {
+        return orgId;
+    }
+
     const body = await request.json();
-    const parsed = await fileSourceRequestSchema.safeParseAsync(body);
+    const parsed = await fileSourceRequestSchema.safeParseAsync({
+        ...body,
+        ...({orgId: orgId}),
+    });
     if (!parsed.success) {
         return serviceErrorResponse(
             schemaValidationError(parsed.error)

--- a/packages/web/src/app/api/(server)/source/route.ts
+++ b/packages/web/src/app/api/(server)/source/route.ts
@@ -14,17 +14,14 @@ export const POST = async (request: NextRequest) => {
     }
 
     const body = await request.json();
-    const parsed = await fileSourceRequestSchema.safeParseAsync({
-        ...body,
-        ...({orgId: orgId}),
-    });
+    const parsed = await fileSourceRequestSchema.safeParseAsync(body);
     if (!parsed.success) {
         return serviceErrorResponse(
             schemaValidationError(parsed.error)
         );
     }
 
-    const response = await getFileSource(parsed.data);
+    const response = await getFileSource(parsed.data, orgId);
     if (isServiceError(response)) {
         return serviceErrorResponse(response);
     }

--- a/packages/web/src/app/browse/[...path]/page.tsx
+++ b/packages/web/src/app/browse/[...path]/page.tsx
@@ -133,8 +133,7 @@ const CodePreviewWrapper = async ({
         fileName: path,
         repository: repoName,
         branch: revisionName,
-        orgId,
-    });
+    }, orgId);
 
     if (isServiceError(fileSourceResponse)) {
         if (fileSourceResponse.errorCode === ErrorCode.FILE_NOT_FOUND) {

--- a/packages/web/src/app/page.tsx
+++ b/packages/web/src/app/page.tsx
@@ -11,93 +11,102 @@ import { Separator } from "@/components/ui/separator";
 import { SymbolIcon } from "@radix-ui/react-icons";
 import { UpgradeToast } from "./components/upgradeToast";
 import Link from "next/link";
+import { getCurrentUserOrg } from "../auth"
 
 
 export default async function Home() {
+    const orgId = await getCurrentUserOrg();
+
     return (
         <div className="flex flex-col items-center overflow-hidden min-h-screen">
             <NavigationMenu />
             <UpgradeToast />
 
-            <div className="flex flex-col justify-center items-center mt-8 mb-8 md:mt-18 w-full px-5">
-                <div className="max-h-44 w-auto">
-                    <Image
-                        src={logoDark}
-                        className="h-18 md:h-40 w-auto hidden dark:block"
-                        alt={"Sourcebot logo"}
-                        priority={true}
-                    />
-                    <Image
-                        src={logoLight}
-                        className="h-18 md:h-40 w-auto block dark:hidden"
-                        alt={"Sourcebot logo"}
-                        priority={true}
-                    />
+            {isServiceError(orgId) ? (
+                <div className="mt-8 text-red-500">
+                    You are not authenticated. Please log in to continue.
                 </div>
-                <SearchBar
-                    autoFocus={true}
-                    className="mt-4 w-full max-w-[800px]"
-                />
-                <div className="mt-8">
-                    <Suspense fallback={<div>...</div>}>
-                        <RepositoryList />
-                    </Suspense>
-                </div>
-                <div className="flex flex-col items-center w-fit gap-6">
-                    <Separator className="mt-5" />
-                    <span className="font-semibold">How to search</span>
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
-                        <HowToSection
-                            title="Search in files or paths"
-                        >
-                            <QueryExample>
-                                <Query query="test todo">test todo</Query> <QueryExplanation>(both test and todo)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="test or todo">test <Highlight>or</Highlight> todo</Query> <QueryExplanation>(either test or todo)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query={`"exit boot"`}>{`"exit boot"`}</Query> <QueryExplanation>(exact match)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="TODO case:yes">TODO <Highlight>case:</Highlight>yes</Query> <QueryExplanation>(case sensitive)</QueryExplanation>
-                            </QueryExample>
-                        </HowToSection>
-                        <HowToSection
-                            title="Filter results"
-                        >
-                            <QueryExample>
-                                <Query query="file:README setup"><Highlight>file:</Highlight>README setup</Query> <QueryExplanation>(by filename)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="repo:torvalds/linux test"><Highlight>repo:</Highlight>torvalds/linux test</Query> <QueryExplanation>(by repo)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="lang:typescript"><Highlight>lang:</Highlight>typescript</Query> <QueryExplanation>(by language)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="rev:HEAD"><Highlight>rev:</Highlight>HEAD</Query> <QueryExplanation>(by branch or tag)</QueryExplanation>
-                            </QueryExample>
-                        </HowToSection>
-                        <HowToSection
-                            title="Advanced"
-                        >
-                            <QueryExample>
-                                <Query query="file:\.py$"><Highlight>file:</Highlight>{`\\.py$`}</Query> <QueryExplanation>{`(files that end in ".py")`}</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="sym:main"><Highlight>sym:</Highlight>main</Query> <QueryExplanation>{`(symbols named "main")`}</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="todo -lang:c">todo <Highlight>-lang:c</Highlight></Query> <QueryExplanation>(negate filter)</QueryExplanation>
-                            </QueryExample>
-                            <QueryExample>
-                                <Query query="content:README"><Highlight>content:</Highlight>README</Query> <QueryExplanation>(search content only)</QueryExplanation>
-                            </QueryExample>
-                        </HowToSection>
+            ) : (
+                <div className="flex flex-col justify-center items-center mt-8 mb-8 md:mt-18 w-full px-5">
+                    <div className="max-h-44 w-auto">
+                        <Image
+                            src={logoDark}
+                            className="h-18 md:h-40 w-auto hidden dark:block"
+                            alt={"Sourcebot logo"}
+                            priority={true}
+                        />
+                        <Image
+                            src={logoLight}
+                            className="h-18 md:h-40 w-auto block dark:hidden"
+                            alt={"Sourcebot logo"}
+                            priority={true}
+                        />
+                    </div>
+                    <SearchBar
+                        autoFocus={true}
+                        className="mt-4 w-full max-w-[800px]"
+                    />
+                    <div className="mt-8">
+                        <Suspense fallback={<div>...</div>}>
+                            <RepositoryList orgId={orgId}/>
+                        </Suspense>
+                    </div>
+                    <div className="flex flex-col items-center w-fit gap-6">
+                        <Separator className="mt-5" />
+                        <span className="font-semibold">How to search</span>
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-5">
+                            <HowToSection
+                                title="Search in files or paths"
+                            >
+                                <QueryExample>
+                                    <Query query="test todo">test todo</Query> <QueryExplanation>(both test and todo)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="test or todo">test <Highlight>or</Highlight> todo</Query> <QueryExplanation>(either test or todo)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query={`"exit boot"`}>{`"exit boot"`}</Query> <QueryExplanation>(exact match)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="TODO case:yes">TODO <Highlight>case:</Highlight>yes</Query> <QueryExplanation>(case sensitive)</QueryExplanation>
+                                </QueryExample>
+                            </HowToSection>
+                            <HowToSection
+                                title="Filter results"
+                            >
+                                <QueryExample>
+                                    <Query query="file:README setup"><Highlight>file:</Highlight>README setup</Query> <QueryExplanation>(by filename)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="repo:torvalds/linux test"><Highlight>repo:</Highlight>torvalds/linux test</Query> <QueryExplanation>(by repo)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="lang:typescript"><Highlight>lang:</Highlight>typescript</Query> <QueryExplanation>(by language)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="rev:HEAD"><Highlight>rev:</Highlight>HEAD</Query> <QueryExplanation>(by branch or tag)</QueryExplanation>
+                                </QueryExample>
+                            </HowToSection>
+                            <HowToSection
+                                title="Advanced"
+                            >
+                                <QueryExample>
+                                    <Query query="file:\.py$"><Highlight>file:</Highlight>{`\\.py$`}</Query> <QueryExplanation>{`(files that end in ".py")`}</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="sym:main"><Highlight>sym:</Highlight>main</Query> <QueryExplanation>{`(symbols named "main")`}</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="todo -lang:c">todo <Highlight>-lang:c</Highlight></Query> <QueryExplanation>(negate filter)</QueryExplanation>
+                                </QueryExample>
+                                <QueryExample>
+                                    <Query query="content:README"><Highlight>content:</Highlight>README</Query> <QueryExplanation>(search content only)</QueryExplanation>
+                                </QueryExample>
+                            </HowToSection>
+                        </div>
                     </div>
                 </div>
-            </div>
+            )}
 
             <footer className="w-full mt-auto py-4 flex flex-row justify-center items-center gap-4">
                 <Link href="https://sourcebot.dev" className="text-gray-400 text-sm hover:underline">About</Link>
@@ -110,8 +119,8 @@ export default async function Home() {
     )
 }
 
-const RepositoryList = async () => {
-    const _repos = await listRepositories();
+const RepositoryList = async ({ orgId }: { orgId: number}) => {
+    const _repos = await listRepositories(orgId);
 
     if (isServiceError(_repos)) {
         return null;

--- a/packages/web/src/app/repos/page.tsx
+++ b/packages/web/src/app/repos/page.tsx
@@ -1,14 +1,25 @@
 import { Suspense } from "react";
 import { NavigationMenu } from "../components/navigationMenu";
 import { RepositoryTable } from "./repositoryTable";
+import { getCurrentUserOrg } from "@/auth";
+import { isServiceError } from "@/lib/utils";
 
-export default function ReposPage() {
+export default async function ReposPage() {
+    const orgId = await getCurrentUserOrg();
+    if (isServiceError(orgId)) {
+        return (
+            <>
+                Error: {orgId.message}
+            </>
+        )
+    }
+    
     return (
         <div className="h-screen flex flex-col items-center">
             <NavigationMenu />
             <Suspense fallback={<div>Loading...</div>}>
                 <div className="max-w-[90%]">
-                    <RepositoryTable />
+                    <RepositoryTable orgId={ orgId }/>
                 </div>
             </Suspense>
         </div>

--- a/packages/web/src/app/repos/repositoryTable.tsx
+++ b/packages/web/src/app/repos/repositoryTable.tsx
@@ -3,8 +3,8 @@ import { columns, RepositoryColumnInfo } from "./columns";
 import { listRepositories } from "@/lib/server/searchService";
 import { isServiceError } from "@/lib/utils";
 
-export const RepositoryTable = async () => {
-    const _repos = await listRepositories();
+export const RepositoryTable = async ({ orgId }: { orgId: number }) => {
+    const _repos = await listRepositories(orgId);
 
     if (isServiceError(_repos)) {
         return <div>Error fetching repositories</div>;

--- a/packages/web/src/app/secrets/page.tsx
+++ b/packages/web/src/app/secrets/page.tsx
@@ -1,6 +1,6 @@
 import { NavigationMenu } from "../components/navigationMenu";
 import { SecretsTable } from "./secretsTable";
-import { getSecrets, createSecret } from "../../actions"
+import { getSecrets } from "../../actions"
 import { isServiceError } from "@/lib/utils";
 
 export interface SecretsTableProps {

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -3,8 +3,8 @@ import { z } from "zod";
 export const searchRequestSchema = z.object({
     query: z.string(),
     maxMatchDisplayCount: z.number(),
+    orgId: z.number(),
     whole: z.boolean().optional(),
-    tenantId: z.number().optional(),
 });
 
 
@@ -90,6 +90,7 @@ export const searchResponseSchema = z.object({
 export const fileSourceRequestSchema = z.object({
     fileName: z.string(),
     repository: z.string(),
+    orgId: z.number(),
     branch: z.string().optional(),
 });
 

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -3,7 +3,6 @@ import { z } from "zod";
 export const searchRequestSchema = z.object({
     query: z.string(),
     maxMatchDisplayCount: z.number(),
-    orgId: z.number(),
     whole: z.boolean().optional(),
 });
 
@@ -90,7 +89,6 @@ export const searchResponseSchema = z.object({
 export const fileSourceRequestSchema = z.object({
     fileName: z.string(),
     repository: z.string(),
-    orgId: z.number(),
     branch: z.string().optional(),
 });
 

--- a/packages/web/src/lib/server/searchService.ts
+++ b/packages/web/src/lib/server/searchService.ts
@@ -34,7 +34,7 @@ const aliasPrefixMappings: Record<string, zoektPrefixes> = {
     "revision:": zoektPrefixes.branch,
 }
 
-export const search = async ({ query, maxMatchDisplayCount, whole, orgId}: SearchRequest): Promise<SearchResponse | ServiceError> => {
+export const search = async ({ query, maxMatchDisplayCount, whole}: SearchRequest, orgId: number): Promise<SearchResponse | ServiceError> => {
     // Replace any alias prefixes with their corresponding zoekt prefixes.
     for (const [prefix, zoektPrefix] of Object.entries(aliasPrefixMappings)) {
         query = query.replaceAll(prefix, zoektPrefix);
@@ -90,7 +90,7 @@ export const search = async ({ query, maxMatchDisplayCount, whole, orgId}: Searc
 // @todo (bkellam) : We should really be using `git show <hash>:<path>` to fetch file contents here.
 // This will allow us to support permalinks to files at a specific revision that may not be indexed
 // by zoekt.
-export const getFileSource = async ({ fileName, repository, branch, orgId }: FileSourceRequest): Promise<FileSourceResponse | ServiceError> => {
+export const getFileSource = async ({ fileName, repository, branch }: FileSourceRequest, orgId: number): Promise<FileSourceResponse | ServiceError> => {
     const escapedFileName = escapeStringRegexp(fileName);
     const escapedRepository = escapeStringRegexp(repository);
     
@@ -103,8 +103,7 @@ export const getFileSource = async ({ fileName, repository, branch, orgId }: Fil
         query,
         maxMatchDisplayCount: 1,
         whole: true,
-        orgId,
-    });
+    }, orgId);
 
     if (isServiceError(searchResponse)) {
         return searchResponse;

--- a/packages/web/src/lib/server/searchService.ts
+++ b/packages/web/src/lib/server/searchService.ts
@@ -34,7 +34,7 @@ const aliasPrefixMappings: Record<string, zoektPrefixes> = {
     "revision:": zoektPrefixes.branch,
 }
 
-export const search = async ({ query, maxMatchDisplayCount, whole, tenantId }: SearchRequest): Promise<SearchResponse | ServiceError> => {
+export const search = async ({ query, maxMatchDisplayCount, whole, orgId}: SearchRequest): Promise<SearchResponse | ServiceError> => {
     // Replace any alias prefixes with their corresponding zoekt prefixes.
     for (const [prefix, zoektPrefix] of Object.entries(aliasPrefixMappings)) {
         query = query.replaceAll(prefix, zoektPrefix);
@@ -54,11 +54,9 @@ export const search = async ({ query, maxMatchDisplayCount, whole, tenantId }: S
     });
 
     let header: Record<string, string> = {};
-    if (tenantId) {
-        header = {
-            "X-Tenant-ID": tenantId.toString()
-        };
-    }
+    header = {
+        "X-Tenant-ID": orgId.toString()
+    };
 
     const searchResponse = await zoektFetch({
         path: "/api/search",
@@ -92,7 +90,7 @@ export const search = async ({ query, maxMatchDisplayCount, whole, tenantId }: S
 // @todo (bkellam) : We should really be using `git show <hash>:<path>` to fetch file contents here.
 // This will allow us to support permalinks to files at a specific revision that may not be indexed
 // by zoekt.
-export const getFileSource = async ({ fileName, repository, branch }: FileSourceRequest): Promise<FileSourceResponse | ServiceError> => {
+export const getFileSource = async ({ fileName, repository, branch, orgId }: FileSourceRequest): Promise<FileSourceResponse | ServiceError> => {
     const escapedFileName = escapeStringRegexp(fileName);
     const escapedRepository = escapeStringRegexp(repository);
     
@@ -105,6 +103,7 @@ export const getFileSource = async ({ fileName, repository, branch }: FileSource
         query,
         maxMatchDisplayCount: 1,
         whole: true,
+        orgId,
     });
 
     if (isServiceError(searchResponse)) {
@@ -126,15 +125,22 @@ export const getFileSource = async ({ fileName, repository, branch }: FileSource
     }
 }
 
-export const listRepositories = async (): Promise<ListRepositoriesResponse | ServiceError> => {
+export const listRepositories = async (orgId: number): Promise<ListRepositoriesResponse | ServiceError> => {
     const body = JSON.stringify({
         opts: {
             Field: 0,
         }
     });
+
+    let header: Record<string, string> = {};
+    header = {
+        "X-Tenant-ID": orgId.toString()
+    };
+
     const listResponse = await zoektFetch({
         path: "/api/list",
         body,
+        header,
         method: "POST",
         cache: "no-store",
     });


### PR DESCRIPTION
NOTE: this PR will break non-auth mode since it expects an auth session to exist for search and repoList endpoints!

- Run `yarn dev:mt` to run with tenancy enforced
- This will result in repos being indexed with tenancyId's, and all future searches and repo list calls to only return results for repos owned by the org