### PR TITLE
Generate `AUTH_SECRET` if not provided

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,7 +27,7 @@ if [ ! -d "$DB_DATA_DIR" ]; then
 fi
 
 if [ -z "$SOURCEBOT_ENCRYPTION_KEY" ]; then
-    echo -e "\e[31m[Error] SOURCEBOT_ENCRYPTION_KEY is not set.\e[0m"
+    echo -e "\e[33m[Warning] SOURCEBOT_ENCRYPTION_KEY is not set.\e[0m"
 
     if [ -f "$DATA_CACHE_DIR/.secret" ]; then
         echo -e "\e[34m[Info] Loading environment variables from $DATA_CACHE_DIR/.secret\e[0m"
@@ -39,6 +39,23 @@ if [ -z "$SOURCEBOT_ENCRYPTION_KEY" ]; then
 
     set -a
     . "$DATA_CACHE_DIR/.secret"
+    set +a
+fi
+
+# @see : https://authjs.dev/getting-started/deployment#auth_secret
+if [ -z "$AUTH_SECRET" ]; then
+    echo -e "\e[33m[Warning] AUTH_SECRET is not set.\e[0m"
+
+    if [ -f "$DATA_CACHE_DIR/.authjs-secret" ]; then
+        echo -e "\e[34m[Info] Loading environment variables from $DATA_CACHE_DIR/.authjs-secret\e[0m"
+    else
+        echo -e "\e[34m[Info] Generating a new encryption key...\e[0m"
+        AUTH_SECRET=$(openssl rand -base64 33)
+        echo "AUTH_SECRET=\"$AUTH_SECRET\"" >> "$DATA_CACHE_DIR/.authjs-secret"
+    fi
+
+    set -a
+    . "$DATA_CACHE_DIR/.authjs-secret"
     set +a
 fi
 

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -24,14 +24,18 @@ declare module 'next-auth/jwt' {
 }
 
 const providers: Provider[] = [
-    GitHub({
-        clientId: AUTH_GITHUB_CLIENT_ID,
-        clientSecret: AUTH_GITHUB_CLIENT_SECRET,
-    }),
-    Google({
-        clientId: AUTH_GOOGLE_CLIENT_ID!,
-        clientSecret: AUTH_GOOGLE_CLIENT_SECRET!,
-    })
+    ...(AUTH_GITHUB_CLIENT_ID && AUTH_GITHUB_CLIENT_SECRET ? [
+        GitHub({
+            clientId: AUTH_GITHUB_CLIENT_ID,
+            clientSecret: AUTH_GITHUB_CLIENT_SECRET,
+        }),
+    ] : []),
+    ...(AUTH_GOOGLE_CLIENT_ID && AUTH_GOOGLE_CLIENT_SECRET ? [
+        Google({
+            clientId: AUTH_GOOGLE_CLIENT_ID,
+            clientSecret: AUTH_GOOGLE_CLIENT_SECRET,
+        }),
+    ] : []),
 ];
 
 // @see: https://authjs.dev/guides/pages/signin
@@ -56,6 +60,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
     session: {
         strategy: "jwt",
     },
+    trustHost: true,
     callbacks: {
         async jwt({ token, user: _user }) {
             const user = _user as User | undefined;


### PR DESCRIPTION
This PR:
- Adds a step to the `entrypoint.sh` to generate a token for authjs if one is not provided via `AUTH_SECRET`.
- Adds `trustHost: true` to the auth config s.t., we don't need to pass `AUTH_TRUST_HOST` (see: https://authjs.dev/getting-started/deployment#docker)
- Excludes providers if the necessary client id / secret are not provided.