### PR TITLE
(fix) Environment variable type massaging for numbers

### DIFF
--- a/packages/backend/src/env.ts
+++ b/packages/backend/src/env.ts
@@ -5,6 +5,11 @@ import dotenv from 'dotenv';
 // Booleans are specified as 'true' or 'false' strings.
 const booleanSchema = z.enum(["true", "false"]);
 
+// Numbers are treated as strings in .env files.
+// coerce helps us convert them to numbers.
+// @see: https://zod.dev/?id=coercion-for-primitives
+const numberSchema = z.coerce.number();
+
 dotenv.config({
 	path: './.env',
 });
@@ -28,7 +33,7 @@ export const env = createEnv({
         FALLBACK_GITLAB_TOKEN: z.string().optional(),
         FALLBACK_GITEA_TOKEN: z.string().optional(),
 
-        REDIS_URL: z.string().url(),
+        REDIS_URL: z.string().url().default("redis://localhost:6379"),
 
         SENTRY_BACKEND_DSN: z.string().optional(),
         SENTRY_ENVIRONMENT: z.string().optional(),
@@ -36,8 +41,8 @@ export const env = createEnv({
         LOGTAIL_TOKEN: z.string().optional(),
         LOGTAIL_HOST: z.string().url().optional(),
 
-        INDEX_CONCURRENCY_MULTIPLE: z.number().optional(),
-        DATABASE_URL: z.string().url(),
+        INDEX_CONCURRENCY_MULTIPLE: numberSchema.optional(),
+        DATABASE_URL: z.string().url().default("postgresql://postgres:postgres@localhost:5432/postgres")
     },
     runtimeEnv: process.env,
     emptyStringAsUndefined: true,

--- a/packages/web/src/env.mjs
+++ b/packages/web/src/env.mjs
@@ -4,12 +4,17 @@ import { z } from "zod";
 // Booleans are specified as 'true' or 'false' strings.
 const booleanSchema = z.enum(["true", "false"]);
 
+// Numbers are treated as strings in .env files.
+// coerce helps us convert them to numbers.
+// @see: https://zod.dev/?id=coercion-for-primitives
+const numberSchema = z.coerce.number();
+
 export const env = createEnv({
     server: {
         // Zoekt
-        ZOEKT_WEBSERVER_URL: z.string().url(),
-        SHARD_MAX_MATCH_COUNT: z.number().default(10000),
-        TOTAL_MAX_MATCH_COUNT: z.number().default(100000),
+        ZOEKT_WEBSERVER_URL: z.string().url().default("http://localhost:6070"),
+        SHARD_MAX_MATCH_COUNT: numberSchema.default(10000),
+        TOTAL_MAX_MATCH_COUNT: numberSchema.default(100000),
         
         // Auth
         AUTH_SECRET: z.string(),
@@ -31,7 +36,7 @@ export const env = createEnv({
         STRIPE_ENABLE_TEST_CLOCKS: booleanSchema.default('false'),
 
         // Misc
-        CONFIG_MAX_REPOS_NO_TOKEN: z.number().default(500),
+        CONFIG_MAX_REPOS_NO_TOKEN: numberSchema.default(500),
         SOURCEBOT_ROOT_DOMAIN: z.string().default("localhost:3000"),
         NODE_ENV: z.enum(["development", "test", "production"]),
         SOURCEBOT_TELEMETRY_DISABLED: booleanSchema.default('false'),
@@ -45,7 +50,7 @@ export const env = createEnv({
 
         // Misc
         NEXT_PUBLIC_SOURCEBOT_VERSION: z.string().default('unknown'),
-        NEXT_PUBLIC_POLLING_INTERVAL_MS: z.number().default(5000),
+        NEXT_PUBLIC_POLLING_INTERVAL_MS: numberSchema.default(5000),
     },
     // For Next.js >= 13.4.4, you only need to destructure client variables:
     experimental__runtimeEnv: {


### PR DESCRIPTION
**Problem:** Environment variables are treated as strings, even when they look like numbers (e.g., `MY_VAR=42`, 42 will be of type `string`, not `number`). This creates runtime env var validation errors.

**Solution:** Use [z.coerce](https://zod.dev/?id=coercion-for-primitives) to coerce strings into numbers when we expect them to be.