### PR TITLE
Set correct variable name in docs

### DIFF
--- a/docs/self-hosting/more/tenancy.mdx
+++ b/docs/self-hosting/more/tenancy.mdx
@@ -6,7 +6,7 @@ sidebarTitle: Multi tenancy
 <Warning>If you're switching from single-tenant mode, delete the Sourcebot cache (the `.sourcebot` folder) before starting.</Warning>
 <Warning>[Authentication](/self-hosting/more/authentication) must be enabled to enable multi tenancy mode</Warning>
 Multi tenancy allows your Sourcebot deployment to have **multiple organizations**, each with their own set of members and repos. To enable multi tenancy mode, define an environment variable
-named `SOURCEBOT_AUTH_ENABLED` and set its value to `multi`. When multi tenancy mode is enabled:
+named `SOURCEBOT_TENANCY_MODE` and set its value to `multi`. When multi tenancy mode is enabled:
 
 - Any members or repos that are configured in an organization are isolated to that organization
 - Members must be invited to an organization to gain access 


### PR DESCRIPTION
Tenancy mode is set via SOURCEBOT_TENANCY_MODE, not SOURCEBOT_AUTH_ENABLED

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the multi-tenancy deployment instructions. The environment variable to enable this mode has been renamed from `SOURCEBOT_AUTH_ENABLED` to `SOURCEBOT_TENANCY_MODE`, so please update your configuration accordingly for proper functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->