### PR TITLE
Display name improvements

### DIFF
--- a/.vscode/sourcebot.code-workspace
+++ b/.vscode/sourcebot.code-workspace
@@ -1,0 +1,16 @@
+{
+	"folders": [
+		{
+			"path": ".."
+		},
+		{
+			"path": "../vendor/zoekt"
+		}
+	],
+	"settings": {
+		"files.associations": {
+			"*.json": "jsonc",
+			"index.json": "json"
+		}
+	}
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixes
 - Change connection manager upsert timeout to 5 minutes
+- Fix issue with repo display names being poorly formatted, especially for gerrit. ([#259](https://github.com/sourcebot-dev/sourcebot/pull/259))
 
 ## [3.0.1] - 2025-04-01
 

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -8,6 +8,7 @@ import { WithRequired } from "./types.js"
 import { marshalBool } from "./utils.js";
 import { GerritConnectionConfig, GiteaConnectionConfig, GitlabConnectionConfig } from '@sourcebot/schemas/v3/connection.type';
 import { RepoMetadata } from './types.js';
+import path from 'path';
 
 export type RepoData = WithRequired<Prisma.RepoCreateInput, 'connections'>;
 
@@ -29,10 +30,13 @@ export const compileGithubConfig = async (
     const notFound = gitHubReposResult.notFound;
 
     const hostUrl = config.url ?? 'https://github.com';
-    const hostname = new URL(hostUrl).hostname;
+    const repoNameRoot = new URL(hostUrl)
+        .toString()
+        .replace(/^https?:\/\//, '');
 
     const repos = gitHubRepos.map((repo) => {
-        const repoName = `${hostname}/${repo.full_name}`;
+        const repoDisplayName = repo.full_name;
+        const repoName = path.join(repoNameRoot, repoDisplayName);
         const cloneUrl = new URL(repo.clone_url!);
 
         const record: RepoData = {
@@ -42,6 +46,7 @@ export const compileGithubConfig = async (
             cloneUrl: cloneUrl.toString(),
             webUrl: repo.html_url,
             name: repoName,
+            displayName: repoDisplayName,
             imageUrl: repo.owner.avatar_url,
             isFork: repo.fork,
             isArchived: !!repo.archived,
@@ -67,6 +72,7 @@ export const compileGithubConfig = async (
                     'zoekt.archived': marshalBool(repo.archived),
                     'zoekt.fork': marshalBool(repo.fork),
                     'zoekt.public': marshalBool(repo.private === false),
+                    'zoekt.display-name': repoDisplayName,
                 },
                 branches: config.revisions?.branches ?? undefined,
                 tags: config.revisions?.tags ?? undefined,
@@ -93,13 +99,16 @@ export const compileGitlabConfig = async (
     const notFound = gitlabReposResult.notFound;
 
     const hostUrl = config.url ?? 'https://gitlab.com';
-    const hostname = new URL(hostUrl).hostname;
-    
+    const repoNameRoot = new URL(hostUrl)
+        .toString()
+        .replace(/^https?:\/\//, '');
+
     const repos = gitlabRepos.map((project) => {
         const projectUrl = `${hostUrl}/${project.path_with_namespace}`;
         const cloneUrl = new URL(project.http_url_to_repo);
         const isFork = project.forked_from_project !== undefined;
-        const repoName = `${hostname}/${project.path_with_namespace}`;
+        const repoDisplayName = project.path_with_namespace;
+        const repoName = path.join(repoNameRoot, repoDisplayName);
 
         const record: RepoData = {
             external_id: project.id.toString(),
@@ -108,6 +117,7 @@ export const compileGitlabConfig = async (
             cloneUrl: cloneUrl.toString(),
             webUrl: projectUrl,
             name: repoName,
+            displayName: repoDisplayName,
             imageUrl: project.avatar_url,
             isFork: isFork,
             isArchived: !!project.archived,
@@ -130,7 +140,8 @@ export const compileGitlabConfig = async (
                     'zoekt.gitlab-forks': (project.forks_count ?? 0).toString(),
                     'zoekt.archived': marshalBool(project.archived),
                     'zoekt.fork': marshalBool(isFork),
-                    'zoekt.public': marshalBool(project.private === false)
+                    'zoekt.public': marshalBool(project.private === false),
+                    'zoekt.display-name': repoDisplayName,
                 },
                 branches: config.revisions?.branches ?? undefined,
                 tags: config.revisions?.tags ?? undefined,
@@ -157,11 +168,14 @@ export const compileGiteaConfig = async (
     const notFound = giteaReposResult.notFound;
 
     const hostUrl = config.url ?? 'https://gitea.com';
-    const hostname = new URL(hostUrl).hostname;
+    const repoNameRoot = new URL(hostUrl)
+        .toString()
+        .replace(/^https?:\/\//, '');
 
     const repos = giteaRepos.map((repo) => {
         const cloneUrl = new URL(repo.clone_url!);
-        const repoName = `${hostname}/${repo.full_name!}`;
+        const repoDisplayName = repo.full_name!;
+        const repoName = path.join(repoNameRoot, repoDisplayName);
 
         const record: RepoData = {
             external_id: repo.id!.toString(),
@@ -170,6 +184,7 @@ export const compileGiteaConfig = async (
             cloneUrl: cloneUrl.toString(),
             webUrl: repo.html_url,
             name: repoName,
+            displayName: repoDisplayName,
             imageUrl: repo.owner?.avatar_url,
             isFork: repo.fork!,
             isArchived: !!repo.archived,
@@ -191,6 +206,7 @@ export const compileGiteaConfig = async (
                     'zoekt.archived': marshalBool(repo.archived),
                     'zoekt.fork': marshalBool(repo.fork!),
                     'zoekt.public': marshalBool(repo.internal === false && repo.private === false),
+                    'zoekt.display-name': repoDisplayName,
                 },
                 branches: config.revisions?.branches ?? undefined,
                 tags: config.revisions?.tags ?? undefined,
@@ -212,27 +228,32 @@ export const compileGerritConfig = async (
     orgId: number) => {
 
     const gerritRepos = await getGerritReposFromConfig(config);
-    const hostUrl = (config.url ?? 'https://gerritcodereview.com').replace(/\/$/, ''); // Remove trailing slash
-    const hostname = new URL(hostUrl).hostname;
+    const hostUrl = config.url;
+    const repoNameRoot = new URL(hostUrl)
+        .toString()
+        .replace(/^https?:\/\//, '');
 
     const repos = gerritRepos.map((project) => {
-        const repoId = `${hostname}/${project.name}`;
-        const cloneUrl = new URL(`${config.url}/${encodeURIComponent(project.name)}`);
+        const cloneUrl = new URL(path.join(hostUrl, encodeURIComponent(project.name)));
+        const repoDisplayName = project.name;
+        const repoName = path.join(repoNameRoot, repoDisplayName);
 
-        let webUrl = "https://www.gerritcodereview.com/";
-        // Gerrit projects can have multiple web links; use the first one
-        if (project.web_links) {
-            const webLink = project.web_links[0];
-            if (webLink) {
-                webUrl = webLink.url;
+        const webUrl = (() => {
+            if (!project.web_links || project.web_links.length === 0) {
+                return null;
             }
-        }
 
-        // Handle case where webUrl is just a gitiles path
-        // https://github.com/GerritCodeReview/plugins_gitiles/blob/5ee7f57/src/main/java/com/googlesource/gerrit/plugins/gitiles/GitilesWeblinks.java#L50
-        if (webUrl.startsWith('/plugins/gitiles/')) {
-            webUrl = `${hostUrl}${webUrl}`;
-        }
+            const webLink = project.web_links[0];
+            const webUrl = webLink.url;
+
+            // Handle case where webUrl is just a gitiles path
+            // https://github.com/GerritCodeReview/plugins_gitiles/blob/5ee7f57/src/main/java/com/googlesource/gerrit/plugins/gitiles/GitilesWeblinks.java#L50
+            if (webUrl.startsWith('/plugins/gitiles/')) {
+                return `${hostUrl}${webUrl}`;
+            } else {
+                return webUrl;
+            }
+        })();
 
         const record: RepoData = {
             external_id: project.id.toString(),
@@ -240,7 +261,8 @@ export const compileGerritConfig = async (
             external_codeHostUrl: hostUrl,
             cloneUrl: cloneUrl.toString(),
             webUrl: webUrl,
-            name: project.name,
+            name: repoName,
+            displayName: repoDisplayName,
             isFork: false,
             isArchived: false,
             org: {
@@ -256,11 +278,12 @@ export const compileGerritConfig = async (
             metadata: {
                 gitConfig: {
                     'zoekt.web-url-type': 'gitiles',
-                    'zoekt.web-url': webUrl,
-                    'zoekt.name': repoId,
+                    'zoekt.web-url': webUrl ?? '',
+                    'zoekt.name': repoName,
                     'zoekt.archived': marshalBool(false),
                     'zoekt.fork': marshalBool(false),
                     'zoekt.public': marshalBool(true),
+                    'zoekt.display-name': repoDisplayName,
                 },
             } satisfies RepoMetadata,
         };

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -249,7 +249,7 @@ export const compileGerritConfig = async (
             // Handle case where webUrl is just a gitiles path
             // https://github.com/GerritCodeReview/plugins_gitiles/blob/5ee7f57/src/main/java/com/googlesource/gerrit/plugins/gitiles/GitilesWeblinks.java#L50
             if (webUrl.startsWith('/plugins/gitiles/')) {
-                return `${hostUrl}${webUrl}`;
+                return path.join(hostUrl, webUrl);
             } else {
                 return webUrl;
             }

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -3,7 +3,7 @@ import { Redis } from 'ioredis';
 import { createLogger } from "./logger.js";
 import { Connection, PrismaClient, Repo, RepoToConnection, RepoIndexingStatus, StripeSubscriptionStatus } from "@sourcebot/db";
 import { GithubConnectionConfig, GitlabConnectionConfig, GiteaConnectionConfig } from '@sourcebot/schemas/v3/connection.type';
-import { AppContext, Settings, RepoMetadata } from "./types.js";
+import { AppContext, Settings, repoMetadataSchema } from "./types.js";
 import { getRepoPath, getTokenFromConfig, measure, getShardPrefix } from "./utils.js";
 import { cloneRepository, fetchRepository, upsertGitConfig } from "./git.js";
 import { existsSync, readdirSync, promises } from 'fs';
@@ -200,8 +200,7 @@ export class RepoManager implements IRepoManager {
         let cloneDuration_s: number | undefined = undefined;
 
         const repoPath = getRepoPath(repo, this.ctx);
-        const metadata = repo.metadata as RepoMetadata;
-
+        const metadata = repoMetadataSchema.parse(repo.metadata);
         
         // If the repo was already in the indexing state, this job was likely killed and picked up again. As a result,
         // to ensure the repo state is valid, we delete the repo if it exists so we get a fresh clone 

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -1,4 +1,5 @@
 import { Settings as SettingsSchema } from "@sourcebot/schemas/v3/index.type";
+import { z } from "zod";
 
 export type AppContext = {
     /**
@@ -16,28 +17,32 @@ export type AppContext = {
 
 export type Settings = Required<SettingsSchema>;
 
-/**
- * Structure of the `metadata` field in the `Repo` table.
- */
-export type RepoMetadata = {
+// Structure of the `metadata` field in the `Repo` table.
+//
+// @WARNING: If you modify this schema, please make sure it is backwards
+// compatible with any prior versions of the schema!!
+// @NOTE: If you move this schema, please update the comment in schema.prisma
+// to point to the new location.
+export const repoMetadataSchema = z.object({
     /**
      * A set of key-value pairs that will be used as git config
      * variables when cloning the repo.
      * @see: https://git-scm.com/docs/git-clone#Documentation/git-clone.txt-code--configcodecodeltkeygtltvaluegtcode
      */
-    gitConfig?: Record<string, string>;
+    gitConfig: z.record(z.string(), z.string()).optional(),
 
     /**
      * A list of branches to index. Glob patterns are supported.
      */
-    branches?: string[];
+    branches: z.array(z.string()).optional(),
 
     /**
      * A list of tags to index. Glob patterns are supported.
      */
-    tags?: string[];
-}
+    tags: z.array(z.string()).optional(),
+});
 
+export type RepoMetadata = z.infer<typeof repoMetadataSchema>;
 
 // @see : https://stackoverflow.com/a/61132308
 export type DeepPartial<T> = T extends object ? {

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -1,5 +1,5 @@
 import { exec } from "child_process";
-import { AppContext, RepoMetadata, Settings } from "./types.js";
+import { AppContext, repoMetadataSchema, Settings } from "./types.js";
 import { Repo } from "@sourcebot/db";
 import { getRepoPath } from "./utils.js";
 import { getShardPrefix } from "./utils.js";
@@ -17,7 +17,7 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, ctx: Ap
 
     const repoPath = getRepoPath(repo, ctx);
     const shardPrefix = getShardPrefix(repo.orgId, repo.id);
-    const metadata = repo.metadata as RepoMetadata;
+    const metadata = repoMetadataSchema.parse(repo.metadata);
 
     if (metadata.branches) {
         const branchGlobs = metadata.branches

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -57,7 +57,17 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, ctx: Ap
         revisions = revisions.slice(0, 64);
     }
     
-    const command = `zoekt-git-index -allow_missing_branches -index ${ctx.indexPath} -max_trigram_count ${settings.maxTrigramCount} -file_limit ${settings.maxFileSize} -branches ${revisions.join(',')} -tenant_id ${repo.orgId} -shard_prefix ${shardPrefix} ${repoPath}`;
+    const command = [
+        'zoekt-git-index',
+        '-allow_missing_branches',
+        `-index ${ctx.indexPath}`,
+        `-max_trigram_count ${settings.maxTrigramCount}`,
+        `-file_limit ${settings.maxFileSize}`,
+        `-branches ${revisions.join(',')}`,
+        `-tenant_id ${repo.orgId}`,
+        `-shard_prefix ${shardPrefix}`,
+        repoPath
+    ].join(' ');
 
     return new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
         exec(command, (error, stdout, stderr) => {

--- a/packages/db/prisma/migrations/20250402232401_add_display_name_to_repo/migration.sql
+++ b/packages/db/prisma/migrations/20250402232401_add_display_name_to_repo/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Repo" ADD COLUMN     "displayName" TEXT;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -43,7 +43,7 @@ model Repo {
   indexedAt          DateTime?
   isFork             Boolean
   isArchived         Boolean
-  metadata           Json
+  metadata           Json // For schema see repoMetadataSchema in packages/backend/src/types.ts
   cloneUrl           String
   webUrl             String?
   connections        RepoToConnection[]

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -38,6 +38,7 @@ enum StripeSubscriptionStatus {
 model Repo {
   id                 Int                @id @default(autoincrement())
   name               String
+  displayName        String?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
   indexedAt          DateTime?

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -429,6 +429,7 @@ export const getRepos = async (domain: string, filter: { status?: RepoIndexingSt
                 codeHostType: repo.external_codeHostType,
                 repoId: repo.id,
                 repoName: repo.name,
+                repoDisplayName: repo.displayName ?? undefined,
                 repoCloneUrl: repo.cloneUrl,
                 webUrl: repo.webUrl ?? undefined,
                 linkedConnections: repo.connections.map(({ connection }) => ({

--- a/packages/web/src/app/[domain]/components/repositoryCarousel.tsx
+++ b/packages/web/src/app/[domain]/components/repositoryCarousel.tsx
@@ -73,7 +73,7 @@ const RepositoryBadge = ({
 
         return {
             repoIcon: <FileIcon className="w-4 h-4" />,
-            displayName: repo.repoName.split('/').slice(-2).join('/'),
+            displayName: repo.repoName,
             repoLink: undefined,
         }
     })();

--- a/packages/web/src/app/[domain]/repos/repositoryTable.tsx
+++ b/packages/web/src/app/[domain]/repos/repositoryTable.tsx
@@ -39,7 +39,7 @@ export const RepositoryTable = ({ isAddNewRepoButtonVisible }: RepositoryTablePr
 
         if (!repos) return [];
         return repos.map((repo): RepositoryColumnInfo => ({
-            name: repo.repoName.split('/').length > 2 ? repo.repoName.split('/').slice(-2).join('/') : repo.repoName,
+            name: repo.repoDisplayName ?? repo.repoName,
             imageUrl: repo.imageUrl,
             connections: repo.linkedConnections,
             repoIndexingStatus: repo.repoIndexingStatus as RepoIndexingStatus,

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -168,6 +168,7 @@ export const repositoryQuerySchema = z.object({
     codeHostType: z.string(),
     repoId: z.number(),
     repoName: z.string(),
+    repoDisplayName: z.string().optional(),
     repoCloneUrl: z.string(),
     webUrl: z.string().optional(),
     linkedConnections: z.array(z.object({

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -47,22 +47,19 @@ export const getRepoCodeHostInfo = (repo?: Repository): CodeHostInfo | undefined
         return undefined;
     }
 
-    const webUrlType = repo.RawConfig ? repo.RawConfig['web-url-type'] : undefined;
-    if (!webUrlType) {
+    if (!repo.RawConfig) {
         return undefined;
     }
 
-    const url = new URL(repo.URL);
-    const displayName = url.pathname.slice(1);
+    // @todo : use zod to validate config schema
+    const webUrlType = repo.RawConfig['web-url-type']!;
+    const displayName = repo.RawConfig['display-name'] ?? repo.RawConfig['name']!;
+
     return _getCodeHostInfoInternal(webUrlType, displayName, repo.URL);
 }
 
-export const getRepoQueryCodeHostInfo = (repo?: RepositoryQuery): CodeHostInfo | undefined => {
-    if (!repo) {
-        return undefined;
-    }
-
-    const displayName = repo.repoName.split('/').slice(-2).join('/');
+export const getRepoQueryCodeHostInfo = (repo: RepositoryQuery): CodeHostInfo | undefined => {
+    const displayName = repo.repoDisplayName ?? repo.repoName;
     return _getCodeHostInfoInternal(repo.codeHostType, displayName, repo.webUrl ?? repo.repoCloneUrl);
 }
 


### PR DESCRIPTION
This PR does the following:
- Adds an optional `displayName` field to the Repos table. This field differs to `name` in that it does not include the `hostUrl` as a prefix, and thus is shorter & easier to read. The displayName is also passed along to zoekt via `zoekt.display-name`. This field replaces needing to create a display name client side.
- Altered the behaviour in `RepoManager::syncGitRepository` to always "upsert" the repo's `metadata.gitConfig` regardless of clone or fetch (previously it only happened on fetch). This makes it s.t., the data in the database (`metadata.gitConfig`) is **eventually consistent** with the git config on the repo. This is essential for when we add new fields (like `zoekt.display-name` in this case).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved formatting issues for repository names (notably for Gerrit), resulting in clearer and more consistent display in the interface.

- **New Features**
  - Standardized repository naming across the platform, enabling full names to be displayed reliably in listings and carousels with a dedicated display label for improved user clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->