### PR TITLE
Add periodic connection re-sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Change connection manager upsert timeout to 5 minutes
 - Fix issue with repo display names being poorly formatted, especially for gerrit. ([#259](https://github.com/sourcebot-dev/sourcebot/pull/259))
 
+### Added
+- Added config setting `resyncConnectionIntervalMs` to control how often a connection should be re-synced. ([#260](https://github.com/sourcebot-dev/sourcebot/pull/260))
+
 ## [3.0.1] - 2025-04-01
 
 ### Fixes

--- a/docs/self-hosting/more/declarative-config.mdx
+++ b/docs/self-hosting/more/declarative-config.mdx
@@ -55,6 +55,11 @@ Some teams require Sourcebot to be configured via a file (where it can be stored
           "description": "The interval (in milliseconds) at which the indexer should re-index all repositories. Defaults to 1 hour.",
           "minimum": 1
         },
+        "resyncConnectionIntervalMs": {
+          "type": "number",
+          "description": "The interval (in milliseconds) at which the connection manager should check for connections that need to be re-synced. Defaults to 24 hours.",
+          "minimum": 1
+        },
         "resyncConnectionPollingIntervalMs": {
           "type": "number",
           "description": "The polling rate (in milliseconds) at which the db should be checked for connections that need to be re-synced. Defaults to 1 second.",

--- a/packages/backend/src/constants.ts
+++ b/packages/backend/src/constants.ts
@@ -7,6 +7,7 @@ export const DEFAULT_SETTINGS: Settings = {
     maxFileSize: 2 * 1024 * 1024, // 2MB in bytes
     maxTrigramCount: 20000,
     reindexIntervalMs: 1000 * 60 * 60, // 1 hour
+    resyncConnectionIntervalMs: 1000 * 60 * 60 * 24, // 24 hours
     resyncConnectionPollingIntervalMs: 1000 * 1, // 1 second
     reindexRepoPollingIntervalMs: 1000 * 1, // 1 second
     maxConnectionSyncJobConcurrency: 8,

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -23,6 +23,11 @@ const schema = {
           "description": "The interval (in milliseconds) at which the indexer should re-index all repositories. Defaults to 1 hour.",
           "minimum": 1
         },
+        "resyncConnectionIntervalMs": {
+          "type": "number",
+          "description": "The interval (in milliseconds) at which the connection manager should check for connections that need to be re-synced. Defaults to 24 hours.",
+          "minimum": 1
+        },
         "resyncConnectionPollingIntervalMs": {
           "type": "number",
           "description": "The polling rate (in milliseconds) at which the db should be checked for connections that need to be re-synced. Defaults to 1 second.",

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -40,6 +40,10 @@ export interface Settings {
    */
   reindexIntervalMs?: number;
   /**
+   * The interval (in milliseconds) at which the connection manager should check for connections that need to be re-synced. Defaults to 24 hours.
+   */
+  resyncConnectionIntervalMs?: number;
+  /**
    * The polling rate (in milliseconds) at which the db should be checked for connections that need to be re-synced. Defaults to 1 second.
    */
   resyncConnectionPollingIntervalMs?: number;

--- a/schemas/v3/index.json
+++ b/schemas/v3/index.json
@@ -23,6 +23,11 @@
                     "description": "The interval (in milliseconds) at which the indexer should re-index all repositories. Defaults to 1 hour.",
                     "minimum": 1
                 },
+                "resyncConnectionIntervalMs": {
+                    "type": "number",
+                    "description": "The interval (in milliseconds) at which the connection manager should check for connections that need to be re-synced. Defaults to 24 hours.",
+                    "minimum": 1
+                },
                 "resyncConnectionPollingIntervalMs": {
                     "type": "number",
                     "description": "The polling rate (in milliseconds) at which the db should be checked for connections that need to be re-synced. Defaults to 1 second.",


### PR DESCRIPTION
This PR adds the `resyncConnectionIntervalMs` to control how often a given connection should be re-synced.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a new configuration setting, `resyncConnectionIntervalMs`, which specifies the frequency at which connections should be re-synced, defaulting to 24 hours. This enhancement allows for more efficient management of connection synchronization.
  
- **Documentation**
  - Updated documentation to include details about the new `resyncConnectionIntervalMs` property in the JSON schema and other relevant sections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->