### PR TITLE
Embed filter selection in query params

### DIFF
--- a/packages/web/src/app/[domain]/search/page.tsx
+++ b/packages/web/src/app/[domain]/search/page.tsx
@@ -47,7 +47,7 @@ const SearchPageInternal = () => {
     const domain = useDomain();
     const { toast } = useToast();
 
-    const { data: searchResponse, isLoading, error } = useQuery({
+    const { data: searchResponse, isLoading: isSearchLoading, error } = useQuery({
         queryKey: ["search", searchQuery, maxMatchDisplayCount],
         queryFn: () => measure(() => unwrapServiceError(search({
             query: searchQuery,
@@ -91,7 +91,7 @@ const SearchPageInternal = () => {
     // repository metadata (like host type, repo name, etc.)
     // Convert this into a map of repo name to repo metadata
     // for easy lookup.
-    const { data: repoMetadata } = useQuery({
+    const { data: repoMetadata, isLoading: isRepoMetadataLoading } = useQuery({
         queryKey: ["repos"],
         queryFn: () => getRepos(domain),
         select: (data): Record<string, Repository> =>
@@ -194,7 +194,7 @@ const SearchPageInternal = () => {
                 <Separator />
             </div>
 
-            {isLoading ? (
+            {(isSearchLoading || isRepoMetadataLoading) ? (
                 <div className="flex flex-col items-center justify-center h-full gap-2">
                     <SymbolIcon className="h-6 w-6 animate-spin" />
                     <p className="font-semibold text-center">Searching...</p>

--- a/packages/web/src/hooks/useNonEmptyQueryParam.ts
+++ b/packages/web/src/hooks/useNonEmptyQueryParam.ts
@@ -17,11 +17,11 @@ import { useMemo } from "react";
  */
 export const useNonEmptyQueryParam = (param: string) => {
     const searchParams = useSearchParams();
-    const inviteId = useMemo(() => {
+    const paramValue = useMemo(() => {
         return getSearchParam(param, searchParams);
     }, [param, searchParams]);
 
-    return inviteId;
+    return paramValue;
 };
 
 /**


### PR DESCRIPTION
This PR changes the filter panel to embed the filter selection into query parameters to make it easier to share search results. For example:

<img width="297" alt="image" src="https://github.com/user-attachments/assets/34291c8b-e69e-4777-a3a8-4f45cba5b3c7" />

`http://localhost:3000/~/search?query=hello&repos=github.com%2Fsourcebot-dev%2Fsourcebot&langs=JSON%2CTSX`

#166 