### PR TITLE
Add `exclude.readOnly` and `exclude.hidden` to gerrit connection config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `exclude.readOnly` and `exclude.hidden` options to Gerrit connection config. [#280](https://github.com/sourcebot-dev/sourcebot/pull/280)
+
 ## [3.1.1] - 2025-04-28
 
 ### Changed

--- a/docs/docs/connections/gerrit.mdx
+++ b/docs/docs/connections/gerrit.mdx
@@ -51,7 +51,13 @@ To connect to a gerrit instance, provide the `url` property to your config:
                 "projects": [
                     "project1/foo-project",
                     "project2/sub-project/some-sub-folder/**"
-                ]
+                ],
+
+                // projects that have state READ_ONLY
+                "readOnly": true,
+
+                // projects that have state HIDDEN
+                "hidden": true
             }
         }
         ```
@@ -110,6 +116,16 @@ To connect to a gerrit instance, provide the `url` property to your config:
             ]
           ],
           "description": "List of specific projects to exclude from syncing."
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude read-only projects from syncing."
+        },
+        "hidden": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude hidden projects from syncing."
         }
       },
       "additionalProperties": false

--- a/packages/schemas/src/v3/connection.schema.ts
+++ b/packages/schemas/src/v3/connection.schema.ts
@@ -494,6 +494,16 @@ const schema = {
                 ]
               ],
               "description": "List of specific projects to exclude from syncing."
+            },
+            "readOnly": {
+              "type": "boolean",
+              "default": false,
+              "description": "Exclude read-only projects from syncing."
+            },
+            "hidden": {
+              "type": "boolean",
+              "default": false,
+              "description": "Exclude hidden projects from syncing."
             }
           },
           "additionalProperties": false

--- a/packages/schemas/src/v3/connection.type.ts
+++ b/packages/schemas/src/v3/connection.type.ts
@@ -234,6 +234,14 @@ export interface GerritConnectionConfig {
      * List of specific projects to exclude from syncing.
      */
     projects?: string[];
+    /**
+     * Exclude read-only projects from syncing.
+     */
+    readOnly?: boolean;
+    /**
+     * Exclude hidden projects from syncing.
+     */
+    hidden?: boolean;
   };
 }
 export interface BitbucketConnectionConfig {

--- a/packages/schemas/src/v3/gerrit.schema.ts
+++ b/packages/schemas/src/v3/gerrit.schema.ts
@@ -45,6 +45,16 @@ const schema = {
             ]
           ],
           "description": "List of specific projects to exclude from syncing."
+        },
+        "readOnly": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude read-only projects from syncing."
+        },
+        "hidden": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude hidden projects from syncing."
         }
       },
       "additionalProperties": false

--- a/packages/schemas/src/v3/gerrit.type.ts
+++ b/packages/schemas/src/v3/gerrit.type.ts
@@ -18,5 +18,13 @@ export interface GerritConnectionConfig {
      * List of specific projects to exclude from syncing.
      */
     projects?: string[];
+    /**
+     * Exclude read-only projects from syncing.
+     */
+    readOnly?: boolean;
+    /**
+     * Exclude hidden projects from syncing.
+     */
+    hidden?: boolean;
   };
 }

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -623,6 +623,16 @@ const schema = {
                         ]
                       ],
                       "description": "List of specific projects to exclude from syncing."
+                    },
+                    "readOnly": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Exclude read-only projects from syncing."
+                    },
+                    "hidden": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Exclude hidden projects from syncing."
                     }
                   },
                   "additionalProperties": false

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -329,6 +329,14 @@ export interface GerritConnectionConfig {
      * List of specific projects to exclude from syncing.
      */
     projects?: string[];
+    /**
+     * Exclude read-only projects from syncing.
+     */
+    readOnly?: boolean;
+    /**
+     * Exclude hidden projects from syncing.
+     */
+    hidden?: boolean;
   };
 }
 export interface BitbucketConnectionConfig {

--- a/schemas/v3/gerrit.json
+++ b/schemas/v3/gerrit.json
@@ -44,6 +44,16 @@
                         ]
                     ],
                     "description": "List of specific projects to exclude from syncing."
+                },
+                "readOnly": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Exclude read-only projects from syncing."
+                },
+                "hidden": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Exclude hidden projects from syncing."
                 }
             },
             "additionalProperties": false


### PR DESCRIPTION
^ Title ^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Added options to exclude read-only and hidden projects from Gerrit syncing via configuration settings.
- **Bug Fixes**
	- Improved filtering logic to more accurately exclude special, read-only, and hidden projects based on configuration.
- **Documentation**
	- Updated configuration schema documentation to describe new exclusion options for read-only and hidden projects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->