### PR TITLE
feat: add `rev:*` syntax to explicitly search all branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added special `*` value for `rev:` to allow searching across all branches. [#281](https://github.com/sourcebot-dev/sourcebot/pull/281)
+
 ## [3.1.2] - 2025-04-30
 
 ### Added

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -29,19 +29,25 @@
                         "group": "Connecting your code",
                         "pages": [
                             "docs/connections/overview",
-                            "docs/connections/github",
-                            "docs/connections/gitlab",
-                            "docs/connections/bitbucket-cloud",
-                            "docs/connections/bitbucket-data-center",
-                            "docs/connections/gitea",
-                            "docs/connections/gerrit",
-                            "docs/connections/request-new"
+                            {
+                                "group": "Supported platforms",
+                                "pages": [
+                                    "docs/connections/github",
+                                    "docs/connections/gitlab",
+                                    "docs/connections/bitbucket-cloud",
+                                    "docs/connections/bitbucket-data-center",
+                                    "docs/connections/gitea",
+                                    "docs/connections/gerrit",
+                                    "docs/connections/request-new"
+                                ]
+                            }
                         ]
                     },
                     {
                         "group": "More",
                         "pages": [
                             "docs/more/syntax-reference",
+                            "docs/more/multi-branch-indexing",
                             "docs/more/roles-and-permissions"
                         ]
                     }

--- a/docs/docs/more/multi-branch-indexing.mdx
+++ b/docs/docs/more/multi-branch-indexing.mdx
@@ -59,7 +59,25 @@ For each repo defined in the connection, any branches or tags matching the patte
 
 ## Search syntax
 
-todo
+To search branches other than the default, the `rev:` prefix can be used followed by the branch (or tag) name:
+
+| Example | Explanation |
+| :--- | :--- |
+| `rev:feature/foo repo:A useEffect` | Search for `/useEffect/` on branch `feature/foo` in repo `A` |
+| `rev:feature/foo useEffect ` | Search for `/useEffect/` on branch `feature/foo` across all repos |
+| `rev:feature/ useEffect` | Search for `/useEffect/` on branches that contain `feature/` across all repos |
+| `rev:feature/a rev:feature/b foo` | Search for `/foo/` on branches `feature/a` and `feature/b` |
+| `rev:feature/ -rev:feature/a foo` | Search for `/foo/` on branches that contain `feature/` _except_ for `feature/a` across all repos |
+
+To search across **all** branches, `rev:*`:
+| Example | Explanation |
+| :--- | :--- |
+| `rev:* repo:A "error message"` | Search for `/error message/` across **all** branches in repo `A` |
+| `rev:* "error message"` | Search for `/error message/` across **all** branches and **all** repos |
+
+Additional info:
+- `refs/heads/` or `refs/tags/` can be included to fully qualify a branch or a tag, respectively. E.g., `rev:refs/heads/foo` will search the branch `foo`, while `rev:refs/tags/foo` will search the tag `foo`.
+- `rev:` does **not** support regular expressions or glob patterns. It uses a simple `contains` call between the branch name and the pattern. See [here](https://github.com/sourcebot-dev/zoekt/blob/7d1896215eea6f97af66c9549c9ec70436356b51/matchtree.go#L1067).
 
 
 ## Platform support

--- a/docs/docs/more/multi-branch-indexing.mdx
+++ b/docs/docs/more/multi-branch-indexing.mdx
@@ -1,0 +1,75 @@
+---
+title: Searching multiple branches and tags
+sidebarTitle: Searching multiple branches
+---
+
+By default, only the default branch of a repository is indexed and can be searched. Sourcebot can be configured to index additional branches (or tags) enabling multi-branch search. This is useful for scenarios such as:
+
+- Searching across different releases
+- Searching through feature branches during development
+- Tracking changes across multiple maintenance branches simultaneously
+
+## Configuration
+
+<Warning>
+Multi-branch indexing is currently limited to 64 branches and tags. If this limitation impacts your use-case, please [open a discussion](https://github.com/sourcebot-dev/sourcebot/discussions/categories/support).
+</Warning>
+
+Multi-branch indexing is configured on in the [connection](/docs/connections/overview) using the `revisions.branches` and `revisions.tags` arrays. Glob patterns are supported. For example:
+
+```json
+{
+    "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/v3/index.json",
+    "connections": {
+        "my-connection": {
+            "type": "github",
+            // For each of the repositories defined in this connection...
+            "repos": [
+                "org/repo1",
+                "org/repo2"
+            ],
+            // ... index the default branch, as well as...
+            "revisions": {
+                // These branches (if they exist):
+                "branches": [
+                    // Exact matches
+                    "dev",
+                    "staging",
+
+                    // Glob patterns
+                    "feature/*" // Matches: feature/auth, feature/ui, etc.
+                ],
+                
+                // These tags (if they exist):
+                "tags": [
+                    // Exact matches
+                    "v4.0.0-dev",
+                    
+                    // Glob patterns
+                    "v3.*.*", // Matches: v3.0.0, v3.0.1, etc.
+                    "rc-*"    // Matches: rc-1, rc-2, etc.
+                ]
+            }
+        }
+    }
+}
+```
+
+For each repo defined in the connection, any branches or tags matching the patterns in `branches` and `tags` array will be indexed.
+
+## Search syntax
+
+todo
+
+
+## Platform support
+
+| Platform | Multi-branch indexing support |
+|:----------|------------------------------|
+| GitHub | ✅ |
+| GitLab | ✅ |
+| Bitbucket Cloud | ✅ |
+| Bitbucket Data Center | ✅ |
+| Gitea | ✅ |
+| Gerrit | ❌ |
+

--- a/packages/web/src/lib/server/searchService.ts
+++ b/packages/web/src/lib/server/searchService.ts
@@ -41,7 +41,14 @@ const transformZoektQuery = async (query: string, orgId: number): Promise<string
         // Handle mapping `rev:` and `revision:` to `branch:`
         if (part.match(/^-?(rev|revision):.+$/)) {
             const isNegated = part.startsWith("-");
-            const revisionName = part.slice(part.indexOf(":") + 1);
+            let revisionName = part.slice(part.indexOf(":") + 1);
+
+            // Special case: `*` -> search all revisions.
+            // In zoekt, providing a blank string will match all branches.
+            // @see: https://github.com/sourcebot-dev/zoekt/blob/main/eval.go#L560-L562
+            if (revisionName === "*") {
+                revisionName = "";
+            }
             newQueryParts.push(`${isNegated ? "-" : ""}${zoektPrefixes.branch}${revisionName}`);
         }
 


### PR DESCRIPTION
This PR makes it s.t., using `rev:*` searches _all_ revisions that are indexed for a given repository.

Fixes #120 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enabled wildcard searches across all branches using the revision query prefix with an asterisk (*), allowing users to search across all revisions.
  - Added documentation on multi-branch and tag searching, including configuration and search syntax guidance.
  - Updated documentation navigation with a new "Supported platforms" subgroup and a page on multi-branch indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->