### PR TITLE
fix: Fix repo carousel thrashing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixes bug with repos not being visible in the homepage carousel when re-indexing. [#294](https://github.com/sourcebot-dev/sourcebot/pull/294)
+
 ### Added
 - Added special `*` value for `rev:` to allow searching across all branches. [#281](https://github.com/sourcebot-dev/sourcebot/pull/281)
 

--- a/packages/web/src/app/[domain]/components/repositorySnapshot.tsx
+++ b/packages/web/src/app/[domain]/components/repositorySnapshot.tsx
@@ -29,10 +29,10 @@ export function RepositorySnapshot({
     const domain = useDomain();
 
     const { data: repos, isPending, isError } = useQuery({
-        queryKey: ['repos', initialRepos, domain],
+        queryKey: ['repos', domain],
         queryFn: () => unwrapServiceError(getRepos(domain)),
         refetchInterval: env.NEXT_PUBLIC_POLLING_INTERVAL_MS,
-        initialData: initialRepos,
+        placeholderData: initialRepos,
     });
 
     if (isPending || isError || !repos) {

--- a/packages/web/src/app/[domain]/page.tsx
+++ b/packages/web/src/app/[domain]/page.tsx
@@ -10,12 +10,16 @@ import { SourcebotLogo } from "../components/sourcebotLogo";
 import { RepositorySnapshot } from "./components/repositorySnapshot";
 import { SyntaxReferenceGuideHint } from "./components/syntaxReferenceGuideHint";
 import { env } from '@/env.mjs';
+import { getRepos } from "@/actions";
+import { isServiceError } from "@/lib/utils";
 
 export default async function Home({ params: { domain } }: { params: { domain: string } }) {
     const org = await getOrgFromDomain(domain);
     if (!org) {
         return <PageNotFound />
     }
+
+    const repos = await getRepos(domain);
 
     return (
         <div className="flex flex-col items-center overflow-hidden min-h-screen">
@@ -34,7 +38,10 @@ export default async function Home({ params: { domain } }: { params: { domain: s
                     className="mt-4 w-full max-w-[800px]"
                 />
                 <div className="mt-8">
-                    <RepositorySnapshot authEnabled={env.SOURCEBOT_AUTH_ENABLED === 'true'} />
+                    <RepositorySnapshot
+                        authEnabled={env.SOURCEBOT_AUTH_ENABLED === 'true'}
+                        repos={isServiceError(repos) ? [] : repos}
+                    />
                 </div>
                 <div className="flex flex-col items-center w-fit gap-6">
                     <Separator className="mt-5" />


### PR DESCRIPTION
This PR fixes repo carousel thrashing by showing repos that have **ever** had a zoekt index (using `indexedAt !== undefined`) instead of relying on the current repo indexing status. It also adds hydration server side s.t., the skeleton does not appear on first page load.

Fixes #293 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Improved repository snapshot display by refining which repositories are shown as indexed.
  - Enhanced initial loading experience with more accurate loading and empty states for repositories.

- **Bug Fixes**
  - Added error handling to prevent service errors from affecting repository lists.
  - Fixed issue where repositories were not visible in the homepage carousel after re-indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->