### PR TITLE
fix: Fixed issue with repositories appearing in the carousel when indexing fails on first sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue with repos appearing in the carousel when they fail indexing for the first time. [#305](https://github.com/sourcebot-dev/sourcebot/pull/305)
+
 ## [3.1.4] - 2025-05-10
 
 ### Fixed

--- a/packages/backend/src/connectionManager.ts
+++ b/packages/backend/src/connectionManager.ts
@@ -334,7 +334,6 @@ export class ConnectionManager implements IConnectionManager {
                 },
                 data: {
                     syncStatus: ConnectionSyncStatus.FAILED,
-                    syncedAt: new Date(),
                     syncStatusMetadata: syncStatusMetadata as Prisma.InputJsonValue,
                 }
             });

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -392,7 +392,6 @@ export class RepoManager implements IRepoManager {
                 },
                 data: {
                     repoIndexingStatus: RepoIndexingStatus.FAILED,
-                    indexedAt: new Date(),
                 }
             })
         }

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -41,6 +41,7 @@ model Repo {
   displayName        String?
   createdAt          DateTime           @default(now())
   updatedAt          DateTime           @updatedAt
+  /// When the repo was last indexed successfully.
   indexedAt          DateTime?
   isFork             Boolean
   isArchived         Boolean
@@ -86,6 +87,7 @@ model Connection {
   isDeclarative      Boolean              @default(false)
   createdAt          DateTime             @default(now())
   updatedAt          DateTime             @updatedAt
+  /// When the connection was last synced successfully.
   syncedAt           DateTime?
   repos              RepoToConnection[]
   syncStatus         ConnectionSyncStatus @default(SYNC_NEEDED)


### PR DESCRIPTION
**Problem**: If a repository fails to index on the **first** sync, it will appear in the repository carousel, even if the repo doesn't have any shards associated with it:

<img width="1832" alt="image" src="https://github.com/user-attachments/assets/0a140715-1db5-42d8-b4da-eb56ecfff06f" />

**Solution**: I've changed the behaviour of repoManager to **not** set the `indexedAt` field on index job failure. Functionally, this changes the behaviour from:
> last time a indexing job completed in either a success or failure state.

To: 
> late time this repository was successfully indexed

IMO the new behaviour is more expected for the name we are using. To keep things consistent, I've also changed the `syncedAt` field in connectionManager to have the same behaviour.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where repositories that failed indexing for the first time could incorrectly appear in the carousel.

- **Documentation**
  - Improved descriptions for fields related to last successful indexing and syncing times in the data models.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->