### PR TITLE
Update MCP readme for VSCode

### DIFF
--- a/docs/docs/more/mcp-server.mdx
+++ b/docs/docs/more/mcp-server.mdx
@@ -84,10 +84,10 @@ The [Model Context Protocol](https://modelcontextprotocol.io/introduction) (MCP)
                             "sourcebot": {
                                 "type": "stdio",
                                 "command": "npx",
-                                "args": ["-y", "@sourcebot/mcp@latest"]
-                            },
-                            "env": {
-                                "SOURCEBOT_HOST": "http://localhost:3000"
+                                "args": ["-y", "@sourcebot/mcp@latest"],
+                                "env": {
+                                    "SOURCEBOT_HOST": "http://localhost:3000"
+                                }
                             }
                         }
                     }


### PR DESCRIPTION
The env values are nested incorrectly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Corrected the JSON configuration example for the VS Code MCP server by properly nesting the environment variables within the server configuration section.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->