### PR TITLE
fix: Fix symbol hover popover clipping issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue with the symbol hover popover clipping at the top of the page. [#326](https://github.com/sourcebot-dev/sourcebot/pull/326)
+
 ## [4.1.0] - 2025-06-02
 
 ### Added

--- a/packages/web/src/ee/features/codeNav/components/symbolHoverPopup/index.tsx
+++ b/packages/web/src/ee/features/codeNav/components/symbolHoverPopup/index.tsx
@@ -94,48 +94,56 @@ export const SymbolHoverPopup: React.FC<SymbolHoverPopupProps> = ({
         }
     }, [symbolInfo, onGotoDefinition]);
 
-    return symbolInfo ? (
-            <div
-                ref={ref}
-                className="absolute z-10 flex flex-col gap-2 bg-background border border-gray-300 dark:border-gray-700 rounded-md shadow-lg p-2 max-w-3xl"
-                onMouseOver={() => setIsSticky(true)}
-                onMouseOut={() => setIsSticky(false)}
-            >
-                {symbolInfo.isSymbolDefinitionsLoading ? (
-                    <div className="flex flex-row items-center gap-2 text-sm">
-                        <Loader2 className="w-4 h-4 animate-spin" />
-                        Loading...
-                    </div>
-                ) : symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 0 ? (
-                    <SymbolDefinitionPreview
-                        symbolDefinition={symbolInfo.symbolDefinitions[0]}
-                    />
-                ) : (
-                    <p className="text-sm font-medium text-muted-foreground">No hover info found</p>
-                )}
-                <Separator />
-                <div className="flex flex-row gap-2 mt-2">
-                    <LoadingButton
-                        loading={symbolInfo.isSymbolDefinitionsLoading}
-                        disabled={!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0}
-                        variant="outline"
-                        size="sm"
-                        onClick={onGotoDefinition}
-                    >
-                        {
-                            !symbolInfo.isSymbolDefinitionsLoading && (!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0) ?
-                                "No definition found" :
-                                `Go to ${symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 1 ? "definitions" : "definition"}`
-                        }
-                    </LoadingButton>
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onFindReferences(symbolInfo.symbolName)}
-                    >
-                        Find references
-                    </Button>
+    if (!symbolInfo) {
+        return null;
+    }
+
+    // We use a portal here to render the popup at the document body level.
+    // This avoids clipping issues that occur when the popup is rendered inside scrollable or overflow-hidden containers (like the editor or its parent).
+    // By rendering in a portal, the popup can be absolutely positioned anywhere in the viewport without being cut off by parent containers.
+    return createPortal(
+        <div
+            ref={ref}
+            className="absolute z-10 flex flex-col gap-2 bg-background border border-gray-300 dark:border-gray-700 rounded-md shadow-lg p-2 max-w-3xl"
+            onMouseOver={() => setIsSticky(true)}
+            onMouseOut={() => setIsSticky(false)}
+        >
+            {symbolInfo.isSymbolDefinitionsLoading ? (
+                <div className="flex flex-row items-center gap-2 text-sm">
+                    <Loader2 className="w-4 h-4 animate-spin" />
+                    Loading...
                 </div>
-        </div>
-    ) : null;
+            ) : symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 0 ? (
+                <SymbolDefinitionPreview
+                    symbolDefinition={symbolInfo.symbolDefinitions[0]}
+                />
+            ) : (
+                <p className="text-sm font-medium text-muted-foreground">No hover info found</p>
+            )}
+            <Separator />
+            <div className="flex flex-row gap-2 mt-2">
+                <LoadingButton
+                    loading={symbolInfo.isSymbolDefinitionsLoading}
+                    disabled={!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0}
+                    variant="outline"
+                    size="sm"
+                    onClick={onGotoDefinition}
+                >
+                    {
+                        !symbolInfo.isSymbolDefinitionsLoading && (!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0) ?
+                            "No definition found" :
+                            `Go to ${symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 1 ? "definitions" : "definition"}`
+                    }
+                </LoadingButton>
+                <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => onFindReferences(symbolInfo.symbolName)}
+                >
+                    Find references
+                </Button>
+            </div>
+        </div>,
+        document.body
+    );
 };

--- a/packages/web/src/ee/features/codeNav/components/symbolHoverPopup/index.tsx
+++ b/packages/web/src/ee/features/codeNav/components/symbolHoverPopup/index.tsx
@@ -7,6 +7,7 @@ import { Loader2 } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SymbolDefinition, useHoveredOverSymbolInfo } from "./useHoveredOverSymbolInfo";
 import { SymbolDefinitionPreview } from "./symbolDefinitionPreview";
+import { createPortal } from "react-dom";
 
 interface SymbolHoverPopupProps {
     editorRef: ReactCodeMirrorRef;
@@ -55,9 +56,11 @@ export const SymbolHoverPopup: React.FC<SymbolHoverPopupProps> = ({
                         crossAxis: false,
                         fallbackPlacements: ['bottom'],
                         boundary: editorRef.view?.dom,
+                        padding: 20,
                     }),
                     shift({
                         padding: 5,
+                        boundary: editorRef.view?.dom,
                     })
                 ]
             }).then(({ x, y }) => {
@@ -92,47 +95,47 @@ export const SymbolHoverPopup: React.FC<SymbolHoverPopupProps> = ({
     }, [symbolInfo, onGotoDefinition]);
 
     return symbolInfo ? (
-        <div
-            ref={ref}
-            className="absolute z-10 flex flex-col gap-2 bg-background border border-gray-300 dark:border-gray-700 rounded-md shadow-lg p-2 max-w-3xl"
-            onMouseOver={() => setIsSticky(true)}
-            onMouseOut={() => setIsSticky(false)}
-        >
-            {symbolInfo.isSymbolDefinitionsLoading ? (
-                <div className="flex flex-row items-center gap-2 text-sm">
-                    <Loader2 className="w-4 h-4 animate-spin" />
-                    Loading...
+            <div
+                ref={ref}
+                className="absolute z-10 flex flex-col gap-2 bg-background border border-gray-300 dark:border-gray-700 rounded-md shadow-lg p-2 max-w-3xl"
+                onMouseOver={() => setIsSticky(true)}
+                onMouseOut={() => setIsSticky(false)}
+            >
+                {symbolInfo.isSymbolDefinitionsLoading ? (
+                    <div className="flex flex-row items-center gap-2 text-sm">
+                        <Loader2 className="w-4 h-4 animate-spin" />
+                        Loading...
+                    </div>
+                ) : symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 0 ? (
+                    <SymbolDefinitionPreview
+                        symbolDefinition={symbolInfo.symbolDefinitions[0]}
+                    />
+                ) : (
+                    <p className="text-sm font-medium text-muted-foreground">No hover info found</p>
+                )}
+                <Separator />
+                <div className="flex flex-row gap-2 mt-2">
+                    <LoadingButton
+                        loading={symbolInfo.isSymbolDefinitionsLoading}
+                        disabled={!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0}
+                        variant="outline"
+                        size="sm"
+                        onClick={onGotoDefinition}
+                    >
+                        {
+                            !symbolInfo.isSymbolDefinitionsLoading && (!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0) ?
+                                "No definition found" :
+                                `Go to ${symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 1 ? "definitions" : "definition"}`
+                        }
+                    </LoadingButton>
+                    <Button
+                        variant="outline"
+                        size="sm"
+                        onClick={() => onFindReferences(symbolInfo.symbolName)}
+                    >
+                        Find references
+                    </Button>
                 </div>
-            ) : symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 0 ? (
-                <SymbolDefinitionPreview
-                    symbolDefinition={symbolInfo.symbolDefinitions[0]}
-                />
-            ) : (
-                <p className="text-sm font-medium text-muted-foreground">No hover info found</p>
-            )}
-            <Separator />
-            <div className="flex flex-row gap-2 mt-2">
-                <LoadingButton
-                    loading={symbolInfo.isSymbolDefinitionsLoading}
-                    disabled={!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0}
-                    variant="outline"
-                    size="sm"
-                    onClick={onGotoDefinition}
-                >
-                    {
-                        !symbolInfo.isSymbolDefinitionsLoading && (!symbolInfo.symbolDefinitions || symbolInfo.symbolDefinitions.length === 0) ?
-                            "No definition found" :
-                            `Go to ${symbolInfo.symbolDefinitions && symbolInfo.symbolDefinitions.length > 1 ? "definitions" : "definition"}`
-                    }
-                </LoadingButton>
-                <Button
-                    variant="outline"
-                    size="sm"
-                    onClick={() => onFindReferences(symbolInfo.symbolName)}
-                >
-                    Find references
-                </Button>
-            </div>
         </div>
     ) : null;
 };


### PR DESCRIPTION
Before:
<img width="581" alt="image" src="https://github.com/user-attachments/assets/4b7e82b3-6fc5-446c-bf71-cb2416e28b4b" />

After:
<img width="604" alt="image" src="https://github.com/user-attachments/assets/c1870ee7-6e2b-4236-9846-fe4b2ae8c4b3" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Resolved an issue where the symbol hover popover was clipped at the top of the page, ensuring it displays correctly within the editor area.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->