### PR TITLE
improvement: Add separate login / signup screens 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added seperate page for signup. [#311](https://github.com/sourcebot-dev/sourcebot/pull/331)
+
 ## [4.1.1] - 2025-06-03
 
 ### Added

--- a/packages/web/src/app/login/components/loginForm.tsx
+++ b/packages/web/src/app/login/components/loginForm.tsx
@@ -22,9 +22,10 @@ interface LoginFormProps {
     callbackUrl?: string;
     error?: string;
     providers: Array<{ id: string; name: string }>;
+    context: "login" | "signup";
 }
 
-export const LoginForm = ({ callbackUrl, error, providers }: LoginFormProps) => {
+export const LoginForm = ({ callbackUrl, error, providers, context }: LoginFormProps) => {
     const captureEvent = useCaptureEvent();
     const onSignInWithOauth = useCallback((provider: string) => {
         signIn(provider, {
@@ -77,9 +78,11 @@ export const LoginForm = ({ callbackUrl, error, providers }: LoginFormProps) => 
         <div className="flex flex-col items-center justify-center w-full">
             <div className="mb-6 flex flex-col items-center">
                 <SourcebotLogo
-                    className="h-12 sm:h-16"
+                    className="h-12 sm:h-16 mb-3"
                 />
-                <h2 className="text-lg font-bold text-center">Sign in to your account</h2>
+                <h2 className="text-lg font-medium text-center">
+                    {context === "login" ? "Sign in to your account" : "Create a new account"}
+                </h2>
             </div>
             {env.NEXT_PUBLIC_SOURCEBOT_CLOUD_ENVIRONMENT !== undefined && (
                 <div className="w-full sm:w-[500px] max-w-[500px]">
@@ -120,6 +123,17 @@ export const LoginForm = ({ callbackUrl, error, providers }: LoginFormProps) => 
                         ] : [])
                     ]}
                 />
+                <p className="text-sm text-muted-foreground mt-8">
+                    {context === "login" ?
+                        <>
+                            No account yet? <Link className="underline" href="/signup">Sign up</Link>
+                        </>
+                    :
+                        <>
+                            Already have an account? <Link className="underline" href="/login">Sign in</Link>
+                        </>
+                    }
+                </p>
             </Card>
             {env.NEXT_PUBLIC_SOURCEBOT_CLOUD_ENVIRONMENT !== undefined && (
                 <p className="text-xs text-muted-foreground mt-8">By signing in, you agree to the <Link className="underline" href={TERMS_OF_SERVICE_URL} target="_blank">Terms of Service</Link> and <Link className="underline" href={PRIVACY_POLICY_URL} target="_blank">Privacy Policy</Link>.</p>

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -1,11 +1,11 @@
 import { auth } from "@/auth";
-import { LoginForm } from "./components/loginForm";
+import { LoginForm } from "../login/components/loginForm";
 import { redirect } from "next/navigation";
 import { getProviders } from "@/auth";
 import { Footer } from "@/app/components/footer";
 import { createLogger } from "@sourcebot/logger";
 
-const logger = createLogger('login-page');
+const logger = createLogger('signup-page');
 
 interface LoginProps {
     searchParams: {
@@ -14,11 +14,10 @@ interface LoginProps {
     }
 }
 
-export default async function Login({ searchParams }: LoginProps) {
-    logger.info("Login page loaded");
+export default async function Signup({ searchParams }: LoginProps) {
     const session = await auth();
     if (session) {
-        logger.info("Session found in login page, redirecting to home");
+        logger.info("Session found in signup page, redirecting to home");
         return redirect("/");
     }
 
@@ -40,7 +39,7 @@ export default async function Login({ searchParams }: LoginProps) {
                     callbackUrl={searchParams.callbackUrl}
                     error={searchParams.error}
                     providers={providerData}
-                    context="login"
+                    context="signup"
                 />
             </div>
             <Footer />

--- a/packages/web/src/middleware.ts
+++ b/packages/web/src/middleware.ts
@@ -10,7 +10,11 @@ export async function middleware(request: NextRequest) {
         return NextResponse.next();
     }
 
-    if (url.pathname.startsWith('/login') || url.pathname.startsWith('/redeem')) {
+    if (
+        url.pathname.startsWith('/login') ||
+        url.pathname.startsWith('/redeem') ||
+        url.pathname.startsWith('/signup')
+    ) {
         return NextResponse.next();
     }
 


### PR DESCRIPTION
This PR adds a separate signup screen and a small "No account yet?" and "Already have an account?" dialogs.

Login:
<img width="655" alt="image" src="https://github.com/user-attachments/assets/2b27cadc-073e-4a8a-aa1a-39f09704beb8" />

Signup:
<img width="593" alt="image" src="https://github.com/user-attachments/assets/6bc9cf2a-5f5e-40d9-818e-e48bce3283c6" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a dedicated signup page allowing users to create new accounts.
  - Enhanced login and signup forms to display context-specific headings and navigation prompts with links between login and signup.

- **Bug Fixes**
  - Improved navigation flow by ensuring users are redirected appropriately when accessing signup or login pages.
  - Updated routing logic to allow direct access to the signup page without redirection.

- **Style**
  - Adjusted spacing below the logo for improved visual layout.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->