### PR TITLE
Handle long repo names better in the UI

### DIFF
--- a/packages/web/src/app/[domain]/components/repositoryCarousel.tsx
+++ b/packages/web/src/app/[domain]/components/repositoryCarousel.tsx
@@ -11,6 +11,7 @@ import Image from "next/image";
 import { FileIcon } from "@radix-ui/react-icons";
 import clsx from "clsx";
 import { RepositoryQuery } from "@/lib/types";
+import { RepositoryName } from "@/components/ui/repositoryName";
 
 interface RepositoryCarouselProps {
     repos: RepositoryQuery[];
@@ -95,9 +96,13 @@ const RepositoryBadge = ({
             })}
         >
             {repoIcon}
-            <span className="text-sm font-mono">
-                {displayName}
-            </span>
+            <RepositoryName
+                repoName={displayName}
+                displayMode="project-only"
+                maxLength={25}
+                className="flex-1 min-w-0"
+                showTooltip={false}
+            />
         </div>
     )
 }

--- a/packages/web/src/app/[domain]/search/components/filterPanel/entry.tsx
+++ b/packages/web/src/app/[domain]/search/components/filterPanel/entry.tsx
@@ -5,7 +5,7 @@ import clsx from "clsx";
 
 export type Entry = {
     key: string;
-    displayName: string;
+    displayName: string | React.ReactNode;
     count: number;
     isSelected: boolean;
     isHidden: boolean;
@@ -44,13 +44,19 @@ export const Entry = ({
             )}
             onClick={() => onClicked()}
         >
-            <div className="flex flex-row items-center gap-1 overflow-hidden">
+            <div className="flex flex-row items-center gap-1 overflow-hidden min-w-0">
                 {Icon ? Icon : (
                     <QuestionMarkCircledIcon className="w-4 h-4 flex-shrink-0" />
                 )}
-                <p className="overflow-hidden text-ellipsis whitespace-nowrap">{displayName}</p>
+                <div className="overflow-hidden flex-1 min-w-0">
+                    {typeof displayName === 'string' ? (
+                        <p className="overflow-hidden text-ellipsis whitespace-nowrap">{displayName}</p>
+                    ) : (
+                        displayName
+                    )}
+                </div>
             </div>
-            <div className="px-2 py-0.5 bg-accent text-sm rounded-md">
+            <div className="px-2 py-0.5 bg-accent text-sm rounded-md flex-shrink-0">
                 {countText}
             </div>
         </div>

--- a/packages/web/src/app/[domain]/search/components/filterPanel/index.tsx
+++ b/packages/web/src/app/[domain]/search/components/filterPanel/index.tsx
@@ -11,6 +11,7 @@ import { Entry } from "./entry";
 import { Filter } from "./filter";
 import { LANGUAGES_QUERY_PARAM, REPOS_QUERY_PARAM, useFilteredMatches } from "./useFilterMatches";
 import { useGetSelectedFromQuery } from "./useGetSelectedFromQuery";
+import { RepositoryName } from "@/components/ui/repositoryName";
 
 interface FilePanelProps {
     matches: SearchResultFile[];
@@ -76,7 +77,15 @@ export const FilterPanel = ({
 
                 return {
                     key: repository,
-                    displayName: info?.displayName ?? repository,
+                    displayName: (
+                        <RepositoryName 
+                            repoName={info?.displayName ?? repository}
+                            displayMode="truncate"
+                            maxLength={50}
+                            tooltipSide="right"
+                            className="flex-1 min-w-0"
+                        />
+                    ),
                     count: 0,
                     isSelected,
                     isDisabled,

--- a/packages/web/src/components/ui/repositoryName.tsx
+++ b/packages/web/src/components/ui/repositoryName.tsx
@@ -1,0 +1,135 @@
+'use client';
+
+import { cn } from "@/lib/utils";
+import { createTruncatedRepoDisplay, createBreadcrumbRepoDisplay, getProjectName, createCompactRepoDisplay } from "@/lib/repositoryDisplayUtils";
+import { Tooltip, TooltipContent, TooltipTrigger } from "./tooltip";
+import { Breadcrumb, BreadcrumbItem, BreadcrumbList, BreadcrumbEllipsis, BreadcrumbSeparator } from "./breadcrumb";
+import React from "react";
+
+export interface RepositoryNameProps {
+    repoName: string;
+    displayMode?: 'truncate' | 'breadcrumb' | 'project-only' | 'compact';
+    maxLength?: number;
+    className?: string;
+    tooltipSide?: 'top' | 'bottom' | 'left' | 'right';
+    showTooltip?: boolean;
+    customTooltipContent?: React.ReactNode;
+}
+
+/**
+ * A flexible component for displaying repository names with intelligent truncation.
+ * Automatically handles long GitLab project names with nested groups.
+ * 
+ * Display modes:
+ * - 'truncate': Shows meaningful parts with ellipsis (default)
+ * - 'breadcrumb': Shows breadcrumb-style navigation with collapsing
+ * - 'project-only': Shows only the project name
+ * - 'compact': Shows project name with group context in parentheses
+ */
+export const RepositoryName = React.forwardRef<
+    HTMLSpanElement,
+    RepositoryNameProps
+>(({
+    repoName,
+    displayMode = 'truncate',
+    maxLength = 50,
+    className,
+    tooltipSide = 'top',
+    showTooltip = true,
+    customTooltipContent,
+    ...props
+}, ref) => {
+    const renderContent = () => {
+        switch (displayMode) {
+            case 'breadcrumb': {
+                const { parts, isCollapsed, fullParts } = createBreadcrumbRepoDisplay(repoName);
+                return (
+                    <Breadcrumb>
+                        <BreadcrumbList className="flex-nowrap">
+                            {parts.map((part, index) => (
+                                <React.Fragment key={index}>
+                                    {index > 0 && <BreadcrumbSeparator />}
+                                    <BreadcrumbItem>
+                                        {part === '…' ? (
+                                            <BreadcrumbEllipsis />
+                                        ) : (
+                                            <span className="font-mono text-sm">{part}</span>
+                                        )}
+                                    </BreadcrumbItem>
+                                </React.Fragment>
+                            ))}
+                        </BreadcrumbList>
+                    </Breadcrumb>
+                );
+            }
+            
+            case 'project-only': {
+                const projectName = getProjectName(repoName);
+                return (
+                    <span className="font-mono text-sm">
+                        {projectName.length > maxLength 
+                            ? projectName.substring(0, maxLength - 1) + '…'
+                            : projectName
+                        }
+                    </span>
+                );
+            }
+            
+            case 'compact': {
+                const { displayText } = createCompactRepoDisplay(repoName, maxLength);
+                return <span className="font-mono text-sm">{displayText}</span>;
+            }
+            
+            case 'truncate':
+            default: {
+                const { displayText } = createTruncatedRepoDisplay(repoName, maxLength);
+                return <span className="font-mono text-sm">{displayText}</span>;
+            }
+        }
+    };
+
+    const content = (
+        <span
+            ref={ref}
+            className={cn("inline-flex items-center", className)}
+            {...props}
+        >
+            {renderContent()}
+        </span>
+    );
+
+    // Only show tooltip if content is truncated or explicitly requested
+    const shouldShowTooltip = showTooltip && (
+        customTooltipContent ||
+        displayMode === 'breadcrumb' ||
+        displayMode === 'project-only' ||
+        repoName.length > maxLength ||
+        repoName !== content.props.children.props.children
+    );
+
+    if (!shouldShowTooltip) {
+        return content;
+    }
+
+    return (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                {content}
+            </TooltipTrigger>
+            <TooltipContent side={tooltipSide} className="max-w-sm">
+                {customTooltipContent || (
+                    <div className="space-y-1">
+                        <p className="font-mono text-sm">{repoName}</p>
+                        {repoName.includes('/') && (
+                            <p className="text-xs text-muted-foreground">
+                                Project: {getProjectName(repoName)}
+                            </p>
+                        )}
+                    </div>
+                )}
+            </TooltipContent>
+        </Tooltip>
+    );
+});
+
+RepositoryName.displayName = "RepositoryName"; 

--- a/packages/web/src/lib/repositoryDisplayUtils.ts
+++ b/packages/web/src/lib/repositoryDisplayUtils.ts
@@ -1,0 +1,183 @@
+/**
+ * Utilities for displaying repository names in a user-friendly way,
+ * especially for long GitLab project names with nested groups.
+ */
+
+export interface TruncatedRepoDisplay {
+    displayText: string;
+    fullText: string;
+    isTruncated: boolean;
+    parts?: string[];
+}
+
+/**
+ * Intelligently truncates repository names for display in constrained spaces.
+ * For GitLab nested groups, prioritizes showing the project name and immediate parent.
+ * Always shows at least one parent group + project (if groups exist), even if both need truncation.
+ * 
+ * Examples:
+ * - "very-long-group/another-group/subgroup/my-project" → "subgroup/my-project"
+ * - "group/project" → "group/project" (no truncation needed)
+ * - "extremely-long-group-name-here/another-extremely-long-group/final-group/my-awesome-project-with-long-name"
+ *   → "final-gr…/my-awesome-proj…"
+ */
+export function createTruncatedRepoDisplay(
+    repoName: string,
+    maxLength: number = 50,
+    showParts: number = 2
+): TruncatedRepoDisplay {
+    const parts = repoName.split('/');
+    const fullText = repoName;
+
+    // If it's short enough, don't truncate
+    if (repoName.length <= maxLength) {
+        return {
+            displayText: repoName,
+            fullText,
+            isTruncated: false,
+            parts
+        };
+    }
+
+    // For multiple parts, always show at least the last parent + project
+    const relevantParts = parts.slice(-showParts);
+    let displayText = relevantParts.join('/');
+
+    // If still too long, truncate both parent and project proportionally
+    if (displayText.length > maxLength) {
+        const projectName = relevantParts[relevantParts.length - 1];
+        const parentParts = relevantParts.slice(0, -1);
+        const parentPath = parentParts.join('/');
+        
+        // Reserve space for the slash and ellipsis characters
+        const reservedChars = 3; // "/" + "…" for each truncated part
+        const availableLength = maxLength - reservedChars;
+        
+        // Allocate space: give slight preference to project name
+        const projectAllocation = Math.max(8, Math.floor(availableLength * 0.6));
+        const parentAllocation = availableLength - projectAllocation;
+        
+        let truncatedProject = projectName;
+        let truncatedParent = parentPath;
+        
+        // Truncate project if needed
+        if (projectName.length > projectAllocation) {
+            truncatedProject = projectName.substring(0, projectAllocation - 1) + '…';
+        }
+        
+        // Truncate parent if needed
+        if (parentPath.length > parentAllocation) {
+            // For parent groups, truncate from the right to keep the beginning part
+            truncatedParent = parentPath.substring(0, parentAllocation - 1) + '…';
+        }
+        
+        displayText = truncatedParent + '/' + truncatedProject;
+    }
+
+    return {
+        displayText,
+        fullText,
+        isTruncated: true,
+        parts
+    };
+}
+
+/**
+ * Creates a breadcrumb-style display for repository names with intelligent collapsing.
+ * Shows first part, ellipsis, and last N parts for very long paths.
+ * 
+ * Example: "group1/group2/group3/group4/project" → ["group1", "…", "group4", "project"]
+ */
+export function createBreadcrumbRepoDisplay(
+    repoName: string,
+    maxVisibleParts: number = 3
+): { parts: string[], isCollapsed: boolean, fullParts: string[] } {
+    const fullParts = repoName.split('/');
+    
+    if (fullParts.length <= maxVisibleParts) {
+        return {
+            parts: fullParts,
+            isCollapsed: false,
+            fullParts
+        };
+    }
+
+    // Show first part, ellipsis, then last (maxVisibleParts - 2) parts
+    const visibleEndParts = maxVisibleParts - 2; // Account for first part and ellipsis
+    const parts = [
+        fullParts[0],
+        '…',
+        ...fullParts.slice(-visibleEndParts)
+    ];
+
+    return {
+        parts,
+        isCollapsed: true,
+        fullParts
+    };
+}
+
+/**
+ * Extracts just the project name from a repository path.
+ * Useful for very constrained spaces like carousel items.
+ */
+export function getProjectName(repoName: string): string {
+    const parts = repoName.split('/');
+    return parts[parts.length - 1];
+}
+
+/**
+ * Creates a compact display that shows project name with group context in parentheses.
+ * Example: "my-project (from group/subgroup)"
+ */
+export function createCompactRepoDisplay(
+    repoName: string,
+    maxLength: number = 40
+): TruncatedRepoDisplay {
+    const parts = repoName.split('/');
+    const projectName = parts[parts.length - 1];
+    const fullText = repoName;
+
+    if (parts.length === 1) {
+        return createTruncatedRepoDisplay(repoName, maxLength);
+    }
+
+    const groupPath = parts.slice(0, -1).join('/');
+    const compactFormat = `${projectName} (${groupPath})`;
+
+    if (compactFormat.length <= maxLength) {
+        return {
+            displayText: compactFormat,
+            fullText,
+            isTruncated: false,
+            parts
+        };
+    }
+
+    // Try to fit by truncating the group path
+    const baseLength = projectName.length + 3; // " ()" = 3 chars
+    const availableForGroup = maxLength - baseLength;
+
+    if (availableForGroup > 10) {
+        const truncatedGroup = groupPath.length > availableForGroup 
+            ? '…' + groupPath.substring(groupPath.length - availableForGroup + 1)
+            : groupPath;
+        
+        return {
+            displayText: `${projectName} (${truncatedGroup})`,
+            fullText,
+            isTruncated: true,
+            parts
+        };
+    }
+
+    // If even that doesn't fit, just show the project name
+    return {
+        displayText: projectName.length > maxLength 
+            ? projectName.substring(0, maxLength - 1) + '…'
+            : projectName,
+        fullText,
+        isTruncated: true,
+        parts
+    };
+} 


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/a1441cef-6c71-489c-9c0c-bbd4f848e646)
