### PR TITLE
[search/browse] link repo name to file browser; link code image to external

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Changed repository link in search to file tree + move external link to code host logo. [#340](https://github.com/sourcebot-dev/sourcebot/pull/340)
+
 ## [4.2.0] - 2025-06-09
 
 ### Added

--- a/packages/web/src/app/[domain]/components/pathHeader.tsx
+++ b/packages/web/src/app/[domain]/components/pathHeader.tsx
@@ -223,22 +223,27 @@ export const PathHeader = ({
     return (
         <div className="flex flex-row gap-2 items-center w-full overflow-hidden">
             {info?.icon ? (
-                <Image
-                    src={info.icon}
-                    alt={info.codeHostName}
-                    className={`w-4 h-4 ${info.iconClassName}`}
-                />
-            ): (
+                <a href={info.repoLink} target="_blank" rel="noopener noreferrer">
+                    <Image
+                        src={info.icon}
+                        alt={info.codeHostName}
+                        className={`w-4 h-4 ${info.iconClassName}`}
+                    />
+                </a>
+            ) : (
                 <LaptopIcon className="w-4 h-4" />
             )}
-            <Link
-                className={clsx("font-medium", {
-                    "cursor-pointer hover:underline": info?.repoLink,
+            <div
+                className="font-medium cursor-pointer hover:underline"
+                onClick={() => navigateToPath({
+                    repoName: repo.name,
+                    path: '',
+                    pathType: 'tree',
+                    revisionName: branchDisplayName,
                 })}
-                href={info?.repoLink ?? ""}
             >
                 {info?.displayName}
-            </Link>
+            </div>
             {branchDisplayName && (
                 <p
                     className="text-xs font-semibold text-gray-500 dark:text-gray-400 mt-[3px] flex items-center gap-0.5"


### PR DESCRIPTION
* [Change] Updates repository name to use the file browser / tree by default instead of the external repository.
* [New] Adds a link to the external repository on the source code logo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Repository icon now links directly to the repository if a link is available.
- **Refactor**
  - Repository name is always styled as clickable and navigates to the repository root path on click, replacing the previous external link behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->