### PR TITLE
fix(gitlab): Properly handle auth for Gitlab project avatars

### DIFF
--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -121,7 +121,10 @@ export const compileGitlabConfig = async (
         const isFork = project.forked_from_project !== undefined;
         const repoDisplayName = project.path_with_namespace;
         const repoName = path.join(repoNameRoot, repoDisplayName);
-
+        // project.avatar_url is not directly accessible with tokens; use the avatar API endpoint if available
+        const avatarUrl = project.avatar_url
+            ? new URL(`/api/v4/projects/${project.id}/avatar`, hostUrl).toString()
+            : null;
         logger.debug(`Found gitlab repo ${repoDisplayName} with webUrl: ${projectUrl}`);
 
         const record: RepoData = {
@@ -132,7 +135,7 @@ export const compileGitlabConfig = async (
             webUrl: projectUrl,
             name: repoName,
             displayName: repoDisplayName,
-            imageUrl: project.avatar_url,
+            imageUrl: avatarUrl,
             isFork: isFork,
             isArchived: !!project.archived,
             org: {

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -419,7 +419,6 @@ export const getRepoImageSrc = (imageUrl: string | undefined, repoId: number, do
         // List of known public instances that don't require authentication
         const publicHostnames = [
             'github.com',
-            'gitlab.com',
             'avatars.githubusercontent.com',
             'gitea.com',
             'bitbucket.org',


### PR DESCRIPTION
Hey 👋 

## Context

We've noticed that our Gitlab project avatars were not loading properly, even in 4.2.0.

## Proposed fix

I believe it's because the URL in project.avatarUrl [does not accept Gitlab tokens anymore](https://gitlab.com/gitlab-org/gitlab/-/issues/25498).

Gitlab provides a [~new API to get a project's avatar](https://docs.gitlab.com/api/projects/#download-a-project-avatar), supporting the same authentication modes as other APIs. This API does not require authentication for public projects.

I've also removed `gitlab.com` from the list of domains never needing auth - to properly support private projects on Gitlab.com.

## Validation

I've only tested this change on an internal Gitlab with public/private projects and on gitlab.com with public/private projects.

Have a great day!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of GitLab repository avatar images to ensure consistent image display.
  - Updated logic so that images from gitlab.com are now loaded through a proxy, enhancing reliability for private or protected repositories.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->