### PR TITLE
fix: Add default debounce & staleTime to file/folder prefetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Text highlighting clarity. [#342](https://github.com/sourcebot-dev/sourcebot/pull/342)
 - Fixed repo list column header styling. [#344](https://github.com/sourcebot-dev/sourcebot/pull/344)
 - Clean up successful and failed jobs in Redis queues. [#343](https://github.com/sourcebot-dev/sourcebot/pull/343)
+- Fixed issue with files occasionally not loading after moving the cursor rapidly over the file browser. [#346](https://github.com/sourcebot-dev/sourcebot/pull/346)
 
 ## [4.2.0] - 2025-06-09
 


### PR DESCRIPTION
We noticed that if you move your cursor across many files in the file tree and then click on one of the files, occasionally the file would never load. This was especially apparent in deployed environments like the demo instance.

My theory is that we were doing too many prefetches too quickly, resulting in some issue when loading the file after the user clicked on it. This PR adds:
1. A default `staleTime` ([docs](https://tanstack.com/query/v4/docs/framework/react/reference/useQuery)) of 5 minutes, meaning that if a user hovers over a file that has already been fetched, it won't be fetched again (until 5 minutes has elapsed).
2. A default `debounceDelay` time of 200ms, meaning we will only prefetch when the user's cursor has "settled" on a file.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for customizing debounce delay and cache freshness when prefetching file sources and folder contents.

- **Refactor**
  - Improved prefetching behavior for file sources and folder contents with configurable options for enhanced performance and flexibility.

- **Bug Fixes**
  - Fixed an issue where files occasionally failed to load after rapidly moving the cursor over the file browser.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->