### PR TITLE
Delete account join request when redeeming an invite

### DIFF
--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -1147,6 +1147,23 @@ export const redeemInvite = async (inviteId: string): Promise<{ success: boolean
                 }
             });
 
+            // Delete the account request if it exists since we've redeemed an invite
+            const accountRequest = await tx.accountRequest.findUnique({
+                where: {
+                    requestedById: user.id,
+                    orgId: invite.orgId,
+                },
+            });
+
+            if (accountRequest) {
+                logger.info(`Deleting account request ${accountRequest.id} for user ${user.id} since they've redeemed an invite`);
+                await tx.accountRequest.delete({
+                    where: {
+                        id: accountRequest.id,
+                    }
+                });
+            }
+
             if (IS_BILLING_ENABLED) {
                 const result = await incrementOrgSeatCount(invite.orgId, tx);
                 if (isServiceError(result)) {

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -1150,8 +1150,10 @@ export const redeemInvite = async (inviteId: string): Promise<{ success: boolean
             // Delete the account request if it exists since we've redeemed an invite
             const accountRequest = await tx.accountRequest.findUnique({
                 where: {
-                    requestedById: user.id,
-                    orgId: invite.orgId,
+                    requestedById_orgId: {
+                        requestedById: user.id,
+                        orgId: invite.orgId,
+                    }
                 },
             });
 


### PR DESCRIPTION
Fixes https://github.com/sourcebot-dev/sourcebot/issues/337

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved invite redemption process by automatically removing any existing account requests linked to the user and organization after redeeming an invite. This ensures a smoother onboarding experience and prevents duplicate account requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->