### PR TITLE
Correctly build URLs to file paths containing spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Fixed
+- Fixed issue with external source code links being broken for paths with spaces. [#364](https://github.com/sourcebot-dev/sourcebot/pull/364)
+
 ## [4.5.0] - 2025-06-21
 
 ### Added

--- a/packages/web/src/features/search/searchApi.ts
+++ b/packages/web/src/features/search/searchApi.ts
@@ -106,13 +106,14 @@ const getFileWebUrl = (template: string, branch: string, fileName: string): stri
 
     const url =
         template.substring("{{URLJoinPath ".length, template.indexOf("}}"))
-            .replace(".Version", branch)
-            .replace(".Path", fileName)
             .split(" ")
             .map((part) => {
                 // remove wrapping quotes
                 if (part.startsWith("\"")) part = part.substring(1);
                 if (part.endsWith("\"")) part = part.substring(0, part.length - 1);
+                // Replace variable references
+                if (part == ".Version") part = branch;
+                if (part == ".Path") part = fileName;
                 return part;
             })
             .join("/");


### PR DESCRIPTION
Previously, such paths would have their spaces replaced with `/`s, breaking external links to the file.

Fixes #249

I haven't tested this yet.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed broken external source code links when paths contain spaces, improving link reliability in search results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->