### PR TITLE
chore: Misc typos (UI, docs, code...), Makefile PATH with spaces

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Fixed typos in UI, docs, code [#369](https://github.com/sourcebot-dev/sourcebot/pull/369)
+
 ## [4.5.1] - 2025-07-14
 
 ### Changed
@@ -234,7 +239,7 @@ Sourcebot v3 is here and brings a number of structural changes to the tool's fou
 
 ### Added
 
-- Added `maxTrigramCount` to the config to control the maximum allowable of trigrams per document. 
+- Added `maxTrigramCount` to the config to control the maximum allowable of trigrams per document.
 
 ### Fixed
 
@@ -292,7 +297,7 @@ Sourcebot v3 is here and brings a number of structural changes to the tool's fou
 - Added config option `settings.maxFileSize` to control the maximum file size zoekt will index. ([#118](https://github.com/sourcebot-dev/sourcebot/pull/118))
 
 ### Fixed
- 
+
 - Fixed syntax highlighting for zoekt query language. ([#115](https://github.com/sourcebot-dev/sourcebot/pull/115))
 - Fixed issue with Gerrit repo fetching not paginating. ([#114](https://github.com/sourcebot-dev/sourcebot/pull/114))
 - Fixed visual issues with filter panel. ([#105](https://github.com/sourcebot-dev/sourcebot/pull/105))
@@ -344,13 +349,13 @@ Sourcebot v3 is here and brings a number of structural changes to the tool's fou
 ### Added
 
 - Added `DOMAIN_SUB_PATH` environment variable to allow overriding the default domain subpath. ([#74](https://github.com/sourcebot-dev/sourcebot/pull/74))
-- Added option `all` to the GitLab index schema, allowing for indexing all projects in a self-hosted GitLab instance. ([#84](https://github.com/sourcebot-dev/sourcebot/pull/84)) 
+- Added option `all` to the GitLab index schema, allowing for indexing all projects in a self-hosted GitLab instance. ([#84](https://github.com/sourcebot-dev/sourcebot/pull/84))
 
 ## [2.4.3] - 2024-11-18
 
 ### Changed
 
-- Bumped NodeJS version to v20. ([#78](https://github.com/sourcebot-dev/sourcebot/pull/78)) 
+- Bumped NodeJS version to v20. ([#78](https://github.com/sourcebot-dev/sourcebot/pull/78))
 
 ## [2.4.2] - 2024-11-14
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@
 
 6. Create a copy of `.env.development` and name it `.env.development.local`. Update the required environment variables.
 
-7. If you're using a declerative configuration file, create a configuration file and update the `CONFIG_PATH` environment variable in your `.env.development.local` file.
+7. If you're using a declarative configuration file, create a configuration file and update the `CONFIG_PATH` environment variable in your `.env.development.local` file.
 
 8. Start Sourcebot with the command:
     ```sh

--- a/Makefile
+++ b/Makefile
@@ -10,7 +10,7 @@ yarn:
 zoekt:
 	mkdir -p bin
 	go build -C vendor/zoekt -o $(PWD)/bin ./cmd/...
-	export PATH=$(PWD)/bin:$(PATH)
+	export PATH="$(PWD)/bin:$(PATH)"
 	export CTAGS_COMMANDS=ctags
 
 clean:

--- a/_typos.toml
+++ b/_typos.toml
@@ -1,0 +1,6 @@
+[default.extend-words]
+# Don't correct the surname "Do Not Exists"
+dne = "dne"
+
+[files]
+extend-exclude = ["vendor/**/*", "CHANGELOG.md", "packages/web/src/lib/languageMetadata.ts"]

--- a/docs/docs/connections/local-repos.mdx
+++ b/docs/docs/connections/local-repos.mdx
@@ -27,7 +27,7 @@ To get Sourcebot to index these repositories:
 
 <Steps>
     <Step title="Mount a volume">
-        We need to mount a docker volume to the `repos` directory so Sourcebot can read it's contents. Sourcebot will **not** write to local repositories, so we can mount a seperate **read-only** volume:
+        We need to mount a docker volume to the `repos` directory so Sourcebot can read it's contents. Sourcebot will **not** write to local repositories, so we can mount a separate **read-only** volume:
 
         ``` bash
         docker run \

--- a/docs/snippets/schemas/v2/index.schema.mdx
+++ b/docs/snippets/schemas/v2/index.schema.mdx
@@ -685,7 +685,7 @@
                 "type": "string",
                 "pattern": ".+"
               },
-              "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+              "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
               "default": [],
               "examples": [
                 [
@@ -1387,7 +1387,7 @@
                     "type": "string",
                     "pattern": ".+"
                   },
-                  "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+                  "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
                   "default": [],
                   "examples": [
                     [
@@ -2171,7 +2171,7 @@
                       "type": "string",
                       "pattern": ".+"
                     },
-                    "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+                    "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
                     "default": [],
                     "examples": [
                       [

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -376,7 +376,7 @@ export const compileBitbucketConfig = async (
             throw new Error(`No links found for ${isServer ? 'server' : 'cloud'} repo ${repoName}`);
         }
 
-        // In server case we get an array of lenth == 1 links in the self field, while in cloud case we get a single
+        // In server case we get an array of length == 1 links in the self field, while in cloud case we get a single
         // link object in the html field
         const link = isServer ? (repoLinks.self as { name: string, href: string }[])?.[0] : repoLinks.html as { href: string };
         if (!link || !link.href) {

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -174,7 +174,7 @@ export class RepoManager implements IRepoManager {
     // We can no longer use repo.cloneUrl directly since it doesn't contain the token for security reasons. As a result, we need to
     // fetch the token here using the connections from the repo. Multiple connections could be referencing this repo, and each
     // may have their own token. This method will just pick the first connection that has a token (if one exists) and uses that. This
-    // may technically cause syncing to fail if that connection's token just so happens to not have access to the repo it's referrencing.
+    // may technically cause syncing to fail if that connection's token just so happens to not have access to the repo it's referencing.
     private async getCloneCredentialsForRepo(repo: RepoWithConnections, db: PrismaClient): Promise<{ username?: string, password: string } | undefined> {
 
         for (const { connection } of repo.connections) {

--- a/packages/mcp/README.md
+++ b/packages/mcp/README.md
@@ -19,7 +19,7 @@ The Sourcebot MCP server gives your LLM agents the ability to fetch code context
 
 - Building custom LLM horizontal agents like like compliance auditing agents, migration agents, etc.
     - _"Find all instances of hardcoded credentials"_
-    - _"Identify repositories that depend on this depreacted api"_
+    - _"Identify repositories that depend on this deprecated api"_
 
 
 ## Getting Started

--- a/packages/schemas/src/v2/index.schema.ts
+++ b/packages/schemas/src/v2/index.schema.ts
@@ -684,7 +684,7 @@ const schema = {
                 "type": "string",
                 "pattern": ".+"
               },
-              "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+              "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
               "default": [],
               "examples": [
                 [
@@ -1386,7 +1386,7 @@ const schema = {
                     "type": "string",
                     "pattern": ".+"
                   },
-                  "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+                  "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
                   "default": [],
                   "examples": [
                     [
@@ -2170,7 +2170,7 @@ const schema = {
                       "type": "string",
                       "pattern": ".+"
                     },
-                    "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+                    "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
                     "default": [],
                     "examples": [
                       [

--- a/packages/schemas/src/v2/index.type.ts
+++ b/packages/schemas/src/v2/index.type.ts
@@ -309,7 +309,7 @@ export interface LocalConfig {
   watch?: boolean;
   exclude?: {
     /**
-     * List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.
+     * List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.
      */
     paths?: string[];
   };

--- a/packages/shared/README.md
+++ b/packages/shared/README.md
@@ -2,7 +2,7 @@ This package contains shared code between the backend & webapp packages.
 
 ### Why two index files?
 
-This package contains two index files: `index.server.ts` and `index.client.ts`. There is some code in this package that will only work in a Node.JS runtime (e.g., because it depends on the `fs` pacakge. Entitlements are a good example of this), and other code that is runtime agnostic (e.g., `constants.ts`). To deal with this, we these two index files export server code and client code, respectively.
+This package contains two index files: `index.server.ts` and `index.client.ts`. There is some code in this package that will only work in a Node.JS runtime (e.g., because it depends on the `fs` package. Entitlements are a good example of this), and other code that is runtime agnostic (e.g., `constants.ts`). To deal with this, we these two index files export server code and client code, respectively.
 
 For package consumers, the usage would look like the following:
 - Server: `import { ... } from @sourcebot/shared`

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -141,7 +141,7 @@ export const withOrgMembership = async <T>(userId: string, domain: string, fn: (
         return notFound("User not a member of this organization");
     }
 
-    const getAuthorizationPrecendence = (role: OrgRole): number => {
+    const getAuthorizationPrecedence = (role: OrgRole): number => {
         switch (role) {
             case OrgRole.GUEST:
                 return 0;
@@ -153,7 +153,7 @@ export const withOrgMembership = async <T>(userId: string, domain: string, fn: (
     }
 
 
-    if (getAuthorizationPrecendence(membership.role) < getAuthorizationPrecendence(minRequiredRole)) {
+    if (getAuthorizationPrecedence(membership.role) < getAuthorizationPrecedence(minRequiredRole)) {
         return {
             statusCode: StatusCodes.FORBIDDEN,
             errorCode: ErrorCode.INSUFFICIENT_PERMISSIONS,
@@ -710,7 +710,7 @@ export const getRepoInfoByName = async (repoName: string, domain: string) => sew
             // In this scenario, both repos will be named "github.com/sourcebot-dev/sourcebot".
             // We will leave this as an edge case for now since it's unlikely to happen in practice.
             //
-            // @v4-todo: we could add a unique contraint on repo name + orgId to help de-duplicate
+            // @v4-todo: we could add a unique constraint on repo name + orgId to help de-duplicate
             // these cases.
             // @see: repoCompileUtils.ts
             const repo = await prisma.repo.findFirst({

--- a/packages/web/src/app/[domain]/browse/hooks/utils.ts
+++ b/packages/web/src/app/[domain]/browse/hooks/utils.ts
@@ -1,18 +1,18 @@
 
 export const getBrowseParamsFromPathParam = (pathParam: string) => {
-    const sentinalIndex = pathParam.search(/\/-\/(tree|blob)/);
-    if (sentinalIndex === -1) {
+    const sentinelIndex = pathParam.search(/\/-\/(tree|blob)/);
+    if (sentinelIndex === -1) {
         throw new Error(`Invalid browse pathname: "${pathParam}" - expected to contain "/-/(tree|blob)/" pattern`);
     }
 
-    const repoAndRevisionPart = pathParam.substring(0, sentinalIndex);
+    const repoAndRevisionPart = pathParam.substring(0, sentinelIndex);
     const lastAtIndex = repoAndRevisionPart.lastIndexOf('@');
     
     const repoName = lastAtIndex === -1 ? repoAndRevisionPart : repoAndRevisionPart.substring(0, lastAtIndex);
     const revisionName = lastAtIndex === -1 ? undefined : repoAndRevisionPart.substring(lastAtIndex + 1);
 
     const { path, pathType } = ((): { path: string, pathType: 'tree' | 'blob' } => {
-        const path = pathParam.substring(sentinalIndex + '/-/'.length);
+        const path = pathParam.substring(sentinelIndex + '/-/'.length);
         const pathType = path.startsWith('tree') ? 'tree' : 'blob';
 
         // @note: decodedURIComponent is needed here incase the path contains a space.

--- a/packages/web/src/app/[domain]/components/searchBar/searchSuggestionsBox.test.tsx
+++ b/packages/web/src/app/[domain]/components/searchBar/searchSuggestionsBox.test.tsx
@@ -34,7 +34,7 @@ test('splitQuery groups all parts together when a quote capture group is not clo
     expect(cursorIndex).toBe(0);
 });
 
-test('splitQuery correclty locates the cursor index given the cursor position (1)', () => {
+test('splitQuery correctly locates the cursor index given the cursor position (1)', () => {
     const query = 'foo bar "fizz buzz"';
 
     const { queryParts: parts1, cursorIndex: index1 } = splitQuery(query, 0);
@@ -50,7 +50,7 @@ test('splitQuery correclty locates the cursor index given the cursor position (1
     expect(parts3[index3]).toBe('"fizz buzz"');
 });
 
-test('splitQuery correclty locates the cursor index given the cursor position (2)', () => {
+test('splitQuery correctly locates the cursor index given the cursor position (2)', () => {
     const query = 'a b';
     expect(splitQuery(query, 0).cursorIndex).toBe(0);
     expect(splitQuery(query, 1).cursorIndex).toBe(0);

--- a/packages/web/src/app/[domain]/components/searchBar/searchSuggestionsBox.tsx
+++ b/packages/web/src/app/[domain]/components/searchBar/searchSuggestionsBox.tsx
@@ -438,7 +438,7 @@ export { SearchSuggestionsBox };
 
 export const splitQuery = (query: string, cursorPos: number) => {
     const queryParts = [];
-    const seperator = " ";
+    const separator = " ";
     let cursorIndex = 0;
     let accumulator = "";
     let isInQuoteCapture = false;
@@ -452,7 +452,7 @@ export const splitQuery = (query: string, cursorPos: number) => {
             isInQuoteCapture = !isInQuoteCapture;
         }
 
-        if (!isInQuoteCapture && query[i] === seperator) {
+        if (!isInQuoteCapture && query[i] === separator) {
             queryParts.push(accumulator);
             accumulator = "";
             continue;

--- a/packages/web/src/app/[domain]/components/searchBar/useSuggestionModeAndQuery.ts
+++ b/packages/web/src/app/[domain]/components/searchBar/useSuggestionModeAndQuery.ts
@@ -21,7 +21,7 @@ export const useSuggestionModeAndQuery = ({
     const suggestionModeMappings = useSuggestionModeMappings();
 
     const { suggestionQuery, suggestionMode } = useMemo<{ suggestionQuery: string, suggestionMode: SuggestionMode }>(() => {
-        // When suggestions are not enabled, fallback to using a sentinal
+        // When suggestions are not enabled, fallback to using a sentinel
         // suggestion mode of "none".
         if (!isSuggestionsEnabled) {
             return {

--- a/packages/web/src/app/[domain]/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/[domain]/components/syntaxReferenceGuide.tsx
@@ -66,7 +66,7 @@ export const SyntaxReferenceGuide = () => {
                 <DialogHeader>
                     <DialogTitle>Syntax Reference Guide</DialogTitle>
                     <DialogDescription className="text-sm text-foreground">
-                        Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>{`""`}</Code> combines them. By default, a file must have at least one match for each expression to be included.
+                        Queries consist of space-separated regular expressions. Wrapping expressions in <Code>{`""`}</Code> combines them. By default, a file must have at least one match for each expression to be included.
                     </DialogDescription>
                 </DialogHeader>
                 <Table>

--- a/packages/web/src/app/[domain]/settings/(general)/components/changeOrgNameCard.tsx
+++ b/packages/web/src/app/[domain]/settings/(general)/components/changeOrgNameCard.tsx
@@ -65,7 +65,7 @@ export function ChangeOrgNameCard({ orgName, currentUserRole }: ChangeOrgNameCar
                 <CardTitle>
                     Organization Name
                 </CardTitle>
-                <CardDescription>{`Your organization's visible name within Sourceobot. For example, the name of your company or department.`}</CardDescription>
+                <CardDescription>{`Your organization's visible name within Sourcebot. For example, the name of your company or department.`}</CardDescription>
             </CardHeader>
             <CardContent>
                 <Form {...form}>

--- a/packages/web/src/app/components/syntaxReferenceGuide.tsx
+++ b/packages/web/src/app/components/syntaxReferenceGuide.tsx
@@ -66,7 +66,7 @@ export const SyntaxReferenceGuide = () => {
                 <DialogHeader>
                     <DialogTitle>Syntax Reference Guide</DialogTitle>
                     <DialogDescription className="text-sm text-foreground">
-                        Queries consist of space-seperated regular expressions. Wrapping expressions in <Code>{`""`}</Code> combines them. By default, a file must have at least one match for each expression to be included.
+                        Queries consist of space-separated regular expressions. Wrapping expressions in <Code>{`""`}</Code> combines them. By default, a file must have at least one match for each expression to be included.
                     </DialogDescription>
                 </DialogHeader>
                 <Table>

--- a/packages/web/src/app/onboard/page.tsx
+++ b/packages/web/src/app/onboard/page.tsx
@@ -14,7 +14,7 @@ import { prisma } from "@/prisma";
 import { OrgRole } from "@sourcebot/db";
 import { LogoutEscapeHatch } from "@/app/components/logoutEscapeHatch";
 import { redirect } from "next/navigation";
-import { BetweenHorizonalStart, GitBranchIcon, LockIcon } from "lucide-react";
+import { BetweenHorizontalStart, GitBranchIcon, LockIcon } from "lucide-react";
 import { hasEntitlement } from "@sourcebot/shared";
 import { env } from "@/env.mjs";
 import { GcpIapAuth } from "@/app/[domain]/components/gcpIapAuth";
@@ -106,7 +106,7 @@ export default async function Onboarding({ searchParams }: OnboardingProps) {
             title: "MCP Server",
             description: "Learn how to setup Sourcebot's MCP server to provide code context to your AI agents",
             href: "https://docs.sourcebot.dev/docs/features/mcp-server",
-            icon: <BetweenHorizonalStart className="w-4 h-4" />,
+            icon: <BetweenHorizontalStart className="w-4 h-4" />,
         }
     ]
 
@@ -182,7 +182,7 @@ export default async function Onboarding({ searchParams }: OnboardingProps) {
                 <div className="space-y-6">
                     <div className="grid grid-cols-1 gap-3">
                         {resourceCards.map((resourceCard) => (
-                            <a 
+                            <a
                                 key={resourceCard.id}
                                 href={resourceCard.href}
                                 target="_blank"
@@ -244,7 +244,7 @@ export default async function Onboarding({ searchParams }: OnboardingProps) {
                                                                                         <div className="relative">
                                         {/* Connecting line */}
                                         {index < steps.length - 1 && (
-                                            <div 
+                                            <div
                                                 className={`absolute top-10 left-1/2 transform -translate-x-1/2 w-0.5 h-8 transition-all duration-300 ${
                                                     index < currentStep ? "bg-primary" : "bg-border"
                                                 }`}
@@ -359,7 +359,7 @@ function NonOwnerOnboardingMessage() {
                                     <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M15 12a3 3 0 11-6 0 3 3 0 016 0z" />
                                 </svg>
                             </div>
-                            
+
                             <div className="space-y-3">
                                 <h1 className="text-2xl font-semibold text-foreground">
                                     Onboarding In Progress
@@ -390,8 +390,8 @@ function NonOwnerOnboardingMessage() {
                             <div className="space-y-3">
                                 <div className="text-xs text-muted-foreground leading-relaxed">
                                     Need help? Contact your organization owner or check out our{" "}
-                                    <a 
-                                        href="https://docs.sourcebot.dev/docs/overview" 
+                                    <a
+                                        href="https://docs.sourcebot.dev/docs/overview"
                                         className="text-primary hover:text-primary/80 underline transition-colors"
                                         target="_blank"
                                         rel="noopener"

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -190,7 +190,7 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
             // to the client.
             session.user = {
                 ...session.user,
-                // Propogate the userId to the session.
+                // Propagate the userId to the session.
                 id: token.userId,
             }
             return session;

--- a/packages/web/src/ee/features/billing/actions.ts
+++ b/packages/web/src/ee/features/billing/actions.ts
@@ -62,7 +62,7 @@ export const createOnboardingSubscription = async (domain: string) => sew(() =>
                 return {
                     statusCode: StatusCodes.BAD_REQUEST,
                     errorCode: ErrorCode.SUBSCRIPTION_ALREADY_EXISTS,
-                    message: "Attemped to create a trial subscription for an organization that already has an active subscription",
+                    message: "Attempted to create a trial subscription for an organization that already has an active subscription",
                 } satisfies ServiceError;
             }
 

--- a/packages/web/src/features/agents/review-agent/app.ts
+++ b/packages/web/src/features/agents/review-agent/app.ts
@@ -12,7 +12,7 @@ const rules = [
     "Do NOT provide general feedback, summaries, explanations of changes, or praises for making good additions.",
     "Do NOT provide any advice that is not actionable or directly related to the changes.",
     "Do NOT provide any comments or reviews on code that you believe is good, correct, or a good addition. Your job is only to identify issues and provide feedback on how to fix them.",
-    "If a review for a chunk contains different reviews at different line ranges, return a seperate review object for each line range.",
+    "If a review for a chunk contains different reviews at different line ranges, return a separate review object for each line range.",
     "Focus solely on offering specific, objective insights based on the given context and refrain from making broad comments about potential impacts on the system or question intentions behind the changes.",
     "Keep comments concise and to the point. Every comment must highlight a specific issue and provide a clear and actionable solution to the developer.",
     "If there are no issues found on a line range, do NOT respond with any comments. This includes comments such as \"No issues found\" or \"LGTM\"."

--- a/packages/web/src/features/agents/review-agent/nodes/generateDiffReviewPrompt.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/generateDiffReviewPrompt.ts
@@ -8,7 +8,7 @@ export const generateDiffReviewPrompt = async (diff: sourcebot_diff, context: so
     logger.debug("Executing generate_diff_review_prompt");
         
     const prompt = `
-    You are an expert software engineer that excells at reviewing code changes. Given the input, additional context, and rules defined below, review the code changes and provide a detailed review. The review you provide
+    You are an expert software engineer that excels at reviewing code changes. Given the input, additional context, and rules defined below, review the code changes and provide a detailed review. The review you provide
     must conform to all of the rules defined below. The output format of your review must conform to the output format defined below.
 
     # Input

--- a/packages/web/src/features/fileTree/components/pureFileTreePanel.tsx
+++ b/packages/web/src/features/fileTree/components/pureFileTreePanel.tsx
@@ -13,11 +13,11 @@ export type FileTreeNode = Omit<RawFileTreeNode, 'children'> & {
     children: FileTreeNode[];
 }
 
-const buildCollapsableTree = (tree: RawFileTreeNode): FileTreeNode => {
+const buildCollapsibleTree = (tree: RawFileTreeNode): FileTreeNode => {
     return {
         ...tree,
         isCollapsed: true,
-        children: tree.children.map(buildCollapsableTree),
+        children: tree.children.map(buildCollapsibleTree),
     }
 }
 
@@ -39,15 +39,15 @@ interface PureFileTreePanelProps {
 }
 
 export const PureFileTreePanel = ({ tree: _tree, path }: PureFileTreePanelProps) => {
-    const [tree, setTree] = useState<FileTreeNode>(buildCollapsableTree(_tree));
+    const [tree, setTree] = useState<FileTreeNode>(buildCollapsibleTree(_tree));
     const scrollAreaRef = useRef<HTMLDivElement>(null);
     const { navigateToPath } = useBrowseNavigation();
     const { repoName, revisionName } = useBrowseParams();
 
     // @note: When `_tree` changes, it indicates that a new tree has been loaded.
-    // In that case, we need to rebuild the collapsable tree.
+    // In that case, we need to rebuild the collapsible tree.
     useEffect(() => {
-        setTree(buildCollapsableTree(_tree));
+        setTree(buildCollapsibleTree(_tree));
     }, [_tree]);
 
     const setIsCollapsed = useCallback((path: string, isCollapsed: boolean) => {

--- a/schemas/v2/index.json
+++ b/schemas/v2/index.json
@@ -494,7 +494,7 @@
                                 "type": "string",
                                 "pattern": ".+"
                             },
-                            "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always exluded.",
+                            "description": "List of paths relative to the provided `path` to exclude from the index. .git, .hg, and .svn are always excluded.",
                             "default": [],
                             "examples": [
                                 [


### PR DESCRIPTION
Hey 👋 

Small PR to fix some typos, after I noticed the `Sourceobot` in the settings. I've also ran [typos](https://github.com/crate-ci/typos/) to fix some. I can add the `typos.toml` config if you're interested.

Also a small Makefile tweak to support PATH with spaces (e.g. `Application Support` on MacOS), with proper quotes.

Have a great day!

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Corrected multiple spelling and typographical errors across guides, READMEs, and user-facing documentation.
  * Updated descriptive text and error messages for clarity and accuracy.
  * Introduced a configuration file to improve typo detection and exclusion for specific words and files.

* **Style**
  * Fixed variable, function, and component naming inconsistencies for improved readability and correctness.
  * Applied minor formatting improvements to JSX elements.

* **Refactor**
  * Renamed a function and its references for consistent spelling in the file tree component.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->