### PR TITLE
Improved Gitlab All in case of many repositories

### DIFF
--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -165,7 +165,9 @@ export class RepoManager implements IRepoManager {
         });
 
         if (repos.length > 0) {
-            await this.scheduleRepoIndexingBulk(repos);
+            for (let i = 0; i < repos.length; i += 100) {
+                await this.scheduleRepoIndexingBulk(repos.slice(i, i + 100));
+            }
         }
     }
 

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -920,15 +920,17 @@ export const flagConnectionForSync = async (connectionId: number, domain: string
 export const flagReposForIndex = async (repoIds: number[], domain: string) => sew(() =>
     withAuth((userId) =>
         withOrgMembership(userId, domain, async ({ org }) => {
-            await prisma.repo.updateMany({
-                where: {
-                    id: { in: repoIds },
-                    orgId: org.id,
-                },
-                data: {
-                    repoIndexingStatus: RepoIndexingStatus.NEW,
-                }
-            });
+            for (let i = 0; i < repoIds.length; i += 1000) {
+                await prisma.repo.updateMany({
+                    where: {
+                        id: { in: repoIds.slice(i, i + 1000) },
+                        orgId: org.id,
+                    },
+                    data: {
+                        repoIndexingStatus: RepoIndexingStatus.NEW,
+                    }
+                });
+            }
 
             return {
                 success: true,

--- a/packages/web/src/initialize.ts
+++ b/packages/web/src/initialize.ts
@@ -67,16 +67,18 @@ const syncConnections = async (connections?: { [key: string]: ConnectionConfig }
             // Re-try any repos that failed to index.
             const failedRepos = currentConnection?.repos.filter(repo => repo.repo.repoIndexingStatus === RepoIndexingStatus.FAILED).map(repo => repo.repo.id) ?? [];
             if (failedRepos.length > 0) {
-                await prisma.repo.updateMany({
-                    where: {
-                        id: {
-                            in: failedRepos,
+                for (let i = 0; i < failedRepos.length; i += 100) {
+                    await prisma.repo.updateMany({
+                        where: {
+                            id: {
+                                in: failedRepos.slice(i, i + 100),
+                            }
+                        },
+                        data: {
+                            repoIndexingStatus: RepoIndexingStatus.NEW,
                         }
-                    },
-                    data: {
-                        repoIndexingStatus: RepoIndexingStatus.NEW,
-                    }
-                })
+                    })
+                }
             }
         }
     }


### PR DESCRIPTION
When there are many repositories on Giltab, doing actions in one hit would fail to API timeout.
This is a quick workaround/hack by using batches. 

Also when there a lot of repositories, just getting the list of them might be too much.

Ideally, I would like Sourcebot to add a repository as it finds it instead of handling the entire connection sync. Otherwise this process blocks other connections from syncing, and if it fails/breaks, then it has to start over.

Note: prisma also failing when there are too many connections, not sure what is the magical number is (sometimes 1000 resulted with errors too):
```
Invalid `prisma.userToOrg.findUnique()` invocation: Too many database connections opened: FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute Prisma Accelerate has built-in connection pooling to prevent such errors: https:/ / pris. ly/ client/ error-accelerate
( https://pris.ly/client/error-accelerate ) at Vn.handleRequestError
(/nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/node_modules/@prisma/client/runtime/library.js:121:7339) at Vn.handleAndLogRequestError
(/nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/node_modules/@prisma/client/runtime/library.js:121:6663) at Vn.request
(/nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/node_modules/@prisma/client/runtime/library.js:121:6370) at async l
(/nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/node_modules/@prisma/client/runtime/library.js:130:9617) at async el (/ nix/ store/ sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/ packages/ web/. next/ server/ chunks/ 616. js:1:39994 (
http://nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/packages/web/.next/server/chunks/616.js:1:39994
) ) at async ei (/ nix/ store/ sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/ packages/ web/. next/ server/ chunks/ 616. js:1:38467 ( http://nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/packages/web/.next/server/chunks/616.js:1:38467
) ) at async j (/ nix/ store/ sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/ packages/ web/. next/ server/ app/ [domain]/ page. js:1:4267 ( http://nix/store/sbwsr0wj0665xvgzg2iqim0c2qdynqkw-sourcebot/packages/web/.next/server/app/[domain]/page.js:1:4267
) ) { code: 'P2037',
clientVersion: '6.2.1',
meta: {
modelName: 'UserToOrg',
message: 'FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute'
}
}
```