### PR TITLE
Add ability to include/exclude connections in search contexts

### DIFF
--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -92,6 +92,13 @@
             ]
           ]
         },
+        "includeConnections": {
+          "type": "array",
+          "description": "List of connections to include in the search context.",
+          "items": {
+            "type": "string"
+          }
+        },
         "exclude": {
           "type": "array",
           "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -105,14 +112,18 @@
             ]
           ]
         },
+        "excludeConnections": {
+          "type": "array",
+          "description": "List of connections to exclude from the search context.",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": {
           "type": "string",
           "description": "Optional description of the search context that surfaces in the UI."
         }
       },
-      "required": [
-        "include"
-      ],
       "additionalProperties": false
     }
   },
@@ -211,6 +222,13 @@
                 ]
               ]
             },
+            "includeConnections": {
+              "type": "array",
+              "description": "List of connections to include in the search context.",
+              "items": {
+                "type": "string"
+              }
+            },
             "exclude": {
               "type": "array",
               "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -224,14 +242,18 @@
                 ]
               ]
             },
+            "excludeConnections": {
+              "type": "array",
+              "description": "List of connections to exclude from the search context.",
+              "items": {
+                "type": "string"
+              }
+            },
             "description": {
               "type": "string",
               "description": "Optional description of the search context that surfaces in the UI."
             }
           },
-          "required": [
-            "include"
-          ],
           "additionalProperties": false
         }
       },

--- a/docs/snippets/schemas/v3/searchContext.schema.mdx
+++ b/docs/snippets/schemas/v3/searchContext.schema.mdx
@@ -19,6 +19,13 @@
         ]
       ]
     },
+    "includeConnections": {
+      "type": "array",
+      "description": "List of connections to include in the search context.",
+      "items": {
+        "type": "string"
+      }
+    },
     "exclude": {
       "type": "array",
       "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -32,14 +39,18 @@
         ]
       ]
     },
+    "excludeConnections": {
+      "type": "array",
+      "description": "List of connections to exclude from the search context.",
+      "items": {
+        "type": "string"
+      }
+    },
     "description": {
       "type": "string",
       "description": "Optional description of the search context that surfaces in the UI."
     }
   },
-  "required": [
-    "include"
-  ],
   "additionalProperties": false
 }
 ```

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -91,6 +91,13 @@ const schema = {
             ]
           ]
         },
+        "includeConnections": {
+          "type": "array",
+          "description": "List of connections to include in the search context.",
+          "items": {
+            "type": "string"
+          }
+        },
         "exclude": {
           "type": "array",
           "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -104,14 +111,18 @@ const schema = {
             ]
           ]
         },
+        "excludeConnections": {
+          "type": "array",
+          "description": "List of connections to exclude from the search context.",
+          "items": {
+            "type": "string"
+          }
+        },
         "description": {
           "type": "string",
           "description": "Optional description of the search context that surfaces in the UI."
         }
       },
-      "required": [
-        "include"
-      ],
       "additionalProperties": false
     }
   },
@@ -210,6 +221,13 @@ const schema = {
                 ]
               ]
             },
+            "includeConnections": {
+              "type": "array",
+              "description": "List of connections to include in the search context.",
+              "items": {
+                "type": "string"
+              }
+            },
             "exclude": {
               "type": "array",
               "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -223,14 +241,18 @@ const schema = {
                 ]
               ]
             },
+            "excludeConnections": {
+              "type": "array",
+              "description": "List of connections to exclude from the search context.",
+              "items": {
+                "type": "string"
+              }
+            },
             "description": {
               "type": "string",
               "description": "Optional description of the search context that surfaces in the UI."
             }
           },
-          "required": [
-            "include"
-          ],
           "additionalProperties": false
         }
       },

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -114,11 +114,19 @@ export interface SearchContext {
   /**
    * List of repositories to include in the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.
    */
-  include: string[];
+  include?: string[];
+  /**
+   * List of connections to include in the search context.
+   */
+  includeConnections?: string[];
   /**
    * List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.
    */
   exclude?: string[];
+  /**
+   * List of connections to exclude from the search context.
+   */
+  excludeConnections?: string[];
   /**
    * Optional description of the search context that surfaces in the UI.
    */

--- a/packages/schemas/src/v3/searchContext.schema.ts
+++ b/packages/schemas/src/v3/searchContext.schema.ts
@@ -18,6 +18,13 @@ const schema = {
         ]
       ]
     },
+    "includeConnections": {
+      "type": "array",
+      "description": "List of connections to include in the search context.",
+      "items": {
+        "type": "string"
+      }
+    },
     "exclude": {
       "type": "array",
       "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -31,14 +38,18 @@ const schema = {
         ]
       ]
     },
+    "excludeConnections": {
+      "type": "array",
+      "description": "List of connections to exclude from the search context.",
+      "items": {
+        "type": "string"
+      }
+    },
     "description": {
       "type": "string",
       "description": "Optional description of the search context that surfaces in the UI."
     }
   },
-  "required": [
-    "include"
-  ],
   "additionalProperties": false
 } as const;
 export { schema as searchContextSchema };

--- a/packages/schemas/src/v3/searchContext.type.ts
+++ b/packages/schemas/src/v3/searchContext.type.ts
@@ -7,11 +7,19 @@ export interface SearchContext {
   /**
    * List of repositories to include in the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.
    */
-  include: string[];
+  include?: string[];
+  /**
+   * List of connections to include in the search context.
+   */
+  includeConnections?: string[];
   /**
    * List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.
    */
   exclude?: string[];
+  /**
+   * List of connections to exclude from the search context.
+   */
+  excludeConnections?: string[];
   /**
    * Optional description of the search context that surfaces in the UI.
    */

--- a/schemas/v3/searchContext.json
+++ b/schemas/v3/searchContext.json
@@ -17,6 +17,13 @@
                 ]
             ]
         },
+        "includeConnections": {
+            "type": "array",
+            "description": "List of connections to include in the search context.",
+            "items": {
+                "type": "string"
+            }
+        },
         "exclude": {
             "type": "array",
             "description": "List of repositories to exclude from the search context. Expected to be formatted as a URL without any leading http(s):// prefix (e.g., 'github.com/sourcebot-dev/sourcebot'). Glob patterns are supported.",
@@ -30,13 +37,17 @@
                 ]
             ]
         },
+        "excludeConnections": {
+            "type": "array",
+            "description": "List of connections to exclude from the search context.",
+            "items": {
+                "type": "string"
+            }
+        },
         "description": {
             "type": "string",
             "description": "Optional description of the search context that surfaces in the UI."
         }
     },
-    "required": [
-        "include"
-    ],
     "additionalProperties": false
 }


### PR DESCRIPTION
```
    "contexts": {
        "sourcebot": {
            "include": [
                "github.com/sourcebot-dev/sourcebot"
            ]
        },
        "nextjs": {
            "includeConnections": [
                "nextjs"
            ],
            "excludeConnections": [
                "sourcebot"
            ]
        }
    }
```