### PR TITLE
Add demo example cards

### DIFF
--- a/packages/shared/src/index.server.ts
+++ b/packages/shared/src/index.server.ts
@@ -12,6 +12,7 @@ export type {
 export {
     base64Decode,
     loadConfig,
+    loadJsonFile,
     isRemotePath,
 } from "./utils.js";
 export {

--- a/packages/shared/src/utils.ts
+++ b/packages/shared/src/utils.ts
@@ -3,6 +3,7 @@ import { indexSchema } from "@sourcebot/schemas/v3/index.schema";
 import { readFile } from 'fs/promises';
 import stripJsonComments from 'strip-json-comments';
 import { Ajv } from "ajv";
+import { z } from "zod";
 
 const ajv = new Ajv({
     validateFormats: false,
@@ -16,6 +17,66 @@ export const base64Decode = (base64: string): string => {
 
 export const isRemotePath = (path: string) => {
     return path.startsWith('https://') || path.startsWith('http://');
+}
+
+// TODO: Merge this with config loading logic which uses AJV
+export const loadJsonFile = async <T>(
+    filePath: string,
+    schema: any
+): Promise<T> => {
+    const fileContent = await (async () => {
+        if (isRemotePath(filePath)) {
+            const response = await fetch(filePath);
+            if (!response.ok) {
+                throw new Error(`Failed to fetch file ${filePath}: ${response.statusText}`);
+            }
+            return response.text();
+        } else {
+            // Retry logic for handling race conditions with mounted volumes
+            const maxAttempts = 5;
+            const retryDelayMs = 2000;
+            let lastError: Error | null = null;
+
+            for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+                try {
+                    return await readFile(filePath, {
+                        encoding: 'utf-8',
+                    });
+                } catch (error) {
+                    lastError = error as Error;
+                    
+                    // Only retry on ENOENT errors (file not found)
+                    if ((error as NodeJS.ErrnoException)?.code !== 'ENOENT') {
+                        throw error; // Throw immediately for non-ENOENT errors
+                    }
+                    
+                    // Log warning before retry (except on the last attempt)
+                    if (attempt < maxAttempts) {
+                        console.warn(`File not found, retrying in 2s... (Attempt ${attempt}/${maxAttempts})`);
+                        await new Promise(resolve => setTimeout(resolve, retryDelayMs));
+                    }
+                }
+            }
+            
+            // If we've exhausted all retries, throw the last ENOENT error
+            if (lastError) {
+                throw lastError;
+            }
+            
+            throw new Error('Failed to load file after all retry attempts');
+        }
+    })();
+
+    const parsedData = JSON.parse(stripJsonComments(fileContent));
+    
+    try {
+        return schema.parse(parsedData);
+    } catch (error) {
+        if (error instanceof z.ZodError) {
+            throw new Error(`File '${filePath}' is invalid: ${error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ')}`);
+        }
+        throw error;
+    }
 }
 
 export const loadConfig = async (configPath: string): Promise<SourcebotConfig> => {

--- a/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
@@ -5,11 +5,8 @@ import { ChatBox } from "@/features/chat/components/chatBox";
 import { ChatBoxToolbar } from "@/features/chat/components/chatBox/chatBoxToolbar";
 import { LanguageModelInfo } from "@/features/chat/types";
 import { useCreateNewChatThread } from "@/features/chat/useCreateNewChatThread";
-import { resetEditor } from "@/features/chat/utils";
-import { useDomain } from "@/hooks/useDomain";
 import { RepositoryQuery, SearchContextQuery } from "@/lib/types";
-import { getDisplayTime } from "@/lib/utils";
-import { Code, Database, FileIcon, FileText, Gamepad2, Globe, Layers, LucideIcon, Search, SearchIcon, Smartphone, Zap } from "lucide-react";
+import { Layers, Search } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { useState } from "react";
 import { SearchModeSelector, SearchModeSelectorProps } from "./toolbar";
@@ -18,14 +15,6 @@ import { CardContent } from "@/components/ui/card";
 import { useLocalStorage } from "usehooks-ts";
 import { ContextItem } from "@/features/chat/components/chatBox/contextSelector";
 import { DemoExamples, DemoSearchExample, DemoSearchContextExample } from "@/types";
-
-const Highlight = ({ children }: { children: React.ReactNode }) => {
-    return (
-        <span className="text-highlight">
-            {children}
-        </span>
-    )
-}
 
 interface AgenticSearchProps {
     searchModeSelectorProps: SearchModeSelectorProps;
@@ -40,101 +29,11 @@ interface AgenticSearchProps {
     demoExamples: DemoExamples | undefined;
 }
 
-const exampleSearches = [
-    {
-        id: "1",
-        title: "Show me examples of how useMemo is used",
-        description: "Find React performance optimization patterns",
-        icon: <Zap className="h-4 w-4" />,
-        category: "React",
-    },
-    {
-        id: "2",
-        title: "How do I implement authentication?",
-        description: "Explore auth patterns and best practices",
-        icon: <Database className="h-4 w-4" />,
-        category: "Security",
-    },
-    {
-        id: "3",
-        title: "Find API route handlers",
-        description: "Locate and analyze API endpoint implementations",
-        icon: <Globe className="h-4 w-4" />,
-        category: "Backend",
-    },
-    {
-        id: "4",
-        title: "Show me error handling patterns",
-        description: "Discover error boundary and exception handling",
-        icon: <FileText className="h-4 w-4" />,
-        category: "Best Practices",
-    },
-    {
-        id: "5",
-        title: "How are components structured?",
-        description: "Analyze component architecture and patterns",
-        icon: <Layers className="h-4 w-4" />,
-        category: "Architecture",
-    },
-]
-
-const searchContextsExample = [
-    {
-        id: "1",
-        displayName: "Next.js",
-        name: "nextjs",
-        description: "React framework for production",
-        icon: <Code className="h-5 w-5" />,
-        color: "bg-black text-white",
-    },
-    {
-        id: "2",
-        displayName: "React",
-        name: "react",
-        description: "JavaScript library for building UIs",
-        icon: <Code className="h-5 w-5" />,
-        color: "bg-blue-500 text-white",
-    },
-    {
-        id: "3",
-        displayName: "TypeScript",
-        name: "typescript",
-        description: "Typed JavaScript at scale",
-        icon: <FileText className="h-5 w-5" />,
-        color: "bg-blue-600 text-white",
-    },
-    {
-        id: "4",
-        displayName: "Tailwind CSS",
-        name: "tailwindcss",
-        description: "Utility-first CSS framework",
-        icon: <Layers className="h-5 w-5" />,
-        color: "bg-cyan-500 text-white",
-    },
-    {
-        id: "5",
-        displayName: "Godot Engine",
-        name: "godot",
-        description: "Open source game engine",
-        icon: <Gamepad2 className="h-5 w-5" />,
-        color: "bg-blue-400 text-white",
-    },
-    {
-        id: "6",
-        displayName: "React Native",
-        name: "react-native",
-        description: "Build mobile apps with React",
-        icon: <Smartphone className="h-5 w-5" />,
-        color: "bg-purple-500 text-white",
-    },
-]
-
 export const AgenticSearch = ({
     searchModeSelectorProps,
     languageModels,
     repos,
     searchContexts,
-    chatHistory,
     demoExamples,
 }: AgenticSearchProps) => {
     const { createNewChatThread, isLoading } = useCreateNewChatThread();
@@ -226,7 +125,7 @@ export const AgenticSearch = ({
                         <h3 className="text-lg font-semibold">Search Contexts</h3>
                     </div>
                     <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
-                        {demoExamples.searchContexts?.map((context) => {
+                        {demoExamples.searchContextExamples.map((context) => {
                             const searchContext = searchContexts.find((item) => item.name === context.name);
                             if (!searchContext) return null;
                             const isSelected = false; //selectedItems.some((item) => item.id === context.id)

--- a/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { ChatBox } from "@/features/chat/components/chatBox";
 import { ChatBoxToolbar } from "@/features/chat/components/chatBox/chatBoxToolbar";
@@ -10,40 +9,15 @@ import { resetEditor } from "@/features/chat/utils";
 import { useDomain } from "@/hooks/useDomain";
 import { RepositoryQuery, SearchContextQuery } from "@/lib/types";
 import { getDisplayTime } from "@/lib/utils";
-import { BrainIcon, FileIcon, LucideIcon, SearchIcon } from "lucide-react";
-import Link from "next/link";
-import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
-import { ReactEditor, useSlate } from "slate-react";
+import { Code, Database, FileIcon, FileText, Gamepad2, Globe, Layers, LucideIcon, Search, SearchIcon, Smartphone, Zap } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { useState } from "react";
 import { SearchModeSelector, SearchModeSelectorProps } from "./toolbar";
+import { Card } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
 import { useLocalStorage } from "usehooks-ts";
 import { ContextItem } from "@/features/chat/components/chatBox/contextSelector";
-
-// @todo: we should probably rename this to a different type since it sort-of clashes
-// with the Suggestion system we have built into the chat box.
-type SuggestionType = "understand" | "find" | "summarize";
-
-const suggestionTypes: Record<SuggestionType, {
-    icon: LucideIcon;
-    title: string;
-    description: string;
-}> = {
-    understand: {
-        icon: BrainIcon,
-        title: "Understand",
-        description: "Understand the codebase",
-    },
-    find: {
-        icon: SearchIcon,
-        title: "Find",
-        description: "Find the codebase",
-    },
-    summarize: {
-        icon: FileIcon,
-        title: "Summarize",
-        description: "Summarize the codebase",
-    },
-}
-
+import { DemoExamples, DemoSearchExample, DemoSearchContextExample } from "@/types";
 
 const Highlight = ({ children }: { children: React.ReactNode }) => {
     return (
@@ -52,59 +26,6 @@ const Highlight = ({ children }: { children: React.ReactNode }) => {
         </span>
     )
 }
-
-const suggestions: Record<SuggestionType, {
-    queryText: string;
-    queryNode?: ReactNode;
-    openRepoSelector?: boolean;
-}[]> = {
-    understand: [
-        {
-            queryText: "How does authentication work in this codebase?",
-            openRepoSelector: true,
-        },
-        {
-            queryText: "How are API endpoints structured and organized?",
-            openRepoSelector: true,
-        },
-        {
-            queryText: "How does the build and deployment process work?",
-            openRepoSelector: true,
-        },
-        {
-            queryText: "How is error handling implemented across the application?",
-            openRepoSelector: true,
-        },
-    ],
-    find: [
-        {
-            queryText: "Find examples of different logging libraries used throughout the codebase.",
-        },
-        {
-            queryText: "Find examples of potential security vulnerabilities or authentication issues.",
-        },
-        {
-            queryText: "Find examples of API endpoints and route handlers.",
-        }
-    ],
-    summarize: [
-        {
-            queryText: "Summarize the purpose of this file @file:",
-            queryNode: <span>Summarize the purpose of this file <Highlight>@file:</Highlight></span>
-        },
-        {
-            queryText: "Summarize the project structure and architecture.",
-            openRepoSelector: true,
-        },
-        {
-            queryText: "Provide a quick start guide for ramping up on this codebase.",
-            openRepoSelector: true,
-        }
-    ],
-}
-
-const MAX_RECENT_CHAT_HISTORY_COUNT = 10;
-
 
 interface AgenticSearchProps {
     searchModeSelectorProps: SearchModeSelectorProps;
@@ -116,7 +37,97 @@ interface AgenticSearchProps {
         createdAt: Date;
         name: string | null;
     }[];
+    demoExamples: DemoExamples | undefined;
 }
+
+const exampleSearches = [
+    {
+        id: "1",
+        title: "Show me examples of how useMemo is used",
+        description: "Find React performance optimization patterns",
+        icon: <Zap className="h-4 w-4" />,
+        category: "React",
+    },
+    {
+        id: "2",
+        title: "How do I implement authentication?",
+        description: "Explore auth patterns and best practices",
+        icon: <Database className="h-4 w-4" />,
+        category: "Security",
+    },
+    {
+        id: "3",
+        title: "Find API route handlers",
+        description: "Locate and analyze API endpoint implementations",
+        icon: <Globe className="h-4 w-4" />,
+        category: "Backend",
+    },
+    {
+        id: "4",
+        title: "Show me error handling patterns",
+        description: "Discover error boundary and exception handling",
+        icon: <FileText className="h-4 w-4" />,
+        category: "Best Practices",
+    },
+    {
+        id: "5",
+        title: "How are components structured?",
+        description: "Analyze component architecture and patterns",
+        icon: <Layers className="h-4 w-4" />,
+        category: "Architecture",
+    },
+]
+
+const searchContextsExample = [
+    {
+        id: "1",
+        displayName: "Next.js",
+        name: "nextjs",
+        description: "React framework for production",
+        icon: <Code className="h-5 w-5" />,
+        color: "bg-black text-white",
+    },
+    {
+        id: "2",
+        displayName: "React",
+        name: "react",
+        description: "JavaScript library for building UIs",
+        icon: <Code className="h-5 w-5" />,
+        color: "bg-blue-500 text-white",
+    },
+    {
+        id: "3",
+        displayName: "TypeScript",
+        name: "typescript",
+        description: "Typed JavaScript at scale",
+        icon: <FileText className="h-5 w-5" />,
+        color: "bg-blue-600 text-white",
+    },
+    {
+        id: "4",
+        displayName: "Tailwind CSS",
+        name: "tailwindcss",
+        description: "Utility-first CSS framework",
+        icon: <Layers className="h-5 w-5" />,
+        color: "bg-cyan-500 text-white",
+    },
+    {
+        id: "5",
+        displayName: "Godot Engine",
+        name: "godot",
+        description: "Open source game engine",
+        icon: <Gamepad2 className="h-5 w-5" />,
+        color: "bg-blue-400 text-white",
+    },
+    {
+        id: "6",
+        displayName: "React Native",
+        name: "react-native",
+        description: "Build mobile apps with React",
+        icon: <Smartphone className="h-5 w-5" />,
+        color: "bg-purple-500 text-white",
+    },
+]
 
 export const AgenticSearch = ({
     searchModeSelectorProps,
@@ -124,41 +135,23 @@ export const AgenticSearch = ({
     repos,
     searchContexts,
     chatHistory,
+    demoExamples,
 }: AgenticSearchProps) => {
-    const [selectedSuggestionType, _setSelectedSuggestionType] = useState<SuggestionType | undefined>(undefined);
     const { createNewChatThread, isLoading } = useCreateNewChatThread();
-    const dropdownRef = useRef<HTMLDivElement>(null);
-    const editor = useSlate();
     const [selectedItems, setSelectedItems] = useLocalStorage<ContextItem[]>("selectedContextItems", [], { initializeWithValue: false });
-    const domain = useDomain();
     const [isContextSelectorOpen, setIsContextSelectorOpen] = useState(false);
 
-    const setSelectedSuggestionType = useCallback((type: SuggestionType | undefined) => {
-        _setSelectedSuggestionType(type);
-        if (type) {
-            ReactEditor.focus(editor);
-        }
-    }, [editor, _setSelectedSuggestionType]);
+    const handleExampleClick = (example: DemoSearchExample) => {
+        console.log(example);
+    }
 
-    // Close dropdown when clicking outside
-    useEffect(() => {
-        function handleClickOutside(event: MouseEvent) {
-            if (
-                !dropdownRef.current?.contains(event.target as Node)
-            ) {
-                setSelectedSuggestionType(undefined);
-            }
-        }
-
-        document.addEventListener("mousedown", handleClickOutside)
-        return () => document.removeEventListener("mousedown", handleClickOutside)
-    }, [setSelectedSuggestionType]);
+    const handleContextClick = (context: DemoSearchContextExample) => {
+        console.log(context);
+    }
 
     return (
-        <div className="flex flex-col items-center w-full max-w-[800px]">
-            <div
-                className="mt-4 w-full border rounded-md shadow-sm"
-            >
+        <div className="flex flex-col items-center w-full">
+            <div className="mt-4 w-full border rounded-md shadow-sm max-w-[800px]">
                 <ChatBox
                     onSubmit={(children) => {
                         createNewChatThread(children, selectedItems);
@@ -187,111 +180,93 @@ export const AgenticSearch = ({
                             className="ml-auto"
                         />
                     </div>
-
-                    {selectedSuggestionType && (
-                        <div
-                            ref={dropdownRef}
-                            className="w-full absolute top-10 z-10 drop-shadow-2xl bg-background border rounded-md p-2"
-                        >
-                            <p className="text-muted-foreground text-sm mb-2">
-                                {suggestionTypes[selectedSuggestionType].title}
-                            </p>
-                            {suggestions[selectedSuggestionType].map(({ queryText, queryNode, openRepoSelector }, index) => (
-                                <div
-                                    key={index}
-                                    className="flex flex-row items-center gap-2 cursor-pointer hover:bg-muted rounded-md px-1 py-0.5"
-                                    onClick={() => {
-                                        resetEditor(editor);
-                                        editor.insertText(queryText);
-                                        setSelectedSuggestionType(undefined);
-
-                                        if (openRepoSelector) {
-                                            setIsContextSelectorOpen(true);
-                                        } else {
-                                            ReactEditor.focus(editor);
-                                        }
-                                    }}
-                                >
-                                    <SearchIcon className="w-4 h-4" />
-                                    {queryNode ?? queryText}
-                                </div>
-                            ))}
-                        </div>
-                    )}
                 </div>
             </div>
-            <div className="flex flex-col items-center w-fit gap-6 mt-8 relative">
-                <div className="flex flex-row items-center gap-4">
-                    {Object.entries(suggestionTypes).map(([type, suggestion], index) => (
-                        <ExampleButton
-                            key={index}
-                            Icon={suggestion.icon}
-                            title={suggestion.title}
-                            onClick={() => {
-                                setSelectedSuggestionType(type as SuggestionType);
-                            }}
-                        />
-                    ))}
-                </div>
-            </div>
-            {chatHistory.length > 0 && (
-                <div className="flex flex-col items-center w-[80%]">
-                    <Separator className="my-6" />
-                    <span className="font-semibold mb-2">Recent conversations</span>
-                    <div
-                        className="flex flex-col gap-1 w-full"
-                    >
-                        {chatHistory
-                            .slice(0, MAX_RECENT_CHAT_HISTORY_COUNT)
-                            .map((chat) => (
-                                <Link
-                                    key={chat.id}
-                                    className="flex flex-row items-center justify-between gap-1 w-full rounded-md hover:bg-muted px-2 py-0.5 cursor-pointer group"
-                                    href={`/${domain}/chat/${chat.id}`}
-                                >
-                                    <span className="text-sm text-muted-foreground group-hover:text-foreground">
-                                        {chat.name ?? "Untitled Chat"}
-                                    </span>
-                                    <span className="text-sm text-muted-foreground group-hover:text-foreground">
-                                        {getDisplayTime(chat.createdAt)}
-                                    </span>
-                                </Link>
-                            ))}
+
+            {demoExamples && (
+            <div className="w-full mt-8 grid grid-cols-1 lg:grid-cols-2 gap-8 px-4 max-w-[1200px]">
+                {/* Example Searches Column */}
+                <div className="space-y-4">
+                    <div className="flex items-center gap-2 mb-6">
+                        <Search className="h-5 w-5 text-muted-foreground" />
+                        <h3 className="text-lg font-semibold">Example Searches</h3>
                     </div>
-                    {chatHistory.length > MAX_RECENT_CHAT_HISTORY_COUNT && (
-                        <Link
-                            href={`/${domain}/chat`}
-                            className="text-sm text-link hover:underline mt-6"
-                        >
-                            View all
-                        </Link>
-                    )}
+                    <div className="space-y-3">
+                        {demoExamples.searchExamples.map((example) => (
+                            <Card
+                                key={example.id}
+                                className="cursor-pointer transition-all duration-200 hover:shadow-md hover:border-primary/50 group"
+                                onClick={() => handleExampleClick(example)}
+                            >
+                                <CardContent className="p-4">
+                                    <div className="flex items-start gap-3">
+                                        <div className="flex-shrink-0 p-2 rounded-lg bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
+                                            {example.icon}
+                                        </div>
+                                        <div className="flex-1 min-w-0">
+                                            <h4 className="font-medium text-sm mb-1 group-hover:text-primary transition-colors">
+                                                {example.title}
+                                            </h4>
+                                            <p className="text-xs text-muted-foreground mb-2">{example.description}</p>
+                                            <Badge className="text-xs">
+                                                {example.category}
+                                            </Badge>
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        ))}
+                    </div>
                 </div>
+
+                {/* Search Contexts Column */}
+                <div className="space-y-4">
+                    <div className="flex items-center gap-2 mb-6">
+                        <Layers className="h-5 w-5 text-muted-foreground" />
+                        <h3 className="text-lg font-semibold">Search Contexts</h3>
+                    </div>
+                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
+                        {demoExamples.searchContexts?.map((context) => {
+                            const searchContext = searchContexts.find((item) => item.name === context.name);
+                            if (!searchContext) return null;
+                            const isSelected = false; //selectedItems.some((item) => item.id === context.id)
+
+                            const numRepos = searchContext.repoNames.length;
+                            return (
+                                <Card
+                                    key={context.id}
+                                    className={`cursor-pointer transition-all duration-200 hover:shadow-md group ${isSelected ? "border-primary bg-primary/5 shadow-sm" : "hover:border-primary/50"
+                                        }`}
+                                    onClick={() => handleContextClick(context)}
+                                >
+                                    <CardContent className="p-4">
+                                        <div className="flex items-start gap-3">
+                                            <div
+                                                className={`flex-shrink-0 p-2 rounded-lg ${context.color} transition-transform group-hover:scale-105`}
+                                            >
+                                                {context.icon}
+                                            </div>
+                                            <div className="flex-1 min-w-0">
+                                                <h4
+                                                    className={`font-medium text-sm mb-1 transition-colors ${isSelected ? "text-primary" : "group-hover:text-primary"
+                                                        }`}
+                                                >
+                                                    {context.displayName}
+                                                </h4>
+                                                <p className="text-xs text-muted-foreground mb-2">{context.description}</p>
+                                                <Badge className="text-xs">
+                                                    {numRepos} repos
+                                                </Badge>
+                                            </div>
+                                        </div>
+                                    </CardContent>
+                                </Card>
+                            )
+                        })}
+                    </div>
+                </div>
+            </div>
             )}
-        </div>
-    )
-}
-
-
-interface ExampleButtonProps {
-    Icon: LucideIcon;
-    title: string;
-    onClick: () => void;
-}
-
-const ExampleButton = ({
-    Icon,
-    title,
-    onClick,
-}: ExampleButtonProps) => {
-    return (
-        <Button
-            variant="secondary"
-            onClick={onClick}
-            className="h-9"
-        >
-            <Icon className="w-4 h-4" />
-            {title}
-        </Button>
+        </div >
     )
 }

--- a/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
@@ -6,15 +6,12 @@ import { ChatBoxToolbar } from "@/features/chat/components/chatBox/chatBoxToolba
 import { LanguageModelInfo } from "@/features/chat/types";
 import { useCreateNewChatThread } from "@/features/chat/useCreateNewChatThread";
 import { RepositoryQuery, SearchContextQuery } from "@/lib/types";
-import { Layers, Search } from "lucide-react";
-import { Badge } from "@/components/ui/badge";
 import { useState } from "react";
 import { SearchModeSelector, SearchModeSelectorProps } from "./toolbar";
-import { Card } from "@/components/ui/card";
-import { CardContent } from "@/components/ui/card";
 import { useLocalStorage } from "usehooks-ts";
 import { ContextItem } from "@/features/chat/components/chatBox/contextSelector";
-import { DemoExamples, DemoSearchExample, DemoSearchContextExample } from "@/types";
+import { DemoExamples } from "@/types";
+import { AskSourcebotDemoCards } from "./askSourcebotDemoCards";
 
 interface AgenticSearchProps {
     searchModeSelectorProps: SearchModeSelectorProps;
@@ -39,14 +36,6 @@ export const AgenticSearch = ({
     const { createNewChatThread, isLoading } = useCreateNewChatThread();
     const [selectedItems, setSelectedItems] = useLocalStorage<ContextItem[]>("selectedContextItems", [], { initializeWithValue: false });
     const [isContextSelectorOpen, setIsContextSelectorOpen] = useState(false);
-
-    const handleExampleClick = (example: DemoSearchExample) => {
-        console.log(example);
-    }
-
-    const handleContextClick = (context: DemoSearchContextExample) => {
-        console.log(context);
-    }
 
     return (
         <div className="flex flex-col items-center w-full">
@@ -83,88 +72,13 @@ export const AgenticSearch = ({
             </div>
 
             {demoExamples && (
-                <div className="w-full mt-8 grid grid-cols-1 lg:grid-cols-2 gap-8 px-4 max-w-[1200px]">
-                    {/* Example Searches Column */}
-                    <div className="space-y-4">
-                        <div className="flex items-center gap-2 mb-6">
-                            <Search className="h-5 w-5 text-muted-foreground" />
-                            <h3 className="text-lg font-semibold">Example Searches</h3>
-                        </div>
-                        <div className="space-y-3">
-                            {demoExamples.searchExamples.map((example) => (
-                                <Card
-                                    key={example.id}
-                                    className="cursor-pointer transition-all duration-200 hover:shadow-md hover:border-primary/50 group"
-                                    onClick={() => handleExampleClick(example)}
-                                >
-                                    <CardContent className="p-4">
-                                        <div className="flex items-start gap-3">
-                                            <div className="flex-shrink-0 p-2 rounded-lg bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
-                                                {example.icon}
-                                            </div>
-                                            <div className="flex-1 min-w-0">
-                                                <h4 className="font-medium text-sm mb-1 group-hover:text-primary transition-colors">
-                                                    {example.title}
-                                                </h4>
-                                                <p className="text-xs text-muted-foreground mb-2">{example.description}</p>
-                                                <Badge className="text-xs">
-                                                    {example.category}
-                                                </Badge>
-                                            </div>
-                                        </div>
-                                    </CardContent>
-                                </Card>
-                            ))}
-                        </div>
-                    </div>
-
-                    {/* Search Contexts Column */}
-                    <div className="space-y-4">
-                        <div className="flex items-center gap-2 mb-6">
-                            <Layers className="h-5 w-5 text-muted-foreground" />
-                            <h3 className="text-lg font-semibold">Search Contexts</h3>
-                        </div>
-                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
-                            {demoExamples.searchContextExamples.map((context) => {
-                                const searchContext = searchContexts.find((item) => item.name === context.name);
-                                if (!searchContext) return null;
-                                const isSelected = false; //selectedItems.some((item) => item.id === context.id)
-
-                                const numRepos = searchContext.repoNames.length;
-                                return (
-                                    <Card
-                                        key={context.id}
-                                        className={`cursor-pointer transition-all duration-200 hover:shadow-md group ${isSelected ? "border-primary bg-primary/5 shadow-sm" : "hover:border-primary/50"
-                                            }`}
-                                        onClick={() => handleContextClick(context)}
-                                    >
-                                        <CardContent className="p-4">
-                                            <div className="flex items-start gap-3">
-                                                <div
-                                                    className={`flex-shrink-0 p-2 rounded-lg ${context.color} transition-transform group-hover:scale-105`}
-                                                >
-                                                    {context.icon}
-                                                </div>
-                                                <div className="flex-1 min-w-0">
-                                                    <h4
-                                                        className={`font-medium text-sm mb-1 transition-colors ${isSelected ? "text-primary" : "group-hover:text-primary"
-                                                            }`}
-                                                    >
-                                                        {context.displayName}
-                                                    </h4>
-                                                    <p className="text-xs text-muted-foreground mb-2">{context.description}</p>
-                                                    <Badge className="text-xs">
-                                                        {numRepos} repos
-                                                    </Badge>
-                                                </div>
-                                            </div>
-                                        </CardContent>
-                                    </Card>
-                                )
-                            })}
-                        </div>
-                    </div>
-                </div>
+                <AskSourcebotDemoCards
+                    demoExamples={demoExamples}
+                    selectedItems={selectedItems}
+                    setSelectedItems={setSelectedItems}
+                    searchContexts={searchContexts}
+                    repos={repos}
+                />
             )}
         </div >
     )

--- a/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/agenticSearch.tsx
@@ -83,88 +83,88 @@ export const AgenticSearch = ({
             </div>
 
             {demoExamples && (
-            <div className="w-full mt-8 grid grid-cols-1 lg:grid-cols-2 gap-8 px-4 max-w-[1200px]">
-                {/* Example Searches Column */}
-                <div className="space-y-4">
-                    <div className="flex items-center gap-2 mb-6">
-                        <Search className="h-5 w-5 text-muted-foreground" />
-                        <h3 className="text-lg font-semibold">Example Searches</h3>
-                    </div>
-                    <div className="space-y-3">
-                        {demoExamples.searchExamples.map((example) => (
-                            <Card
-                                key={example.id}
-                                className="cursor-pointer transition-all duration-200 hover:shadow-md hover:border-primary/50 group"
-                                onClick={() => handleExampleClick(example)}
-                            >
-                                <CardContent className="p-4">
-                                    <div className="flex items-start gap-3">
-                                        <div className="flex-shrink-0 p-2 rounded-lg bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
-                                            {example.icon}
-                                        </div>
-                                        <div className="flex-1 min-w-0">
-                                            <h4 className="font-medium text-sm mb-1 group-hover:text-primary transition-colors">
-                                                {example.title}
-                                            </h4>
-                                            <p className="text-xs text-muted-foreground mb-2">{example.description}</p>
-                                            <Badge className="text-xs">
-                                                {example.category}
-                                            </Badge>
-                                        </div>
-                                    </div>
-                                </CardContent>
-                            </Card>
-                        ))}
-                    </div>
-                </div>
-
-                {/* Search Contexts Column */}
-                <div className="space-y-4">
-                    <div className="flex items-center gap-2 mb-6">
-                        <Layers className="h-5 w-5 text-muted-foreground" />
-                        <h3 className="text-lg font-semibold">Search Contexts</h3>
-                    </div>
-                    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
-                        {demoExamples.searchContextExamples.map((context) => {
-                            const searchContext = searchContexts.find((item) => item.name === context.name);
-                            if (!searchContext) return null;
-                            const isSelected = false; //selectedItems.some((item) => item.id === context.id)
-
-                            const numRepos = searchContext.repoNames.length;
-                            return (
+                <div className="w-full mt-8 grid grid-cols-1 lg:grid-cols-2 gap-8 px-4 max-w-[1200px]">
+                    {/* Example Searches Column */}
+                    <div className="space-y-4">
+                        <div className="flex items-center gap-2 mb-6">
+                            <Search className="h-5 w-5 text-muted-foreground" />
+                            <h3 className="text-lg font-semibold">Example Searches</h3>
+                        </div>
+                        <div className="space-y-3">
+                            {demoExamples.searchExamples.map((example) => (
                                 <Card
-                                    key={context.id}
-                                    className={`cursor-pointer transition-all duration-200 hover:shadow-md group ${isSelected ? "border-primary bg-primary/5 shadow-sm" : "hover:border-primary/50"
-                                        }`}
-                                    onClick={() => handleContextClick(context)}
+                                    key={example.id}
+                                    className="cursor-pointer transition-all duration-200 hover:shadow-md hover:border-primary/50 group"
+                                    onClick={() => handleExampleClick(example)}
                                 >
                                     <CardContent className="p-4">
                                         <div className="flex items-start gap-3">
-                                            <div
-                                                className={`flex-shrink-0 p-2 rounded-lg ${context.color} transition-transform group-hover:scale-105`}
-                                            >
-                                                {context.icon}
+                                            <div className="flex-shrink-0 p-2 rounded-lg bg-primary/10 text-primary group-hover:bg-primary group-hover:text-primary-foreground transition-colors">
+                                                {example.icon}
                                             </div>
                                             <div className="flex-1 min-w-0">
-                                                <h4
-                                                    className={`font-medium text-sm mb-1 transition-colors ${isSelected ? "text-primary" : "group-hover:text-primary"
-                                                        }`}
-                                                >
-                                                    {context.displayName}
+                                                <h4 className="font-medium text-sm mb-1 group-hover:text-primary transition-colors">
+                                                    {example.title}
                                                 </h4>
-                                                <p className="text-xs text-muted-foreground mb-2">{context.description}</p>
+                                                <p className="text-xs text-muted-foreground mb-2">{example.description}</p>
                                                 <Badge className="text-xs">
-                                                    {numRepos} repos
+                                                    {example.category}
                                                 </Badge>
                                             </div>
                                         </div>
                                     </CardContent>
                                 </Card>
-                            )
-                        })}
+                            ))}
+                        </div>
+                    </div>
+
+                    {/* Search Contexts Column */}
+                    <div className="space-y-4">
+                        <div className="flex items-center gap-2 mb-6">
+                            <Layers className="h-5 w-5 text-muted-foreground" />
+                            <h3 className="text-lg font-semibold">Search Contexts</h3>
+                        </div>
+                        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-1 xl:grid-cols-2 gap-3">
+                            {demoExamples.searchContextExamples.map((context) => {
+                                const searchContext = searchContexts.find((item) => item.name === context.name);
+                                if (!searchContext) return null;
+                                const isSelected = false; //selectedItems.some((item) => item.id === context.id)
+
+                                const numRepos = searchContext.repoNames.length;
+                                return (
+                                    <Card
+                                        key={context.id}
+                                        className={`cursor-pointer transition-all duration-200 hover:shadow-md group ${isSelected ? "border-primary bg-primary/5 shadow-sm" : "hover:border-primary/50"
+                                            }`}
+                                        onClick={() => handleContextClick(context)}
+                                    >
+                                        <CardContent className="p-4">
+                                            <div className="flex items-start gap-3">
+                                                <div
+                                                    className={`flex-shrink-0 p-2 rounded-lg ${context.color} transition-transform group-hover:scale-105`}
+                                                >
+                                                    {context.icon}
+                                                </div>
+                                                <div className="flex-1 min-w-0">
+                                                    <h4
+                                                        className={`font-medium text-sm mb-1 transition-colors ${isSelected ? "text-primary" : "group-hover:text-primary"
+                                                            }`}
+                                                    >
+                                                        {context.displayName}
+                                                    </h4>
+                                                    <p className="text-xs text-muted-foreground mb-2">{context.description}</p>
+                                                    <Badge className="text-xs">
+                                                        {numRepos} repos
+                                                    </Badge>
+                                                </div>
+                                            </div>
+                                        </CardContent>
+                                    </Card>
+                                )
+                            })}
+                        </div>
                     </div>
                 </div>
-            </div>
             )}
         </div >
     )

--- a/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
@@ -101,7 +101,7 @@ export const AskSourcebotDemoCards = ({
     }
 
     return (
-        <div className="w-full mt-8 space-y-12 px-4 max-w-[1200px]">
+        <div className="w-full mt-8 space-y-12 px-4 max-w-[1000px]">
             {/* Search Context Row */}
             <div className="space-y-4">
                 <div className="text-center mb-8">

--- a/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
@@ -1,0 +1,211 @@
+'use client';
+
+import Image from "next/image";
+import { Search, LibraryBigIcon, Code, Layers } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+import { CardContent } from "@/components/ui/card";
+import { ContextItem, RepoContextItem, SearchContextItem } from "@/features/chat/components/chatBox/contextSelector";
+import { DemoExamples, DemoSearchExample, DemoSearchContextExample, DemoSearchContext } from "@/types";
+import { cn, getCodeHostIcon } from "@/lib/utils";
+import { RepositoryQuery, SearchContextQuery } from "@/lib/types";
+
+interface AskSourcebotDemoCardsProps {
+    demoExamples: DemoExamples;
+    selectedItems: ContextItem[];
+    setSelectedItems: (items: ContextItem[]) => void;
+    searchContexts: SearchContextQuery[];
+    repos: RepositoryQuery[];
+}
+
+export const AskSourcebotDemoCards = ({
+    demoExamples,
+    selectedItems,
+    setSelectedItems,
+    searchContexts,
+    repos,
+}: AskSourcebotDemoCardsProps) => {
+    const handleExampleClick = (example: DemoSearchExample) => {
+        if (example.url) {
+            window.open(example.url, '_blank');
+        }
+    }
+
+    const getContextIcon = (context: DemoSearchContext, size: number = 20) => {
+        const sizeClass = size === 12 ? "h-3 w-3" : "h-5 w-5";
+        
+        if (context.type === "set") {
+            return <LibraryBigIcon className={cn(sizeClass, "text-muted-foreground")} />;
+        }
+        
+        if (context.codeHostType) {
+            const codeHostIcon = getCodeHostIcon(context.codeHostType);
+            if (codeHostIcon) {
+                return (
+                    <Image
+                        src={codeHostIcon.src}
+                        alt={`${context.codeHostType} icon`}
+                        width={size}
+                        height={size}
+                        className={cn(sizeClass, codeHostIcon.className)}
+                    />
+                );
+            }
+        }
+        
+        return <Code className={cn(sizeClass, "text-muted-foreground")} />;
+    }
+
+    const handleContextClick = (demoSearchContexts: DemoSearchContext[], contextExample: DemoSearchContextExample) => {
+        const context = demoSearchContexts.find((context) => context.id === contextExample.searchContext)
+        if (!context) {
+            console.error(`Search context ${contextExample.searchContext} not found on handleContextClick`);
+            return;
+        }
+
+        if (context.type === "set") {
+            const searchContext = searchContexts.find((item) => item.name === context.value);
+            if (!searchContext) {
+                console.error(`Search context ${context.value} not found on handleContextClick`);
+                return;
+            }
+            
+            const isSelected = selectedItems.some(
+                (selected) => selected.type === 'context' && selected.value === context.value
+            );
+            const newSelectedItems = isSelected
+                ? selectedItems.filter(
+                    (selected) => !(selected.type === 'context' && selected.value === context.value)
+                )
+                : [...selectedItems, { type: 'context', value: context.value, name: context.displayName, repoCount: searchContext.repoNames.length } as SearchContextItem];
+
+            setSelectedItems(newSelectedItems);
+        } else {
+            const repo = repos.find((repo) => repo.repoName === context.value);
+            if (!repo) {
+                console.error(`Repo ${context.value} not found on handleContextClick`);
+                return;
+            }
+
+            const isSelected = selectedItems.some(
+                (selected) => selected.type === 'repo' && selected.value === context.value
+            );
+            const newSelectedItems = isSelected
+                ? selectedItems.filter(
+                    (selected) => !(selected.type === 'repo' && selected.value === context.value)
+                )
+                : [...selectedItems, { type: 'repo', value: context.value, name: context.displayName, codeHostType: repo.codeHostType } as RepoContextItem];
+
+            setSelectedItems(newSelectedItems);
+        }
+    }
+
+    return (
+        <div className="w-full mt-8 space-y-12 px-4 max-w-[1200px]">
+            {/* Search Context Row */}
+            <div className="space-y-4">
+                <div className="text-center mb-8">
+                    <div className="flex items-center justify-center gap-2 mb-2">
+                        <Layers className="h-5 w-5 text-muted-foreground" />
+                        <h3 className="text-lg font-semibold">Search Context</h3>
+                    </div>
+                    <p className="text-sm text-muted-foreground">Select the context you want to ask questions about</p>
+                </div>
+                <div className="flex flex-wrap justify-center gap-3">
+                    {demoExamples.searchContextExamples.map((contextExample) => {
+                        const context = demoExamples.searchContexts.find((context) => context.id === contextExample.searchContext)
+                        if (!context) {
+                            console.error(`Search context ${contextExample.searchContext} not found on handleContextClick`);
+                            return;
+                        }
+
+                        const isSelected = selectedItems.some(
+                            (selected) => (selected.type === 'context' && selected.value === context.value) ||
+                                (selected.type === 'repo' && selected.value === context.value)
+                        );
+
+                        const searchContext = searchContexts.find((item) => item.name === context.value);
+                        const numRepos = searchContext ? searchContext.repoNames.length : undefined;
+                        return (
+                            <Card
+                                key={context.value}
+                                className={`cursor-pointer transition-all duration-200 hover:shadow-md hover:scale-105 group w-full max-w-[280px] ${isSelected ? "border-primary bg-primary/5 shadow-sm" : "hover:border-primary/50"
+                                    }`}
+                                onClick={() => handleContextClick(demoExamples.searchContexts, contextExample)}
+                            >
+                                <CardContent className="p-4">
+                                    <div className="flex items-start gap-3">
+                                        <div
+                                            className={`flex-shrink-0 p-2 rounded-lg transition-transform group-hover:scale-105`}
+                                        >
+                                            {getContextIcon(context)}
+                                        </div>
+                                        <div className="flex-1 min-w-0">
+                                            <div className="flex items-center gap-2 mb-1">
+                                                <h4
+                                                    className={`font-medium text-sm transition-colors ${isSelected ? "text-primary" : "group-hover:text-primary"
+                                                        }`}
+                                                >
+                                                    {context.displayName}
+                                                </h4>
+                                                {numRepos && (
+                                                    <Badge className="text-[10px] px-1.5 py-0.5 h-4">
+                                                        {numRepos} repos
+                                                    </Badge>
+                                                )}
+                                            </div>
+                                            <p className="text-xs text-muted-foreground">{contextExample.description}</p>
+                                        </div>
+                                    </div>
+                                </CardContent>
+                            </Card>
+                        )
+                    })}
+                </div>
+            </div>
+
+            {/* Example Searches Row */}
+            <div className="space-y-4">
+                <div className="text-center mb-8">
+                    <div className="flex items-center justify-center gap-2 mb-2">
+                        <Search className="h-5 w-5 text-muted-foreground" />
+                        <h3 className="text-lg font-semibold">Community Ask Results</h3>
+                    </div>
+                    <p className="text-sm text-muted-foreground">Check out these featured ask results from the community</p>
+                </div>
+                <div className="flex flex-wrap justify-center gap-3">
+                    {demoExamples.searchExamples.map((example) => {
+                        const searchContexts = demoExamples.searchContexts.filter((context) => example.searchContext.includes(context.id))
+                        return (
+                        <Card
+                            key={example.url}
+                            className="cursor-pointer transition-all duration-200 hover:shadow-md hover:scale-105 hover:border-primary/50 group w-full max-w-[350px]"
+                            onClick={() => handleExampleClick(example)}
+                        >
+                            <CardContent className="p-4">
+                                <div className="space-y-3">
+                                    <div className="flex items-center justify-between">
+                                        {searchContexts.map((context) => (
+                                            <Badge key={context.value} variant="secondary" className="text-[10px] px-1.5 py-0.5 h-4 flex items-center gap-1">
+                                                {getContextIcon(context, 12)}
+                                                {context.displayName}
+                                            </Badge>
+                                        ))}
+                                    </div>
+                                    <div className="space-y-1">
+                                        <h4 className="font-semibold text-sm group-hover:text-primary transition-colors line-clamp-2">
+                                            {example.title}
+                                        </h4>
+                                        <p className="text-xs text-muted-foreground line-clamp-3 leading-relaxed">
+                                            {example.description}
+                                        </p>
+                                    </div>
+                                </div>
+                            </CardContent>
+                        </Card>
+                    )})}
+                </div>
+            </div>
+        </div>
+    );
+}; 

--- a/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/askSourcebotDemoCards.tsx
@@ -116,7 +116,7 @@ export const AskSourcebotDemoCards = ({
                         const context = demoExamples.searchContexts.find((context) => context.id === contextExample.searchContext)
                         if (!context) {
                             console.error(`Search context ${contextExample.searchContext} not found on handleContextClick`);
-                            return;
+                            return null;
                         }
 
                         const isSelected = selectedItems.some(

--- a/packages/web/src/app/[domain]/components/homepage/index.tsx
+++ b/packages/web/src/app/[domain]/components/homepage/index.tsx
@@ -10,6 +10,7 @@ import { SearchMode } from "./toolbar";
 import { CustomSlateEditor } from "@/features/chat/customSlateEditor";
 import { setSearchModeCookie } from "@/actions";
 import { useCallback, useState } from "react";
+import { DemoExamples } from "@/types";
 
 interface HomepageProps {
     initialRepos: RepositoryQuery[];
@@ -21,6 +22,7 @@ interface HomepageProps {
         name: string | null;
     }[];
     initialSearchMode: SearchMode;
+    demoExamples: DemoExamples | undefined;
 }
 
 
@@ -30,6 +32,7 @@ export const Homepage = ({
     languageModels,
     chatHistory,
     initialSearchMode,
+    demoExamples,
 }: HomepageProps) => {
     const [searchMode, setSearchMode] = useState<SearchMode>(initialSearchMode);
     const isAgenticSearchEnabled = languageModels.length > 0;
@@ -86,6 +89,7 @@ export const Homepage = ({
                         repos={initialRepos}
                         searchContexts={searchContexts}
                         chatHistory={chatHistory}
+                        demoExamples={demoExamples}
                     />
                 </CustomSlateEditor>
             )}

--- a/packages/web/src/app/[domain]/page.tsx
+++ b/packages/web/src/app/[domain]/page.tsx
@@ -51,7 +51,14 @@ export default async function Home({ params: { domain } }: { params: { domain: s
         searchModeCookie?.value === "precise"
     ) ? searchModeCookie.value : models.length > 0 ? "agentic" : "precise";
 
-    const demoExamples = env.SOURCEBOT_DEMO_EXAMPLES_PATH ? await loadJsonFile<DemoExamples>(env.SOURCEBOT_DEMO_EXAMPLES_PATH, demoExamplesSchema) : undefined;
+    const demoExamples = env.SOURCEBOT_DEMO_EXAMPLES_PATH ? await (async () => {
+        try {
+            return await loadJsonFile<DemoExamples>(env.SOURCEBOT_DEMO_EXAMPLES_PATH!, demoExamplesSchema);
+        } catch (error) {
+            console.error('Failed to load demo examples:', error);
+            return undefined;
+        }
+    })() : undefined;
 
     return (
         <div className="flex flex-col items-center overflow-hidden min-h-screen">

--- a/packages/web/src/app/[domain]/page.tsx
+++ b/packages/web/src/app/[domain]/page.tsx
@@ -2,7 +2,7 @@ import { getRepos, getSearchContexts } from "@/actions";
 import { Footer } from "@/app/components/footer";
 import { getOrgFromDomain } from "@/data/org";
 import { getConfiguredLanguageModelsInfo, getUserChatHistory } from "@/features/chat/actions";
-import { isServiceError, loadDemoExamples } from "@/lib/utils";
+import { isServiceError } from "@/lib/utils";
 import { Homepage } from "./components/homepage";
 import { NavigationMenu } from "./components/navigationMenu";
 import { PageNotFound } from "./components/pageNotFound";
@@ -12,6 +12,8 @@ import { auth } from "@/auth";
 import { cookies } from "next/headers";
 import { SEARCH_MODE_COOKIE_NAME } from "@/lib/constants";
 import { env } from "@/env.mjs";
+import { loadJsonFile } from "@sourcebot/shared";
+import { DemoExamples, demoExamplesSchema } from "@/types";
 
 export default async function Home({ params: { domain } }: { params: { domain: string } }) {
     const org = await getOrgFromDomain(domain);
@@ -49,7 +51,7 @@ export default async function Home({ params: { domain } }: { params: { domain: s
         searchModeCookie?.value === "precise"
     ) ? searchModeCookie.value : models.length > 0 ? "agentic" : "precise";
 
-    const demoExamples = undefined; //await loadDemoExamples(env.SOURCEBOT_DEMO_EXAMPLES_PATH);
+    const demoExamples = env.SOURCEBOT_DEMO_EXAMPLES_PATH ? await loadJsonFile<DemoExamples>(env.SOURCEBOT_DEMO_EXAMPLES_PATH, demoExamplesSchema) : undefined;
 
     return (
         <div className="flex flex-col items-center overflow-hidden min-h-screen">

--- a/packages/web/src/app/[domain]/page.tsx
+++ b/packages/web/src/app/[domain]/page.tsx
@@ -2,7 +2,7 @@ import { getRepos, getSearchContexts } from "@/actions";
 import { Footer } from "@/app/components/footer";
 import { getOrgFromDomain } from "@/data/org";
 import { getConfiguredLanguageModelsInfo, getUserChatHistory } from "@/features/chat/actions";
-import { isServiceError } from "@/lib/utils";
+import { isServiceError, loadDemoExamples } from "@/lib/utils";
 import { Homepage } from "./components/homepage";
 import { NavigationMenu } from "./components/navigationMenu";
 import { PageNotFound } from "./components/pageNotFound";
@@ -11,6 +11,7 @@ import { ServiceErrorException } from "@/lib/serviceError";
 import { auth } from "@/auth";
 import { cookies } from "next/headers";
 import { SEARCH_MODE_COOKIE_NAME } from "@/lib/constants";
+import { env } from "@/env.mjs";
 
 export default async function Home({ params: { domain } }: { params: { domain: string } }) {
     const org = await getOrgFromDomain(domain);
@@ -48,6 +49,8 @@ export default async function Home({ params: { domain } }: { params: { domain: s
         searchModeCookie?.value === "precise"
     ) ? searchModeCookie.value : models.length > 0 ? "agentic" : "precise";
 
+    const demoExamples = undefined; //await loadDemoExamples(env.SOURCEBOT_DEMO_EXAMPLES_PATH);
+
     return (
         <div className="flex flex-col items-center overflow-hidden min-h-screen">
             <NavigationMenu
@@ -61,6 +64,7 @@ export default async function Home({ params: { domain } }: { params: { domain: s
                 languageModels={models}
                 chatHistory={chatHistory}
                 initialSearchMode={initialSearchMode}
+                demoExamples={demoExamples}
             />
             <Footer />
         </div>

--- a/packages/web/src/env.mjs
+++ b/packages/web/src/env.mjs
@@ -129,6 +129,8 @@ export const env = createEnv({
         DEBUG_WRITE_CHAT_MESSAGES_TO_FILE: booleanSchema.default('false'),
 
         LANGFUSE_SECRET_KEY: z.string().optional(),
+
+        SOURCEBOT_DEMO_EXAMPLES_PATH: z.string().optional(),
     },
     // @NOTE: Please make sure of the following:
     // - Make sure you destructure all client variables in

--- a/packages/web/src/features/chat/components/chatBox/chatBox.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBox.tsx
@@ -284,7 +284,7 @@ export const ChatBox = ({
         >
             <Editable
                 className="w-full focus-visible:outline-none focus-visible:ring-0 bg-background text-base disabled:cursor-not-allowed disabled:opacity-50 md:text-sm"
-                placeholder="Ask, plan, or search your codebase. @mention files to refine your query."
+                placeholder="Ask questions about the selected search contexts. @mention files to refine your query."
                 renderElement={renderElement}
                 renderLeaf={renderLeaf}
                 onKeyDown={onKeyDown}

--- a/packages/web/src/features/chat/components/chatBox/chatBox.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBox.tsx
@@ -162,7 +162,7 @@ export const ChatBox = ({
         if (isSubmitDisabled) {
             if (isSubmitDisabledReason === "no-repos-selected") {
                 toast({
-                    description: "⚠️ One or more repositories or search contexts must be selected.",
+                    description: "⚠️ You must select at least one search context",
                     variant: "destructive",
                 });
                 onContextSelectorOpenChanged(true);
@@ -339,7 +339,7 @@ export const ChatBox = ({
                                 <TooltipContent>
                                     <div className="flex flex-row items-center">
                                         <TriangleAlertIcon className="h-4 w-4 text-warning mr-1" />
-                                        <span className="text-destructive">One or more repositories or search contexts must be selected.</span>
+                                        <span className="text-destructive">You must select at least one search context</span>
                                     </div>
                                 </TooltipContent>
                             )}

--- a/packages/web/src/features/chat/components/chatBox/contextSelector.tsx
+++ b/packages/web/src/features/chat/components/chatBox/contextSelector.tsx
@@ -194,7 +194,7 @@ export const ContextSelector = React.forwardRef<
                 >
                     <Command>
                         <CommandInput
-                            placeholder="Search contexts and repos..."
+                            placeholder="Search contexts..."
                             onKeyDown={handleInputKeyDown}
                         />
                         <CommandList ref={scrollContainerRef}>

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -23,7 +23,7 @@ export const demoSearchContextExampleSchema = z.object({
 
 export const demoExamplesSchema = z.object({
     searchExamples: demoSearchExampleSchema.array(),
-    searchContexts: demoSearchContextExampleSchema.array(),
+    searchContextExamples: demoSearchContextExampleSchema.array(),
 })
 
 export type OrgMetadata = z.infer<typeof orgMetadataSchema>;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -4,4 +4,29 @@ export const orgMetadataSchema = z.object({
     anonymousAccessEnabled: z.boolean().optional(),
 })
 
+export const demoSearchExampleSchema = z.object({
+    id: z.string(),
+    title: z.string(),
+    description: z.string(),
+    icon: z.string(),
+    category: z.string(),
+})
+
+export const demoSearchContextExampleSchema = z.object({
+    id: z.string(),
+    displayName: z.string(),
+    name: z.string(),
+    description: z.string(),
+    icon: z.string(),
+    color: z.string(),
+})
+
+export const demoExamplesSchema = z.object({
+    searchExamples: demoSearchExampleSchema.array(),
+    searchContexts: demoSearchContextExampleSchema.array(),
+})
+
 export type OrgMetadata = z.infer<typeof orgMetadataSchema>;
+export type DemoExamples = z.infer<typeof demoExamplesSchema>;
+export type DemoSearchExample = z.infer<typeof demoSearchExampleSchema>;
+export type DemoSearchContextExample = z.infer<typeof demoSearchContextExampleSchema>;

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -4,29 +4,34 @@ export const orgMetadataSchema = z.object({
     anonymousAccessEnabled: z.boolean().optional(),
 })
 
+export const demoSearchContextSchema = z.object({
+    id: z.number(),
+    displayName: z.string(),
+    value: z.string(),
+    type: z.enum(["repo", "set"]),
+    codeHostType: z.string().optional(),
+})
+
 export const demoSearchExampleSchema = z.object({
-    id: z.string(),
     title: z.string(),
     description: z.string(),
-    icon: z.string(),
-    category: z.string(),
+    url: z.string(),
+    searchContext: z.array(z.number())
 })
 
 export const demoSearchContextExampleSchema = z.object({
-    id: z.string(),
-    displayName: z.string(),
-    name: z.string(),
+    searchContext: z.number(),
     description: z.string(),
-    icon: z.string(),
-    color: z.string(),
 })
 
 export const demoExamplesSchema = z.object({
+    searchContexts: demoSearchContextSchema.array(),
     searchExamples: demoSearchExampleSchema.array(),
     searchContextExamples: demoSearchContextExampleSchema.array(),
 })
 
 export type OrgMetadata = z.infer<typeof orgMetadataSchema>;
 export type DemoExamples = z.infer<typeof demoExamplesSchema>;
+export type DemoSearchContext = z.infer<typeof demoSearchContextSchema>;
 export type DemoSearchExample = z.infer<typeof demoSearchExampleSchema>;
 export type DemoSearchContextExample = z.infer<typeof demoSearchContextExampleSchema>;


### PR DESCRIPTION
- Adds `SOURCEBOT_DEMO_EXAMPLES_PATH` which points to a JSON that defines demo cards. This includes search contexts to highlight, as well as example ask sessions
- Renders the contents of this JSON on the Ask Sourcebot homepage. Search context cards are wired into the selector system
- TODO:
  - Need to add back a way to view search history if the user is authed from the homepage


https://github.com/user-attachments/assets/735d49e0-6beb-466b-a3c4-196ec973c557



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced interactive demo cards on the homepage, allowing users to explore search contexts and community example queries.
  * Added support for loading demo example data from a configurable JSON file, validated for correctness.
  * Homepage and search components now display demo examples when available.

* **Improvements**
  * Streamlined the Agentic Search interface by removing suggestion dropdowns and recent chat history, focusing on demo-driven exploration.
  * Updated warning messages to clarify that at least one search context must be selected.
  * Enhanced chat input and context selector placeholders for clearer user guidance.

* **Configuration**
  * Added a new environment variable to specify the path for demo example data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->