### PR TITLE
fix(github): Fix issue with `users` not getting picked up in GitHub config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed issue where `users` specified in a GitHub config were not getting picked up when a `token` is also specified. [#428](https://github.com/sourcebot-dev/sourcebot/pull/428)
+
 ## [4.6.2] - 2025-07-31
 
 ### Changed


### PR DESCRIPTION
## Problem
Consider the following config:
```jsonc
{
    "$schema": "./schemas/v3/index.json",
    "connections": {
        "sourcebot": {
            "type": "github",
            "users": [
                "brendan-kellam",
                "torvalds"
            ],
            "token": {
                "env": "GITHUB_SB_TOKEN"
            }
        }
    }
}
```

Assume `GITHUB_SB_TOKEN` was scoped to my (`brendan-kellam`) user. We would expect to get all public & private repos from `brendan-kellam`, and all public repos from `torvalds`. In actuality, we were **just** getting the repos for `brendan-kellam`.

Why? We were using `listForAuthenticatedUser` when a token is specified, which only lists the repositories for the currently authenticated user (`brendan-kellam`), even when a `username` is specified. So, when we called this for `torvalds`, we were actually getting repos for `brendan-kellam`.

## Solution

[This discussion](https://github.com/orgs/community/discussions/24382#discussioncomment-3243958) recommended using the `search/repositories` endpoint, so I switched to that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue where users specified in GitHub configuration were not recognized when a token was provided.
* **Documentation**
  * Updated changelog to include details of the fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->