### PR TITLE
feat(gerrit): Multi-branch indexing support for Gerrit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added multi-branch indexing support for Gerrit. [#433](https://github.com/sourcebot-dev/sourcebot/pull/433)
+
 ## [4.6.3] - 2025-08-04
 
 ### Fixed

--- a/docs/docs/features/search/multi-branch-indexing.mdx
+++ b/docs/docs/features/search/multi-branch-indexing.mdx
@@ -89,6 +89,6 @@ Additional info:
 | Bitbucket Cloud | ✅ |
 | Bitbucket Data Center | ✅ |
 | Gitea | ✅ |
-| Gerrit | ❌ |
+| Gerrit | ✅ |
 | Generic git host | ✅ |
 

--- a/docs/snippets/schemas/v3/connection.schema.mdx
+++ b/docs/snippets/schemas/v3/connection.schema.mdx
@@ -638,6 +638,47 @@
             }
           },
           "additionalProperties": false
+        },
+        "revisions": {
+          "type": "object",
+          "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+          "properties": {
+            "branches": {
+              "type": "array",
+              "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                [
+                  "main",
+                  "release/*"
+                ],
+                [
+                  "**"
+                ]
+              ],
+              "default": []
+            },
+            "tags": {
+              "type": "array",
+              "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                [
+                  "latest",
+                  "v2.*.*"
+                ],
+                [
+                  "**"
+                ]
+              ],
+              "default": []
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/docs/snippets/schemas/v3/gerrit.schema.mdx
+++ b/docs/snippets/schemas/v3/gerrit.schema.mdx
@@ -59,6 +59,47 @@
         }
       },
       "additionalProperties": false
+    },
+    "revisions": {
+      "type": "object",
+      "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+      "properties": {
+        "branches": {
+          "type": "array",
+          "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "main",
+              "release/*"
+            ],
+            [
+              "**"
+            ]
+          ],
+          "default": []
+        },
+        "tags": {
+          "type": "array",
+          "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "latest",
+              "v2.*.*"
+            ],
+            [
+              "**"
+            ]
+          ],
+          "default": []
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -901,6 +901,47 @@
                     }
                   },
                   "additionalProperties": false
+                },
+                "revisions": {
+                  "type": "object",
+                  "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+                  "properties": {
+                    "branches": {
+                      "type": "array",
+                      "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "examples": [
+                        [
+                          "main",
+                          "release/*"
+                        ],
+                        [
+                          "**"
+                        ]
+                      ],
+                      "default": []
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "examples": [
+                        [
+                          "latest",
+                          "v2.*.*"
+                        ],
+                        [
+                          "**"
+                        ]
+                      ],
+                      "default": []
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -310,6 +310,8 @@ export const compileGerritConfig = async (
                     'zoekt.public': marshalBool(true),
                     'zoekt.display-name': repoDisplayName,
                 },
+                branches: config.revisions?.branches ?? undefined,
+                tags: config.revisions?.tags ?? undefined,
             } satisfies RepoMetadata,
         };
 

--- a/packages/schemas/src/v3/connection.schema.ts
+++ b/packages/schemas/src/v3/connection.schema.ts
@@ -637,6 +637,47 @@ const schema = {
             }
           },
           "additionalProperties": false
+        },
+        "revisions": {
+          "type": "object",
+          "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+          "properties": {
+            "branches": {
+              "type": "array",
+              "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                [
+                  "main",
+                  "release/*"
+                ],
+                [
+                  "**"
+                ]
+              ],
+              "default": []
+            },
+            "tags": {
+              "type": "array",
+              "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+              "items": {
+                "type": "string"
+              },
+              "examples": [
+                [
+                  "latest",
+                  "v2.*.*"
+                ],
+                [
+                  "**"
+                ]
+              ],
+              "default": []
+            }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/packages/schemas/src/v3/connection.type.ts
+++ b/packages/schemas/src/v3/connection.type.ts
@@ -244,6 +244,7 @@ export interface GerritConnectionConfig {
      */
     hidden?: boolean;
   };
+  revisions?: GitRevisions;
 }
 export interface BitbucketConnectionConfig {
   /**

--- a/packages/schemas/src/v3/gerrit.schema.ts
+++ b/packages/schemas/src/v3/gerrit.schema.ts
@@ -58,6 +58,47 @@ const schema = {
         }
       },
       "additionalProperties": false
+    },
+    "revisions": {
+      "type": "object",
+      "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+      "properties": {
+        "branches": {
+          "type": "array",
+          "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "main",
+              "release/*"
+            ],
+            [
+              "**"
+            ]
+          ],
+          "default": []
+        },
+        "tags": {
+          "type": "array",
+          "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "latest",
+              "v2.*.*"
+            ],
+            [
+              "**"
+            ]
+          ],
+          "default": []
+        }
+      },
+      "additionalProperties": false
     }
   },
   "required": [

--- a/packages/schemas/src/v3/gerrit.type.ts
+++ b/packages/schemas/src/v3/gerrit.type.ts
@@ -27,4 +27,18 @@ export interface GerritConnectionConfig {
      */
     hidden?: boolean;
   };
+  revisions?: GitRevisions;
+}
+/**
+ * The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.
+ */
+export interface GitRevisions {
+  /**
+   * List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.
+   */
+  branches?: string[];
+  /**
+   * List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.
+   */
+  tags?: string[];
 }

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -900,6 +900,47 @@ const schema = {
                     }
                   },
                   "additionalProperties": false
+                },
+                "revisions": {
+                  "type": "object",
+                  "description": "The revisions (branches, tags) that should be included when indexing. The default branch (HEAD) is always indexed. A maximum of 64 revisions can be indexed, with any additional revisions being ignored.",
+                  "properties": {
+                    "branches": {
+                      "type": "array",
+                      "description": "List of branches to include when indexing. For a given repo, only the branches that exist on the repo's remote *and* match at least one of the provided `branches` will be indexed. The default branch (HEAD) is always indexed. Glob patterns are supported. A maximum of 64 branches can be indexed, with any additional branches being ignored.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "examples": [
+                        [
+                          "main",
+                          "release/*"
+                        ],
+                        [
+                          "**"
+                        ]
+                      ],
+                      "default": []
+                    },
+                    "tags": {
+                      "type": "array",
+                      "description": "List of tags to include when indexing. For a given repo, only the tags that exist on the repo's remote *and* match at least one of the provided `tags` will be indexed. Glob patterns are supported. A maximum of 64 tags can be indexed, with any additional tags being ignored.",
+                      "items": {
+                        "type": "string"
+                      },
+                      "examples": [
+                        [
+                          "latest",
+                          "v2.*.*"
+                        ],
+                        [
+                          "**"
+                        ]
+                      ],
+                      "default": []
+                    }
+                  },
+                  "additionalProperties": false
                 }
               },
               "required": [

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -369,6 +369,7 @@ export interface GerritConnectionConfig {
      */
     hidden?: boolean;
   };
+  revisions?: GitRevisions;
 }
 export interface BitbucketConnectionConfig {
   /**

--- a/schemas/v3/gerrit.json
+++ b/schemas/v3/gerrit.json
@@ -57,6 +57,9 @@
                 }
             },
             "additionalProperties": false
+        },
+        "revisions": {
+            "$ref": "./shared.json#/definitions/GitRevisions"
         }
     },
     "required": [


### PR DESCRIPTION
This PR adds support for multi-branch indexing to Gerrit.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multi-branch and multi-tag indexing in Gerrit connections, allowing users to specify which branches and tags to include during repository indexing.
  * Updated documentation to reflect Gerrit's new multi-branch indexing capability and revised platform support indicators.

* **Documentation**
  * Enhanced schema and configuration documentation to detail the new "revisions" property for Gerrit, including usage examples and constraints. 
  * Updated changelog to document the addition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->