### PR TITLE
chore(docs): Remove dead links to terms / privacy. Also change some MIT -> FSL references.

### DIFF
--- a/docs/docs/features/agents/review-agent.mdx
+++ b/docs/docs/features/agents/review-agent.mdx
@@ -10,7 +10,7 @@ codebase that the agent may fetch to perform the review.
 
 This agent provides codebase-aware reviews for your PRs. For each diff, this agent fetches relevant context from Sourcebot and feeds it into an LLM for a detailed review of your changes.
 
-The AI Code Review Agent is [open source](https://github.com/sourcebot-dev/sourcebot/tree/main/packages/web/src/features/agents/review-agent) and packaged in [Sourcebot](https://github.com/sourcebot-dev/sourcebot). To get started using this agent, [deploy Sourcebot](/docs/deployment-guide)
+The AI Code Review Agent is [fair source](https://github.com/sourcebot-dev/sourcebot/tree/main/packages/web/src/features/agents/review-agent) and packaged in [Sourcebot](https://github.com/sourcebot-dev/sourcebot). To get started using this agent, [deploy Sourcebot](/docs/deployment-guide)
 and then follow the configuration instructions below.
 
 ![AI Code Review Agent Example](/images/review_agent_example.png)

--- a/docs/docs/license-key.mdx
+++ b/docs/docs/license-key.mdx
@@ -7,7 +7,7 @@ sidebarTitle: License key
 If you'd like a trial license, [reach out](https://www.sourcebot.dev/contact) and we'll send one over within 24 hours
 </Note>
 
-All core Sourcebot features are available in Sourcebot OSS (MIT Licensed) without any limits. Some additional features require a license key. See the [pricing page](https://www.sourcebot.dev/pricing) for more details.
+All core Sourcebot features are available [FSL licensed](https://github.com/sourcebot-dev/sourcebot/blob/main/LICENSE.md#functional-source-license-version-11-alv2-future-license) without any limits. Some additional features require a license key. See the [pricing page](https://www.sourcebot.dev/pricing) for more details.
 
 
 ## Activating a license key

--- a/docs/docs/overview.mdx
+++ b/docs/docs/overview.mdx
@@ -22,7 +22,7 @@ title: "Overview"
     - **Self-hosted:** Deploy it in minutes using our official [docker container](https://github.com/sourcebot-dev/sourcebot/pkgs/container/sourcebot). All of your data stays on your machine.
     - **Modern design:** Light/Dark mode, vim keybindings, keyboard shortcuts, syntax highlighting, etc.
     - **Scalable:** Scales to millions of lines of code.
-    - **Open-source:** Core features are MIT licensed.
+    - **Fair-source:** Core features are [FSL licensed](https://github.com/sourcebot-dev/sourcebot/blob/main/LICENSE.md#functional-source-license-version-11-alv2-future-license).
   </Accordion>
 </AccordionGroup>
 
@@ -196,7 +196,7 @@ Sourcebot does not support horizontal scaling at this time, but it is on our roa
 ## License key
 ---
 
-Sourcebot's core features are available under an [MIT license](https://github.com/sourcebot-dev/sourcebot/blob/HEAD/LICENSE) without any limits. Some [additional features](/docs/license-key#feature-availability) such as SSO and code navigation require a [license key](/docs/license-key).
+Sourcebot's core features are available under an [FSL licensed](https://github.com/sourcebot-dev/sourcebot/blob/main/LICENSE.md#functional-source-license-version-11-alv2-future-license) without any limits. Some [additional features](/docs/license-key#feature-availability) such as SSO and code navigation require a [license key](/docs/license-key).
 
 <CardGroup cols={2}>
     <Card title="Pricing page" href="https://www.sourcebot.dev/pricing" />

--- a/packages/web/src/app/components/footer.tsx
+++ b/packages/web/src/app/components/footer.tsx
@@ -8,8 +8,6 @@ export function Footer() {
         <Separator orientation="vertical" className="h-4" />
         <Link href="https://docs.sourcebot.dev" className="text-gray-400 text-sm hover:underline">Docs</Link>
         <Separator orientation="vertical" className="h-4" />
-        <Link href="https://sourcebot.dev/terms" className="text-gray-400 text-sm hover:underline">Terms</Link>
-        <Separator orientation="vertical" className="h-4" />
         <Link href="https://sourcebot.dev/security" className="text-gray-400 text-sm hover:underline">Security</Link>
         <Separator orientation="vertical" className="h-4" />
         <Link href="https://www.sourcebot.dev/contact" target="_blank" className="text-gray-400 text-sm hover:underline">Contact Us</Link>

--- a/packages/web/src/app/components/securityCard.tsx
+++ b/packages/web/src/app/components/securityCard.tsx
@@ -39,7 +39,7 @@ export default function SecurityCard() {
                         <CheckCircle className="h-5 w-5 text-[#9D5CFF] mr-3 mt-0.5 flex-shrink-0" />
                         <div className="text-sm text-foregroundSecondary text-left">
                             <div className="flex items-center">
-                                <span>Sourcebot is open-source and trusted by thousands of developers</span>
+                                <span>Sourcebot is fair-source and trusted by thousands of developers</span>
                                 <Link
                                     href="https://github.com/sourcebot-dev/sourcebot"
                                     target="_blank"

--- a/packages/web/src/app/login/components/loginForm.tsx
+++ b/packages/web/src/app/login/components/loginForm.tsx
@@ -6,11 +6,7 @@ import { SourcebotLogo } from "@/app/components/sourcebotLogo";
 import { AuthMethodSelector } from "@/app/components/authMethodSelector";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import Link from "next/link";
-import { env } from "@/env.mjs";
 import type { AuthProvider } from "@/lib/authProviders";
-
-const TERMS_OF_SERVICE_URL = "https://sourcebot.dev/terms";
-const PRIVACY_POLICY_URL = "https://sourcebot.dev/privacy";
 
 interface LoginFormProps {
     callbackUrl?: string;
@@ -96,9 +92,6 @@ export const LoginForm = ({ callbackUrl, error, providers, context }: LoginFormP
                     }
                 </p>
             </Card>
-            {env.NEXT_PUBLIC_SOURCEBOT_CLOUD_ENVIRONMENT !== undefined && (
-                <p className="text-xs text-muted-foreground mt-8">By signing in, you agree to the <Link className="underline" href={TERMS_OF_SERVICE_URL} target="_blank">Terms of Service</Link> and <Link className="underline" href={PRIVACY_POLICY_URL} target="_blank">Privacy Policy</Link>.</p>
-            )}
         </div>
     )
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated all references to Sourcebot's licensing from "open source" or "MIT licensed" to "fair source" or "FSL licensed," with updated links to the Functional Source License.
* **Style**
  * Updated footer and security card text to reflect new licensing terminology.
* **Bug Fixes**
  * Removed Terms of Service and Privacy Policy disclaimer from the login form.
  * Removed the "Terms" link from the footer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->