### PR TITLE
feat(ask_sb): Add `headers` param to config to allow users to specify custom headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added multi-branch indexing support for Gerrit. [#433](https://github.com/sourcebot-dev/sourcebot/pull/433)
 - [ask sb] Added `reasoningEffort` option to OpenAI provider. [#446](https://github.com/sourcebot-dev/sourcebot/pull/446)
+- [ask db] Added `headers` option to all providers. [#449](https://github.com/sourcebot-dev/sourcebot/pull/449)
 
 ### Fixed
 - Removed prefix from structured log output. [#443](https://github.com/sourcebot-dev/sourcebot/pull/443)

--- a/docs/docs/configuration/language-model-providers.mdx
+++ b/docs/docs/configuration/language-model-providers.mdx
@@ -324,8 +324,34 @@ The OpenAI compatible provider allows you to use any model that is compatible wi
 }
 ```
 
+# Custom headers
 
-## Schema reference
+You can pass custom headers to the language model provider by using the `headers` parameter. Header values can either be a string or a environment variable. Headers are supported for all providers.
+
+```json wrap icon="code" Example config with custom headers
+{
+    "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/v3/index.json",
+    "models": [
+        {
+            // ... provider, model, displayName, etc...
+
+            // Key-value pairs of headers
+            "headers": {
+                // Header values can be passed as a environment variable...
+                "my-secret-header": {
+                    "env": "MY_SECRET_HEADER_ENV_VAR"
+                },
+
+                // ... or directly as a string.
+                "my-non-secret-header": "plaintextvalue"
+            }
+        }
+    ]
+}
+```
+
+
+# Schema reference
 
 <Accordion title="Reference">
 [schemas/v3/languageModel.json](https://github.com/sourcebot-dev/sourcebot/blob/main/schemas/v3/languageModel.json)

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -1298,6 +1298,49 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1322,7 +1365,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1350,13 +1392,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1385,7 +1471,6 @@
                 "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1413,7 +1498,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
               },
               "apiVersion": {
                 "type": "string",
@@ -1424,6 +1510,49 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1448,7 +1577,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1476,13 +1604,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1507,7 +1679,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1535,13 +1706,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1582,7 +1797,6 @@
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1610,13 +1824,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1659,7 +1917,6 @@
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1687,13 +1944,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1718,7 +2019,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1746,13 +2046,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1783,7 +2127,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1811,7 +2154,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
@@ -1828,6 +2172,49 @@
                   "medium",
                   "high"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1852,7 +2239,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1880,7 +2266,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
               },
               "baseUrl": {
                 "type": "string",
@@ -1890,6 +2277,49 @@
                 "examples": [
                   "http://localhost:8080/v1"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1915,7 +2345,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1943,13 +2372,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1978,7 +2451,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2006,13 +2478,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2114,6 +2630,49 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2138,7 +2697,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2166,13 +2724,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2201,7 +2803,6 @@
                 "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2229,7 +2830,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
               },
               "apiVersion": {
                 "type": "string",
@@ -2240,6 +2842,49 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2264,7 +2909,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2292,13 +2936,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2323,7 +3011,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2351,13 +3038,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2398,7 +3129,6 @@
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2426,13 +3156,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2475,7 +3249,6 @@
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2503,13 +3276,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2534,7 +3351,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2562,13 +3378,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2599,7 +3459,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2627,7 +3486,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
@@ -2644,6 +3504,49 @@
                   "medium",
                   "high"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2668,7 +3571,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2696,7 +3598,8 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
               },
               "baseUrl": {
                 "type": "string",
@@ -2706,6 +3609,49 @@
                 "examples": [
                   "http://localhost:8080/v1"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2731,7 +3677,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2759,13 +3704,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2794,7 +3783,6 @@
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2822,13 +3810,57 @@
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -1303,7 +1303,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1340,7 +1340,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1405,7 +1406,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1442,7 +1443,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1515,7 +1517,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1552,7 +1554,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1617,7 +1620,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1654,7 +1657,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1719,7 +1723,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1756,7 +1760,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1837,7 +1842,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1874,7 +1879,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1957,7 +1963,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1994,7 +2000,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2059,7 +2066,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2096,7 +2103,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2177,7 +2185,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2214,7 +2222,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2282,7 +2291,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2319,7 +2328,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2385,7 +2395,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2422,7 +2432,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2491,7 +2502,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2528,7 +2539,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2635,7 +2647,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2672,7 +2684,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2737,7 +2750,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2774,7 +2787,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2847,7 +2861,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2884,7 +2898,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2949,7 +2964,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2986,7 +3001,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3051,7 +3067,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3088,7 +3104,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3169,7 +3186,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3206,7 +3223,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3289,7 +3307,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3326,7 +3344,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3391,7 +3410,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3428,7 +3447,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3509,7 +3529,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3546,7 +3566,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3614,7 +3635,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3651,7 +3672,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3717,7 +3739,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3754,7 +3776,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3823,7 +3846,7 @@
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3860,7 +3883,8 @@
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [

--- a/docs/snippets/schemas/v3/languageModel.schema.mdx
+++ b/docs/snippets/schemas/v3/languageModel.schema.mdx
@@ -100,7 +100,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -137,7 +137,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -202,7 +203,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -239,7 +240,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -312,7 +314,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -349,7 +351,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -414,7 +417,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -451,7 +454,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -516,7 +520,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -553,7 +557,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -634,7 +639,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -671,7 +676,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -754,7 +760,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -791,7 +797,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -856,7 +863,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -893,7 +900,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -974,7 +982,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1011,7 +1019,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1079,7 +1088,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1116,7 +1125,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1182,7 +1192,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1219,7 +1229,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1288,7 +1299,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1325,7 +1336,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1432,7 +1444,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1469,7 +1481,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1534,7 +1547,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1571,7 +1584,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1644,7 +1658,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1681,7 +1695,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1746,7 +1761,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1783,7 +1798,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1848,7 +1864,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1885,7 +1901,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1966,7 +1983,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2003,7 +2020,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2086,7 +2104,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2123,7 +2141,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2188,7 +2207,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2225,7 +2244,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2306,7 +2326,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2343,7 +2363,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2411,7 +2432,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2448,7 +2469,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2514,7 +2536,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2551,7 +2573,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2620,7 +2643,7 @@
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2657,7 +2680,8 @@
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/docs/snippets/schemas/v3/languageModel.schema.mdx
+++ b/docs/snippets/schemas/v3/languageModel.schema.mdx
@@ -95,6 +95,49 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -119,7 +162,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -147,13 +189,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -182,7 +268,6 @@
           "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -210,7 +295,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
         },
         "apiVersion": {
           "type": "string",
@@ -221,6 +307,49 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -245,7 +374,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -273,13 +401,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -304,7 +476,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -332,13 +503,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -379,7 +594,6 @@
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -407,13 +621,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -456,7 +714,6 @@
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -484,13 +741,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -515,7 +816,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -543,13 +843,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -580,7 +924,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -608,7 +951,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
@@ -625,6 +969,49 @@
             "medium",
             "high"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -649,7 +1036,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
           "anyOf": [
             {
               "type": "object",
@@ -677,7 +1063,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
         },
         "baseUrl": {
           "type": "string",
@@ -687,6 +1074,49 @@
           "examples": [
             "http://localhost:8080/v1"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -712,7 +1142,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -740,13 +1169,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -775,7 +1248,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -803,13 +1275,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -911,6 +1427,49 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -935,7 +1494,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -963,13 +1521,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -998,7 +1600,6 @@
           "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1026,7 +1627,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
         },
         "apiVersion": {
           "type": "string",
@@ -1037,6 +1639,49 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1061,7 +1706,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1089,13 +1733,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1120,7 +1808,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1148,13 +1835,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1195,7 +1926,6 @@
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -1223,13 +1953,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1272,7 +2046,6 @@
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -1300,13 +2073,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1331,7 +2148,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1359,13 +2175,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1396,7 +2256,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1424,7 +2283,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
@@ -1441,6 +2301,49 @@
             "medium",
             "high"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1465,7 +2368,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
           "anyOf": [
             {
               "type": "object",
@@ -1493,7 +2395,8 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
         },
         "baseUrl": {
           "type": "string",
@@ -1503,6 +2406,49 @@
           "examples": [
             "http://localhost:8080/v1"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1528,7 +2474,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1556,13 +2501,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1591,7 +2580,6 @@
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1619,13 +2607,57 @@
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [

--- a/docs/snippets/schemas/v3/shared.schema.mdx
+++ b/docs/snippets/schemas/v3/shared.schema.mdx
@@ -74,6 +74,49 @@
         }
       },
       "additionalProperties": false
+    },
+    "LanguageModelHeaders": {
+      "type": "object",
+      "description": "Optional headers to use with the model.",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "secret": {
+                      "type": "string",
+                      "description": "The name of the secret that contains the token."
+                    }
+                  },
+                  "required": [
+                    "secret"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string",
+                      "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                    }
+                  },
+                  "required": [
+                    "env"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   }
 }

--- a/docs/snippets/schemas/v3/shared.schema.mdx
+++ b/docs/snippets/schemas/v3/shared.schema.mdx
@@ -79,7 +79,7 @@
       "type": "object",
       "description": "Optional headers to use with the model.",
       "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
+        "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
           "anyOf": [
             {
               "type": "string"
@@ -116,7 +116,8 @@
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 }

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -1297,6 +1297,49 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1321,7 +1364,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1349,13 +1391,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1384,7 +1470,6 @@ const schema = {
                 "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1412,7 +1497,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
               },
               "apiVersion": {
                 "type": "string",
@@ -1423,6 +1509,49 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1447,7 +1576,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1475,13 +1603,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1506,7 +1678,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1534,13 +1705,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1581,7 +1796,6 @@ const schema = {
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1609,13 +1823,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1658,7 +1916,6 @@ const schema = {
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1686,13 +1943,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1717,7 +2018,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1745,13 +2045,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1782,7 +2126,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1810,7 +2153,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
@@ -1827,6 +2171,49 @@ const schema = {
                   "medium",
                   "high"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1851,7 +2238,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1879,7 +2265,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
               },
               "baseUrl": {
                 "type": "string",
@@ -1889,6 +2276,49 @@ const schema = {
                 "examples": [
                   "http://localhost:8080/v1"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1914,7 +2344,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -1942,13 +2371,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -1977,7 +2450,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2005,13 +2477,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2113,6 +2629,49 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2137,7 +2696,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2165,13 +2723,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2200,7 +2802,6 @@ const schema = {
                 "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2228,7 +2829,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
               },
               "apiVersion": {
                 "type": "string",
@@ -2239,6 +2841,49 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2263,7 +2908,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2291,13 +2935,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2322,7 +3010,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2350,13 +3037,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2397,7 +3128,6 @@ const schema = {
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2425,13 +3155,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2474,7 +3248,6 @@ const schema = {
                 ]
               },
               "credentials": {
-                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2502,13 +3275,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2533,7 +3350,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2561,13 +3377,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2598,7 +3458,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2626,7 +3485,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
@@ -2643,6 +3503,49 @@ const schema = {
                   "medium",
                   "high"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2667,7 +3570,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2695,7 +3597,8 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
               },
               "baseUrl": {
                 "type": "string",
@@ -2705,6 +3608,49 @@ const schema = {
                 "examples": [
                   "http://localhost:8080/v1"
                 ]
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2730,7 +3676,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2758,13 +3703,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [
@@ -2793,7 +3782,6 @@ const schema = {
                 "description": "Optional display name."
               },
               "token": {
-                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
                 "anyOf": [
                   {
                     "type": "object",
@@ -2821,13 +3809,57 @@ const schema = {
                     ],
                     "additionalProperties": false
                   }
-                ]
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
               },
               "baseUrl": {
                 "type": "string",
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "secret": {
+                                "type": "string",
+                                "description": "The name of the secret that contains the token."
+                              }
+                            },
+                            "required": [
+                              "secret"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                }
               }
             },
             "required": [

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -1302,7 +1302,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1339,7 +1339,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1404,7 +1405,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1441,7 +1442,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1514,7 +1516,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1551,7 +1553,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1616,7 +1619,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1653,7 +1656,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1718,7 +1722,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1755,7 +1759,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1836,7 +1841,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1873,7 +1878,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -1956,7 +1962,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -1993,7 +1999,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2058,7 +2065,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2095,7 +2102,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2176,7 +2184,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2213,7 +2221,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2281,7 +2290,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2318,7 +2327,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2384,7 +2394,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2421,7 +2431,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2490,7 +2501,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2527,7 +2538,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2634,7 +2646,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2671,7 +2683,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2736,7 +2749,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2773,7 +2786,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2846,7 +2860,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2883,7 +2897,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -2948,7 +2963,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -2985,7 +3000,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3050,7 +3066,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3087,7 +3103,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3168,7 +3185,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3205,7 +3222,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3288,7 +3306,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3325,7 +3343,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3390,7 +3409,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3427,7 +3446,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3508,7 +3528,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3545,7 +3565,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3613,7 +3634,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3650,7 +3671,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3716,7 +3738,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3753,7 +3775,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [
@@ -3822,7 +3845,7 @@ const schema = {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
                 "patternProperties": {
-                  "^[a-zA-Z0-9_-]+$": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                       {
                         "type": "string"
@@ -3859,7 +3882,8 @@ const schema = {
                       }
                     ]
                   }
-                }
+                },
+                "additionalProperties": false
               }
             },
             "required": [

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -496,6 +496,32 @@ export interface AmazonBedrockLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
+}
+/**
+ * Optional headers to use with the model.
+ */
+export interface LanguageModelHeaders {
+  /**
+   * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
+   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   */
+  [k: string]:
+    | string
+    | (
+        | {
+            /**
+             * The name of the secret that contains the token.
+             */
+            secret: string;
+          }
+        | {
+            /**
+             * The name of the environment variable that contains the token. Only supported in declarative connection configs.
+             */
+            env: string;
+          }
+      );
 }
 export interface AnthropicLanguageModel {
   /**
@@ -530,6 +556,7 @@ export interface AnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface AzureLanguageModel {
   /**
@@ -572,6 +599,7 @@ export interface AzureLanguageModel {
    * Use a different URL prefix for API calls. Either this or `resourceName` can be used.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface DeepSeekLanguageModel {
   /**
@@ -606,6 +634,7 @@ export interface DeepSeekLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleGenerativeAILanguageModel {
   /**
@@ -640,6 +669,7 @@ export interface GoogleGenerativeAILanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexAnthropicLanguageModel {
   /**
@@ -682,6 +712,7 @@ export interface GoogleVertexAnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexLanguageModel {
   /**
@@ -724,6 +755,7 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface MistralLanguageModel {
   /**
@@ -758,6 +790,7 @@ export interface MistralLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenAILanguageModel {
   /**
@@ -796,6 +829,7 @@ export interface OpenAILanguageModel {
    * The reasoning effort to use with the model. Defaults to `medium`. See https://platform.openai.com/docs/guides/reasoning#get-started-with-reasonings
    */
   reasoningEffort?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenAICompatibleLanguageModel {
   /**
@@ -830,6 +864,7 @@ export interface OpenAICompatibleLanguageModel {
    * Base URL of the OpenAI-compatible chat completions API endpoint.
    */
   baseUrl: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenRouterLanguageModel {
   /**
@@ -864,6 +899,7 @@ export interface OpenRouterLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface XaiLanguageModel {
   /**
@@ -898,4 +934,5 @@ export interface XaiLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -504,7 +504,7 @@ export interface AmazonBedrockLanguageModel {
 export interface LanguageModelHeaders {
   /**
    * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
-   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   * via the `patternProperty` "^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$".
    */
   [k: string]:
     | string

--- a/packages/schemas/src/v3/languageModel.schema.ts
+++ b/packages/schemas/src/v3/languageModel.schema.ts
@@ -99,7 +99,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -136,7 +136,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -201,7 +202,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -238,7 +239,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -311,7 +313,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -348,7 +350,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -413,7 +416,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -450,7 +453,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -515,7 +519,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -552,7 +556,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -633,7 +638,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -670,7 +675,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -753,7 +759,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -790,7 +796,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -855,7 +862,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -892,7 +899,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -973,7 +981,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1010,7 +1018,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1078,7 +1087,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1115,7 +1124,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1181,7 +1191,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1218,7 +1228,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1287,7 +1298,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1324,7 +1335,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1431,7 +1443,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1468,7 +1480,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1533,7 +1546,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1570,7 +1583,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1643,7 +1657,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1680,7 +1694,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1745,7 +1760,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1782,7 +1797,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1847,7 +1863,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -1884,7 +1900,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -1965,7 +1982,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2002,7 +2019,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2085,7 +2103,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2122,7 +2140,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2187,7 +2206,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2224,7 +2243,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2305,7 +2325,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2342,7 +2362,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2410,7 +2431,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2447,7 +2468,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2513,7 +2535,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2550,7 +2572,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [
@@ -2619,7 +2642,7 @@ const schema = {
           "type": "object",
           "description": "Optional headers to use with the model.",
           "patternProperties": {
-            "^[a-zA-Z0-9_-]+$": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
               "anyOf": [
                 {
                   "type": "string"
@@ -2656,7 +2679,8 @@ const schema = {
                 }
               ]
             }
-          }
+          },
+          "additionalProperties": false
         }
       },
       "required": [

--- a/packages/schemas/src/v3/languageModel.schema.ts
+++ b/packages/schemas/src/v3/languageModel.schema.ts
@@ -94,6 +94,49 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -118,7 +161,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -146,13 +188,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -181,7 +267,6 @@ const schema = {
           "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -209,7 +294,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
         },
         "apiVersion": {
           "type": "string",
@@ -220,6 +306,49 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -244,7 +373,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -272,13 +400,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -303,7 +475,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -331,13 +502,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -378,7 +593,6 @@ const schema = {
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -406,13 +620,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -455,7 +713,6 @@ const schema = {
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -483,13 +740,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -514,7 +815,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -542,13 +842,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -579,7 +923,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -607,7 +950,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
@@ -624,6 +968,49 @@ const schema = {
             "medium",
             "high"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -648,7 +1035,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
           "anyOf": [
             {
               "type": "object",
@@ -676,7 +1062,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
         },
         "baseUrl": {
           "type": "string",
@@ -686,6 +1073,49 @@ const schema = {
           "examples": [
             "http://localhost:8080/v1"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -711,7 +1141,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -739,13 +1168,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -774,7 +1247,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -802,13 +1274,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -910,6 +1426,49 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -934,7 +1493,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -962,13 +1520,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `ANTHROPIC_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -997,7 +1599,6 @@ const schema = {
           "description": "Azure resource name. Defaults to the `AZURE_RESOURCE_NAME` environment variable."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1025,7 +1626,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `AZURE_API_KEY` environment variable."
         },
         "apiVersion": {
           "type": "string",
@@ -1036,6 +1638,49 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1060,7 +1705,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1088,13 +1732,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `DEEPSEEK_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1119,7 +1807,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1147,13 +1834,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `GOOGLE_GENERATIVE_AI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1194,7 +1925,6 @@ const schema = {
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -1222,13 +1952,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1271,7 +2045,6 @@ const schema = {
           ]
         },
         "credentials": {
-          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials.",
           "anyOf": [
             {
               "type": "object",
@@ -1299,13 +2072,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional file path to service account credentials JSON. Defaults to the `GOOGLE_APPLICATION_CREDENTIALS` environment variable or application default credentials."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1330,7 +2147,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1358,13 +2174,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `MISTRAL_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1395,7 +2255,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1423,7 +2282,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
@@ -1440,6 +2300,49 @@ const schema = {
             "medium",
             "high"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1464,7 +2367,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>.",
           "anyOf": [
             {
               "type": "object",
@@ -1492,7 +2394,8 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key. If specified, adds an `Authorization` header to request headers with the value Bearer <token>."
         },
         "baseUrl": {
           "type": "string",
@@ -1502,6 +2405,49 @@ const schema = {
           "examples": [
             "http://localhost:8080/v1"
           ]
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1527,7 +2473,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1555,13 +2500,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `OPENROUTER_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [
@@ -1590,7 +2579,6 @@ const schema = {
           "description": "Optional display name."
         },
         "token": {
-          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable.",
           "anyOf": [
             {
               "type": "object",
@@ -1618,13 +2606,57 @@ const schema = {
               ],
               "additionalProperties": false
             }
-          ]
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `XAI_API_KEY` environment variable."
         },
         "baseUrl": {
           "type": "string",
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[a-zA-Z0-9_-]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "secret": {
+                          "type": "string",
+                          "description": "The name of the secret that contains the token."
+                        }
+                      },
+                      "required": [
+                        "secret"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          }
         }
       },
       "required": [

--- a/packages/schemas/src/v3/languageModel.type.ts
+++ b/packages/schemas/src/v3/languageModel.type.ts
@@ -75,7 +75,7 @@ export interface AmazonBedrockLanguageModel {
 export interface LanguageModelHeaders {
   /**
    * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
-   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   * via the `patternProperty` "^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$".
    */
   [k: string]:
     | string

--- a/packages/schemas/src/v3/languageModel.type.ts
+++ b/packages/schemas/src/v3/languageModel.type.ts
@@ -67,6 +67,32 @@ export interface AmazonBedrockLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
+}
+/**
+ * Optional headers to use with the model.
+ */
+export interface LanguageModelHeaders {
+  /**
+   * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
+   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   */
+  [k: string]:
+    | string
+    | (
+        | {
+            /**
+             * The name of the secret that contains the token.
+             */
+            secret: string;
+          }
+        | {
+            /**
+             * The name of the environment variable that contains the token. Only supported in declarative connection configs.
+             */
+            env: string;
+          }
+      );
 }
 export interface AnthropicLanguageModel {
   /**
@@ -101,6 +127,7 @@ export interface AnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface AzureLanguageModel {
   /**
@@ -143,6 +170,7 @@ export interface AzureLanguageModel {
    * Use a different URL prefix for API calls. Either this or `resourceName` can be used.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface DeepSeekLanguageModel {
   /**
@@ -177,6 +205,7 @@ export interface DeepSeekLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleGenerativeAILanguageModel {
   /**
@@ -211,6 +240,7 @@ export interface GoogleGenerativeAILanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexAnthropicLanguageModel {
   /**
@@ -253,6 +283,7 @@ export interface GoogleVertexAnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexLanguageModel {
   /**
@@ -295,6 +326,7 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface MistralLanguageModel {
   /**
@@ -329,6 +361,7 @@ export interface MistralLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenAILanguageModel {
   /**
@@ -367,6 +400,7 @@ export interface OpenAILanguageModel {
    * The reasoning effort to use with the model. Defaults to `medium`. See https://platform.openai.com/docs/guides/reasoning#get-started-with-reasonings
    */
   reasoningEffort?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenAICompatibleLanguageModel {
   /**
@@ -401,6 +435,7 @@ export interface OpenAICompatibleLanguageModel {
    * Base URL of the OpenAI-compatible chat completions API endpoint.
    */
   baseUrl: string;
+  headers?: LanguageModelHeaders;
 }
 export interface OpenRouterLanguageModel {
   /**
@@ -435,6 +470,7 @@ export interface OpenRouterLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }
 export interface XaiLanguageModel {
   /**
@@ -469,4 +505,5 @@ export interface XaiLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  headers?: LanguageModelHeaders;
 }

--- a/packages/schemas/src/v3/shared.schema.ts
+++ b/packages/schemas/src/v3/shared.schema.ts
@@ -78,7 +78,7 @@ const schema = {
       "type": "object",
       "description": "Optional headers to use with the model.",
       "patternProperties": {
-        "^[a-zA-Z0-9_-]+$": {
+        "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
           "anyOf": [
             {
               "type": "string"
@@ -115,7 +115,8 @@ const schema = {
             }
           ]
         }
-      }
+      },
+      "additionalProperties": false
     }
   }
 } as const;

--- a/packages/schemas/src/v3/shared.schema.ts
+++ b/packages/schemas/src/v3/shared.schema.ts
@@ -73,6 +73,49 @@ const schema = {
         }
       },
       "additionalProperties": false
+    },
+    "LanguageModelHeaders": {
+      "type": "object",
+      "description": "Optional headers to use with the model.",
+      "patternProperties": {
+        "^[a-zA-Z0-9_-]+$": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "anyOf": [
+                {
+                  "type": "object",
+                  "properties": {
+                    "secret": {
+                      "type": "string",
+                      "description": "The name of the secret that contains the token."
+                    }
+                  },
+                  "required": [
+                    "secret"
+                  ],
+                  "additionalProperties": false
+                },
+                {
+                  "type": "object",
+                  "properties": {
+                    "env": {
+                      "type": "string",
+                      "description": "The name of the environment variable that contains the token. Only supported in declarative connection configs."
+                    }
+                  },
+                  "required": [
+                    "env"
+                  ],
+                  "additionalProperties": false
+                }
+              ]
+            }
+          ]
+        }
+      }
     }
   }
 } as const;

--- a/packages/schemas/src/v3/shared.type.ts
+++ b/packages/schemas/src/v3/shared.type.ts
@@ -37,3 +37,16 @@ export interface GitRevisions {
    */
   tags?: string[];
 }
+/**
+ * Optional headers to use with the model.
+ *
+ * This interface was referenced by `Shared`'s JSON-Schema
+ * via the `definition` "LanguageModelHeaders".
+ */
+export interface LanguageModelHeaders {
+  /**
+   * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
+   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   */
+  [k: string]: string | Token;
+}

--- a/packages/schemas/src/v3/shared.type.ts
+++ b/packages/schemas/src/v3/shared.type.ts
@@ -46,7 +46,7 @@ export interface GitRevisions {
 export interface LanguageModelHeaders {
   /**
    * This interface was referenced by `LanguageModelHeaders`'s JSON-Schema definition
-   * via the `patternProperty` "^[a-zA-Z0-9_-]+$".
+   * via the `patternProperty` "^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$".
    */
   [k: string]: string | Token;
 }

--- a/packages/web/src/app/api/(server)/chat/route.ts
+++ b/packages/web/src/app/api/(server)/chat/route.ts
@@ -88,7 +88,7 @@ export async function POST(req: Request) {
                     });
                 }
 
-                const { model, providerOptions, headers } = await _getAISDKLanguageModelAndOptions(languageModelConfig, org.id);
+                const { model, providerOptions } = await _getAISDKLanguageModelAndOptions(languageModelConfig, org.id);
 
                 return createMessageStreamResponse({
                     messages,
@@ -97,7 +97,6 @@ export async function POST(req: Request) {
                     model,
                     modelName: languageModelConfig.displayName ?? languageModelConfig.model,
                     modelProviderOptions: providerOptions,
-                    modelHeaders: headers,
                     domain,
                     orgId: org.id,
                 });
@@ -129,7 +128,6 @@ interface CreateMessageStreamResponseProps {
     model: AISDKLanguageModelV2;
     modelName: string;
     modelProviderOptions?: Record<string, Record<string, JSONValue>>;
-    modelHeaders?: Record<string, string>;
     domain: string;
     orgId: number;
 }
@@ -141,7 +139,6 @@ const createMessageStreamResponse = async ({
     model,
     modelName,
     modelProviderOptions,
-    modelHeaders,
     domain,
     orgId,
 }: CreateMessageStreamResponseProps) => {
@@ -210,7 +207,6 @@ const createMessageStreamResponse = async ({
             const researchStream = await createAgentStream({
                 model,
                 providerOptions: modelProviderOptions,
-                headers: modelHeaders,
                 inputMessages: messageHistory,
                 inputSources: sources,
                 searchScopeRepoNames: expandedRepos,

--- a/packages/web/src/features/chat/actions.ts
+++ b/packages/web/src/features/chat/actions.ts
@@ -613,7 +613,5 @@ const extractLanguageModelHeaders = async (
         resolvedHeaders[headerName] = value;
     }
 
-    console.log(resolvedHeaders);
-
     return resolvedHeaders;
 }

--- a/packages/web/src/features/chat/actions.ts
+++ b/packages/web/src/features/chat/actions.ts
@@ -20,8 +20,8 @@ import { LanguageModelV2 as AISDKLanguageModelV2 } from "@ai-sdk/provider";
 import { createXai } from '@ai-sdk/xai';
 import { createOpenRouter } from '@openrouter/ai-sdk-provider';
 import { getTokenFromConfig } from "@sourcebot/crypto";
-import { ChatVisibility, OrgRole, Prisma } from "@sourcebot/db";
-import { LanguageModel } from "@sourcebot/schemas/v3/languageModel.type";
+import { ChatVisibility, OrgRole, Prisma, PrismaClient } from "@sourcebot/db";
+import { LanguageModel, LanguageModelHeaders } from "@sourcebot/schemas/v3/languageModel.type";
 import { loadConfig } from "@sourcebot/shared";
 import { generateText, JSONValue } from "ai";
 import fs from 'fs';
@@ -375,7 +375,6 @@ export const _getConfiguredLanguageModelsFull = async (): Promise<LanguageModel[
 export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, orgId: number): Promise<{
     model: AISDKLanguageModelV2,
     providerOptions?: Record<string, Record<string, JSONValue>>,
-    headers?: Record<string, string>,
 }> => {
     const { provider, model: modelId } = config;
 
@@ -390,6 +389,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 secretAccessKey: config.accessKeySecret
                     ? await getTokenFromConfig(config.accessKeySecret, orgId, prisma)
                     : env.AWS_SECRET_ACCESS_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -402,6 +404,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.ANTHROPIC_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -414,10 +419,6 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                         }
                     } satisfies AnthropicProviderOptions,
                 },
-                headers: {
-                    // @see: https://docs.anthropic.com/en/docs/build-with-claude/extended-thinking#interleaved-thinking
-                    'anthropic-beta': 'interleaved-thinking-2025-05-14',
-                },
             };
         }
         case 'azure': {
@@ -426,6 +427,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token ? (await getTokenFromConfig(config.token, orgId, prisma)) : env.AZURE_API_KEY,
                 apiVersion: config.apiVersion,
                 resourceName: config.resourceName ?? env.AZURE_RESOURCE_NAME,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -436,6 +440,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
             const deepseek = createDeepSeek({
                 baseURL: config.baseUrl,
                 apiKey: config.token ? (await getTokenFromConfig(config.token, orgId, prisma)) : env.DEEPSEEK_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -448,6 +455,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.GOOGLE_GENERATIVE_AI_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -463,6 +473,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                         keyFilename: await getTokenFromConfig(config.credentials, orgId, prisma),
                     }
                 } : {}),
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -486,6 +499,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                         keyFilename: await getTokenFromConfig(config.credentials, orgId, prisma),
                     }
                 } : {}),
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -498,6 +514,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.MISTRAL_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -510,6 +529,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.OPENAI_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -528,6 +550,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : undefined,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -540,6 +565,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.OPENROUTER_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -552,6 +580,9 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
                 apiKey: config.token
                     ? await getTokenFromConfig(config.token, orgId, prisma)
                     : env.XAI_API_KEY,
+                headers: config.headers
+                    ? await extractLanguageModelHeaders(config.headers, orgId, prisma)
+                    : undefined,
             });
 
             return {
@@ -559,4 +590,30 @@ export const _getAISDKLanguageModelAndOptions = async (config: LanguageModel, or
             };
         }
     }
+}
+
+const extractLanguageModelHeaders = async (
+    headers: LanguageModelHeaders,
+    orgId: number,
+    db: PrismaClient,
+): Promise<Record<string, string>> => {
+    const resolvedHeaders: Record<string, string> = {};
+
+    if (!headers) {
+        return resolvedHeaders;
+    }
+
+    for (const [headerName, headerValue] of Object.entries(headers)) {
+        if (typeof headerValue === "string") {
+            resolvedHeaders[headerName] = headerValue;
+            continue;
+        }
+
+        const value = await getTokenFromConfig(headerValue, orgId, db);
+        resolvedHeaders[headerName] = value;
+    }
+
+    console.log(resolvedHeaders);
+
+    return resolvedHeaders;
 }

--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -32,7 +32,6 @@ const stepCountIsGTE = (stepCount: number): StopCondition<any> => {
 export const createAgentStream = async ({
     model,
     providerOptions,
-    headers,
     inputMessages,
     inputSources,
     searchScopeRepoNames,
@@ -46,7 +45,6 @@ export const createAgentStream = async ({
     const stream = streamText({
         model,
         providerOptions,
-        headers,
         system: baseSystemPrompt,
         messages: inputMessages,
         tools: {

--- a/schemas/v3/languageModel.json
+++ b/schemas/v3/languageModel.json
@@ -39,6 +39,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -71,6 +74,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -111,6 +117,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Use a different URL prefix for API calls. Either this or `resourceName` can be used."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -143,6 +152,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -175,6 +187,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -223,6 +238,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -273,6 +291,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -305,6 +326,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -353,6 +377,9 @@
                         "medium",
                         "high"
                     ]
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -388,6 +415,9 @@
                     "examples": [
                         "http://localhost:8080/v1"
                     ]
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -421,6 +451,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [
@@ -457,6 +490,9 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
             },
             "required": [

--- a/schemas/v3/shared.json
+++ b/schemas/v3/shared.json
@@ -77,7 +77,7 @@
             "type": "object",
             "description": "Optional headers to use with the model.",
             "patternProperties": {
-                "^[a-zA-Z0-9_-]+$": {
+                "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
                     "anyOf": [
                         {
                             "type": "string"
@@ -87,7 +87,8 @@
                         }
                     ]
                 }
-            }
+            },
+            "additionalProperties": false
         }
     }
 }

--- a/schemas/v3/shared.json
+++ b/schemas/v3/shared.json
@@ -72,6 +72,22 @@
                 }
             },
             "additionalProperties": false
+        },
+        "LanguageModelHeaders": {
+            "type": "object",
+            "description": "Optional headers to use with the model.",
+            "patternProperties": {
+                "^[a-zA-Z0-9_-]+$": {
+                    "anyOf": [
+                        {
+                            "type": "string"
+                        },
+                        {
+                            "$ref": "#/definitions/Token"
+                        }
+                    ]
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
For example:

```jsonc
"models": [
        {
            "provider": "anthropic",
            "model": "claude-opus-4-1",
            "headers": {
                "cf-client-id": {
                    "env": "CF_CLIENT_ID"
                },
                "cf-client-secret": {
                    "env": "CF_CLIENT_SECRET"
                },
                "my-non-secret-header": "plaintextvalue"
            }
        }
    ]
```

Fixes #441 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for specifying optional custom HTTP headers in all language model configurations. Headers can be set as plain strings or securely referenced via secrets or environment variables.

* **Bug Fixes**
  * Improved clarity of token property descriptions in language model configuration schemas.

* **Documentation**
  * Added a "Custom headers" section explaining how to configure headers with examples.
  * Updated schema documentation to reflect the new optional headers property for all supported language model providers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->