### PR TITLE
fix(ask_sb): Allow unauthed generation of titles for a chat

### DIFF
--- a/packages/web/src/features/chat/actions.ts
+++ b/packages/web/src/features/chat/actions.ts
@@ -233,7 +233,7 @@ User question: ${message}`;
             return {
                 success: true,
             }
-        })
+        }, /* minRequiredRole = */ OrgRole.GUEST), /* allowSingleTenantUnauthedAccess = */ true
     )
 );
 


### PR DESCRIPTION
Noticed that in the demo instance, this error was appearing:

<img width="411" height="125" alt="image" src="https://github.com/user-attachments/assets/a59fc241-8610-4a52-b6b2-3820c790b871" />

This was introduced in #447. I forgot to set the minimum rom for the `generateAndUpdateChatNameFromMessage` action to GUEST. This PR fixes that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved internal handling of organization membership checks for chat-related actions. No visible changes to user experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->