### PR TITLE
feat(web): Add configurable default search mode setting

### DIFF
--- a/packages/web/src/app/[domain]/settings/(general)/components/defaultSearchModeCard.tsx
+++ b/packages/web/src/app/[domain]/settings/(general)/components/defaultSearchModeCard.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { setDefaultSearchMode } from "@/actions";
+import { Card, CardContent, CardDescription, CardFooter, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { OrgRole } from "@sourcebot/db";
+import { MessageCircleIcon, SearchIcon } from "lucide-react";
+import { useState } from "react";
+import { useParams } from "next/navigation";
+import { useToast } from "@/components/hooks/use-toast";
+
+interface DefaultSearchModeCardProps {
+    initialDefaultMode: "precise" | "agentic";
+    currentUserRole: OrgRole;
+    isAskModeAvailable: boolean;
+}
+
+export const DefaultSearchModeCard = ({ initialDefaultMode, currentUserRole, isAskModeAvailable }: DefaultSearchModeCardProps) => {
+    const { domain } = useParams<{ domain: string }>();
+    // If Ask mode is not available and the initial mode is agentic, force it to precise
+    const effectiveInitialMode = !isAskModeAvailable && initialDefaultMode === "agentic" ? "precise" : initialDefaultMode;
+    const [defaultSearchMode, setDefaultSearchModeState] = useState<"precise" | "agentic">(effectiveInitialMode);
+    const [isUpdating, setIsUpdating] = useState(false);
+    const isReadOnly = currentUserRole !== OrgRole.OWNER;
+    const { toast } = useToast();
+
+    const handleUpdateDefaultSearchMode = async () => {
+        if (isReadOnly) {
+            return;
+        }
+
+        setIsUpdating(true);
+        try {
+            const result = await setDefaultSearchMode(domain as string, defaultSearchMode);
+            if (!result || typeof result !== 'object' || !result.success) {
+                throw new Error('Failed to update default search mode');
+            }
+            toast({
+                title: "Default search mode updated",
+                description: `Default search mode has been set to ${defaultSearchMode === "agentic" ? "Ask" : "Code Search"}.`,
+                variant: "success",
+            });
+        } catch (error) {
+            console.error('Error updating default search mode:', error);
+            toast({
+                title: "Failed to update",
+                description: "An error occurred while updating the default search mode.",
+                variant: "destructive",
+            });
+        } finally {
+            setIsUpdating(false);
+        }
+    };
+
+    return (
+        <Card>
+            <CardHeader>
+                <CardTitle>Default Search Mode</CardTitle>
+                <CardDescription>
+                    Choose which search mode will be the default when users first visit Sourcebot
+                    {!isAskModeAvailable && (
+                        <span className="block text-yellow-600 dark:text-yellow-400 mt-1">
+                            Ask mode is unavailable (no language models configured)
+                        </span>
+                    )}
+                </CardDescription>
+            </CardHeader>
+            <CardContent>
+                <Select
+                    value={defaultSearchMode}
+                    onValueChange={(value) => setDefaultSearchModeState(value as "precise" | "agentic")}
+                    disabled={isReadOnly}
+                >
+                    <SelectTrigger>
+                        <SelectValue placeholder="Select default search mode">
+                            {defaultSearchMode === "precise" ? "Code Search" : defaultSearchMode === "agentic" ? "Ask" : undefined}
+                        </SelectValue>
+                    </SelectTrigger>
+                    <SelectContent>
+                        <SelectItem value="precise">Code Search</SelectItem>
+                        <SelectItem value="agentic" disabled={!isAskModeAvailable}>
+                            Ask {!isAskModeAvailable && "(unavailable)"}
+                        </SelectItem>
+                    </SelectContent>
+                </Select>
+            </CardContent>
+            <CardFooter>
+                <LoadingButton
+                    onClick={handleUpdateDefaultSearchMode}
+                    loading={isUpdating}
+                    disabled={isReadOnly || isUpdating || defaultSearchMode === effectiveInitialMode}
+                >
+                    Update
+                </LoadingButton>
+            </CardFooter>
+        </Card>
+    );
+};

--- a/packages/web/src/app/[domain]/settings/(general)/page.tsx
+++ b/packages/web/src/app/[domain]/settings/(general)/page.tsx
@@ -1,11 +1,13 @@
 import { ChangeOrgNameCard } from "./components/changeOrgNameCard";
 import { isServiceError } from "@/lib/utils";
-import { getCurrentUserRole } from "@/actions";
+import { getCurrentUserRole, getDefaultSearchMode } from "@/actions";
 import { getOrgFromDomain } from "@/data/org";
 import { ChangeOrgDomainCard } from "./components/changeOrgDomainCard";
+import { DefaultSearchModeCard } from "./components/defaultSearchModeCard";
 import { ServiceErrorException } from "@/lib/serviceError";
 import { ErrorCode } from "@/lib/errorCodes";
 import { headers } from "next/headers";
+import { getConfiguredLanguageModelsInfo } from "@/features/chat/actions";
 
 interface GeneralSettingsPageProps {
     params: Promise<{
@@ -36,6 +38,14 @@ export default async function GeneralSettingsPage(props: GeneralSettingsPageProp
 
     const host = (await headers()).get('host') ?? '';
 
+    // Get the default search mode setting
+    const defaultSearchMode = await getDefaultSearchMode(domain);
+    const initialDefaultMode = isServiceError(defaultSearchMode) ? "precise" : defaultSearchMode;
+
+    // Get available language models to determine if "Ask" mode is available
+    const languageModels = await getConfiguredLanguageModelsInfo();
+    const isAskModeAvailable = languageModels.length > 0;
+
     return (
         <div className="flex flex-col gap-6">
             <div>
@@ -51,6 +61,12 @@ export default async function GeneralSettingsPage(props: GeneralSettingsPageProp
                 orgDomain={org.domain}
                 currentUserRole={currentUserRole}
                 rootDomain={host}
+            />
+
+            <DefaultSearchModeCard
+                initialDefaultMode={initialDefaultMode}
+                currentUserRole={currentUserRole}
+                isAskModeAvailable={isAskModeAvailable}
             />
         </div>
     )

--- a/packages/web/src/types.ts
+++ b/packages/web/src/types.ts
@@ -2,6 +2,7 @@ import { z } from "zod";
 
 export const orgMetadataSchema = z.object({
     anonymousAccessEnabled: z.boolean().optional(),
+    defaultSearchMode: z.enum(["precise", "agentic"]).optional(),
 })
 
 export const demoSearchScopeSchema = z.object({


### PR DESCRIPTION
  # Add configurable default search mode setting

  Resolves #471

  ## Summary

  Allows organization owners to set whether "Code Search" or "Ask" is the default search mode, preventing accidental token consumption when users intended to use basic code search.

  ## Changes

  * Added `defaultSearchMode` to org metadata schema with `"precise" | "agentic"` enum
  * Created `DefaultSearchModeCard` component in General Settings (owner-only)
  * Implemented server actions with validation and audit logging
  * Homepage follows org default → user cookie → fallback chain
  * Smart handling when Ask mode unavailable (no language models configured)