### PR TITLE
fix(web): Fix error when navigating to paths with percent symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Remove setting `remote.origin.url` for remote git repositories. [#483](https://github.com/sourcebot-dev/sourcebot/pull/483)
+- Fix error when navigating to paths with percentage symbols. [#485](https://github.com/sourcebot-dev/sourcebot/pull/485)
 
 ### Changed
 - Updated NextJS to version 15. [#477](https://github.com/sourcebot-dev/sourcebot/pull/477)

--- a/packages/web/src/app/[domain]/browse/[...path]/page.tsx
+++ b/packages/web/src/app/[domain]/browse/[...path]/page.tsx
@@ -19,7 +19,7 @@ export default async function BrowsePage(props: BrowsePageProps) {
         domain
     } = params;
 
-    const rawPath = decodeURIComponent(_rawPath.join('/'));
+    const rawPath = _rawPath.join('/');
     const { repoName, revisionName, path, pathType } = getBrowseParamsFromPathParam(rawPath);
 
     return (

--- a/packages/web/src/app/[domain]/browse/hooks/utils.test.ts
+++ b/packages/web/src/app/[domain]/browse/hooks/utils.test.ts
@@ -98,6 +98,26 @@ describe('getBrowseParamsFromPathParam', () => {
                 pathType: 'blob',
             });
         });
+
+        it('should decode paths with percent symbols in path', () => {
+            const result = getBrowseParamsFromPathParam('github.com/sourcebot-dev/zoekt@HEAD/-/blob/%25hello%25%2Fworld.c');
+            expect(result).toEqual({
+                repoName: 'github.com/sourcebot-dev/zoekt',
+                revisionName: 'HEAD',
+                path: '%hello%/world.c',
+                pathType: 'blob',
+            });
+        });
+
+        it('should decode paths with @ symbol encoded', () => {
+            const result = getBrowseParamsFromPathParam('github.com/sourcebot-dev/zoekt%40HEAD/-/blob/file.txt');
+            expect(result).toEqual({
+                repoName: 'github.com/sourcebot-dev/zoekt',
+                revisionName: 'HEAD',
+                path: 'file.txt',
+                pathType: 'blob',
+            });
+        })
     });
 
     describe('different revision formats', () => {

--- a/packages/web/src/app/[domain]/browse/hooks/utils.ts
+++ b/packages/web/src/app/[domain]/browse/hooks/utils.ts
@@ -5,7 +5,7 @@ export const getBrowseParamsFromPathParam = (pathParam: string) => {
         throw new Error(`Invalid browse pathname: "${pathParam}" - expected to contain "/-/(tree|blob)/" pattern`);
     }
 
-    const repoAndRevisionPart = pathParam.substring(0, sentinelIndex);
+    const repoAndRevisionPart = decodeURIComponent(pathParam.substring(0, sentinelIndex));
     const lastAtIndex = repoAndRevisionPart.lastIndexOf('@');
     
     const repoName = lastAtIndex === -1 ? repoAndRevisionPart : repoAndRevisionPart.substring(0, lastAtIndex);


### PR DESCRIPTION

Fixes #482 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Fixed navigation and browsing for URLs containing percent-encoded characters (e.g., %25, %2F, %40), ensuring correct repo/revision detection and path handling in file and directory views.
  - Improved reliability when opening encoded paths, reducing decoding-related errors.

- Documentation
  - Updated changelog with an Unreleased entry describing the fix for paths with percentage symbols.

- Tests
  - Added tests covering URL decoding in both repository/revision and path segments to ensure accurate parsing and display.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->