### PR TITLE
fix(worker): Fix "attempting to index 0 total files" zoekt issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fix issue where zoekt was failing to index repositories due to `HEAD` pointing to a branch that does not exist. [#488](https://github.com/sourcebot-dev/sourcebot/pull/488)
+
 ## [4.6.5] - 2025-09-02
 
 ### Fixed

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -18,14 +18,19 @@ export const cloneRepository = async (
             path,
         })
 
-        await git.init(/*bare = */ true);
-
-        await git.fetch([
+        await git.clone(
             remoteUrl.toString(),
-            // See https://git-scm.com/book/en/v2/Git-Internals-The-Refspec
-            "+refs/heads/*:refs/heads/*",
-            "--progress",
-        ]);
+            path,
+            [
+                "--bare",
+            ]
+        );
+
+        await unsetGitConfig(path, ["remote.origin.url"]);
+
+        await git.cwd({
+            path,
+        }).addConfig("remote.origin.fetch", "+refs/heads/*:refs/heads/*");
     } catch (error: unknown) {
         const baseLog = `Failed to clone repository: ${path}`;
 
@@ -54,7 +59,6 @@ export const fetchRepository = async (
 
         await git.fetch([
             remoteUrl.toString(),
-            "+refs/heads/*:refs/heads/*",
             "--prune",
             "--progress"
         ]);


### PR DESCRIPTION
Regression was introduced in #483 - the tl;dr is that `git init --bare` + `git fetch` leaves HEAD pointing to a non-existent default branch. This hot fix changes it back to use `git clone` and instead deletes `remote.origin.url` after cloning.

Fixes #487 