### PR TITLE
feat(gitlab): Add exclude.userOwnedProjects config setting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `exclude.userOwnedProjects` setting to GitLab configs. [#498](https://github.com/sourcebot-dev/sourcebot/pull/498)
+
 ### Fixed
 - Fixed "couldn't find remote ref HEAD" errors when re-indexing certain repositories. [#497](https://github.com/sourcebot-dev/sourcebot/pull/497)
 

--- a/docs/docs/connections/gitlab.mdx
+++ b/docs/docs/connections/gitlab.mdx
@@ -90,6 +90,8 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
                 "archived": true,
                 // projects that are forks
                 "forks": true,
+                // projects that are owned by users (not groups)
+                "userOwnedProjects": true,
                 // projects that match these glob patterns
                 "projects": [
                     "my-group/foo/**",

--- a/docs/snippets/schemas/v3/connection.schema.mdx
+++ b/docs/snippets/schemas/v3/connection.schema.mdx
@@ -343,6 +343,11 @@
               "default": false,
               "description": "Exclude archived projects from syncing."
             },
+            "userOwnedProjects": {
+              "type": "boolean",
+              "default": false,
+              "description": "Exclude user-owned projects from syncing."
+            },
             "projects": {
               "type": "array",
               "items": {

--- a/docs/snippets/schemas/v3/gitlab.schema.mdx
+++ b/docs/snippets/schemas/v3/gitlab.schema.mdx
@@ -126,6 +126,11 @@
           "default": false,
           "description": "Exclude archived projects from syncing."
         },
+        "userOwnedProjects": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude user-owned projects from syncing."
+        },
         "projects": {
           "type": "array",
           "items": {

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -606,6 +606,11 @@
                       "default": false,
                       "description": "Exclude archived projects from syncing."
                     },
+                    "userOwnedProjects": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Exclude user-owned projects from syncing."
+                    },
                     "projects": {
                       "type": "array",
                       "items": {

--- a/packages/backend/src/gitlab.test.ts
+++ b/packages/backend/src/gitlab.test.ts
@@ -56,3 +56,15 @@ test('shouldExcludeProject returns true when the project is excluded by exclude.
         }
     })).toBe(true)
 });
+
+test('shouldExcludeProject returns false when exclude.userOwnedProjects is true but project is group-owned.', () => {
+    const project = {
+        path_with_namespace: 'test/project',
+        namespace: { kind: 'group' },
+    } as unknown as ProjectSchema;
+
+    expect(shouldExcludeProject({
+        project,
+        exclude: { userOwnedProjects: true },
+    })).toBe(false);
+});

--- a/packages/backend/src/gitlab.test.ts
+++ b/packages/backend/src/gitlab.test.ts
@@ -41,3 +41,18 @@ test('shouldExcludeProject returns true when the project is excluded by exclude.
     })).toBe(true)
 });
 
+test('shouldExcludeProject returns true when the project is excluded by exclude.userOwnedProjects.', () => {
+    const project = {
+        path_with_namespace: 'test/project',
+        namespace: {
+            kind: 'user',
+        }
+    } as unknown as ProjectSchema;
+
+    expect(shouldExcludeProject({
+        project,
+        exclude: {
+            userOwnedProjects: true,
+        }
+    })).toBe(true)
+});

--- a/packages/backend/src/gitlab.ts
+++ b/packages/backend/src/gitlab.ts
@@ -222,6 +222,11 @@ export const shouldExcludeProject = ({
             return true;
         }
 
+        if (exclude?.userOwnedProjects && project.namespace.kind === 'user') {
+            reason = `\`exclude.userOwnedProjects\` is true`;
+            return true;
+        }
+
         if (exclude?.projects) {
             if (micromatch.isMatch(projectName, exclude.projects)) {
                 reason = `\`exclude.projects\` contains ${projectName}`;

--- a/packages/schemas/src/v3/connection.schema.ts
+++ b/packages/schemas/src/v3/connection.schema.ts
@@ -342,6 +342,11 @@ const schema = {
               "default": false,
               "description": "Exclude archived projects from syncing."
             },
+            "userOwnedProjects": {
+              "type": "boolean",
+              "default": false,
+              "description": "Exclude user-owned projects from syncing."
+            },
             "projects": {
               "type": "array",
               "items": {

--- a/packages/schemas/src/v3/connection.type.ts
+++ b/packages/schemas/src/v3/connection.type.ts
@@ -154,6 +154,10 @@ export interface GitlabConnectionConfig {
      */
     archived?: boolean;
     /**
+     * Exclude user-owned projects from syncing.
+     */
+    userOwnedProjects?: boolean;
+    /**
      * List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/
      */
     projects?: string[];

--- a/packages/schemas/src/v3/gitlab.schema.ts
+++ b/packages/schemas/src/v3/gitlab.schema.ts
@@ -125,6 +125,11 @@ const schema = {
           "default": false,
           "description": "Exclude archived projects from syncing."
         },
+        "userOwnedProjects": {
+          "type": "boolean",
+          "default": false,
+          "description": "Exclude user-owned projects from syncing."
+        },
         "projects": {
           "type": "array",
           "items": {

--- a/packages/schemas/src/v3/gitlab.type.ts
+++ b/packages/schemas/src/v3/gitlab.type.ts
@@ -57,6 +57,10 @@ export interface GitlabConnectionConfig {
      */
     archived?: boolean;
     /**
+     * Exclude user-owned projects from syncing.
+     */
+    userOwnedProjects?: boolean;
+    /**
      * List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/
      */
     projects?: string[];

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -605,6 +605,11 @@ const schema = {
                       "default": false,
                       "description": "Exclude archived projects from syncing."
                     },
+                    "userOwnedProjects": {
+                      "type": "boolean",
+                      "default": false,
+                      "description": "Exclude user-owned projects from syncing."
+                    },
                     "projects": {
                       "type": "array",
                       "items": {

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -279,6 +279,10 @@ export interface GitlabConnectionConfig {
      */
     archived?: boolean;
     /**
+     * Exclude user-owned projects from syncing.
+     */
+    userOwnedProjects?: boolean;
+    /**
      * List of projects to exclude from syncing. Glob patterns are supported. The project's namespace must be specified, see: https://docs.gitlab.com/ee/user/namespace/
      */
     projects?: string[];

--- a/schemas/v3/gitlab.json
+++ b/schemas/v3/gitlab.json
@@ -97,6 +97,11 @@
                     "default": false,
                     "description": "Exclude archived projects from syncing."
                 },
+                "userOwnedProjects": {
+                    "type": "boolean",
+                    "default": false,
+                    "description": "Exclude user-owned projects from syncing."
+                },
                 "projects": {
                     "type": "array",
                     "items": {


### PR DESCRIPTION
Adds `exclude.userOwnedProjects` to GitLab config setting to allow for excluding all user owned projects from syncing.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added a GitLab exclude option to omit user-owned projects from syncing (configurable, default off).

- Documentation
  - Updated GitLab connection docs, examples, and schemas to include the new userOwnedProjects exclude setting.
  - Added an Unreleased changelog entry describing the new configuration.

- Tests
  - Added test coverage to verify exclusion behavior for user-owned projects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->