### PR TITLE
[search] support uppercase OR/AND

### DIFF
--- a/docs/docs/features/search/syntax-reference.mdx
+++ b/docs/docs/features/search/syntax-reference.mdx
@@ -15,13 +15,15 @@ Queries consist of space-separated regular expressions. Wrapping expressions in 
 | `foo bar` | Match files with regex `/foo/` **and** `/bar/` |
 | `"foo bar"` | Match files with regex `/foo bar/` |
 
-Multiple expressions can be or'd together with `or`, negated with `-`, or grouped with `()`.
+Multiple expressions can be or'd together with `or` (or `OR`), negated with `-`, or grouped with `()`. Both lowercase and uppercase boolean operators are supported.
 
 | Example | Explanation |
 | :--- | :--- |
 | `foo or bar` | Match files with regex `/foo/` **or** `/bar/` |
+| `foo OR bar` | Same as above - uppercase `OR` is also supported |
 | `foo -bar` | Match files with regex `/foo/` but **not** `/bar/` |
 | `foo (bar or baz)` | Match files with regex `/foo/` **and** either `/bar/` **or** `/baz/` |
+| `(file:yarn.lock OR file:package.json)` | Match files named `yarn.lock` **or** `package.json` |
 
 Expressions can be prefixed with certain keywords to modify search behavior. Some keywords can be negated using the `-` prefix.
 

--- a/packages/web/src/features/search/searchApi.test.ts
+++ b/packages/web/src/features/search/searchApi.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from 'vitest';
+
+// Simple function to test the query transformation logic
+// We'll extract just the normalization part to test it separately
+const normalizeQueryOperators = (query: string): string => {
+    return query
+        // Replace standalone uppercase OR with lowercase or
+        .replace(/\bOR\b/g, 'or')
+        // Replace standalone uppercase AND with lowercase and (though AND is implicit in Zoekt)
+        .replace(/\bAND\b/g, 'and');
+};
+
+describe('Query transformation', () => {
+    describe('normalizeQueryOperators', () => {
+        it('should convert uppercase OR to lowercase or', () => {
+            expect(normalizeQueryOperators('file:yarn.lock OR file:package.json'))
+                .toBe('file:yarn.lock or file:package.json');
+        });
+
+        it('should convert uppercase AND to lowercase and', () => {
+            expect(normalizeQueryOperators('foo AND bar'))
+                .toBe('foo and bar');
+        });
+
+        it('should handle parenthesized expressions', () => {
+            expect(normalizeQueryOperators('(file:yarn.lock OR file:package.json)'))
+                .toBe('(file:yarn.lock or file:package.json)');
+        });
+
+        it('should handle complex queries with multiple operators', () => {
+            expect(normalizeQueryOperators('(file:*.json OR file:*.lock) AND content:react'))
+                .toBe('(file:*.json or file:*.lock) and content:react');
+        });
+
+        it('should not affect lowercase operators', () => {
+            expect(normalizeQueryOperators('file:yarn.lock or file:package.json'))
+                .toBe('file:yarn.lock or file:package.json');
+        });
+
+        it('should not affect OR/AND when part of other words', () => {
+            expect(normalizeQueryOperators('ORDER BY something'))
+                .toBe('ORDER BY something');
+            
+            expect(normalizeQueryOperators('ANDROID app'))
+                .toBe('ANDROID app');
+        });
+
+        it('should handle mixed case queries', () => {
+            expect(normalizeQueryOperators('file:src OR file:test and lang:typescript'))
+                .toBe('file:src or file:test and lang:typescript');
+        });
+
+        it('should handle multiple ORs and ANDs', () => {
+            expect(normalizeQueryOperators('A OR B OR C AND D AND E'))
+                .toBe('A or B or C and D and E');
+        });
+    });
+});

--- a/packages/web/src/features/search/searchApi.ts
+++ b/packages/web/src/features/search/searchApi.ts
@@ -36,7 +36,19 @@ enum zoektPrefixes {
 }
 
 const transformZoektQuery = async (query: string, orgId: number): Promise<string | ServiceError> => {
-    const prevQueryParts = query.split(" ");
+    // First, normalize boolean operators to lowercase (Zoekt requirement)
+    // Zoekt only recognizes lowercase 'or' and 'and' operators, but users often expect
+    // uppercase OR/AND to work. This transformation allows both cases to work.
+    // Examples:
+    //   - "(file:yarn.lock OR file:package.json)" → "(file:yarn.lock or file:package.json)"
+    //   - "foo AND bar" → "foo and bar" (though AND is implicit in Zoekt)
+    let normalizedQuery = query
+        // Replace standalone uppercase OR with lowercase or
+        .replace(/\bOR\b/g, 'or')
+        // Replace standalone uppercase AND with lowercase and (though AND is implicit in Zoekt)
+        .replace(/\bAND\b/g, 'and');
+
+    const prevQueryParts = normalizedQuery.split(" ");
     const newQueryParts = [];
 
     for (const part of prevQueryParts) {


### PR DESCRIPTION
* Support uppercase `AND` and `OR` in search syntax.
* Add a few tests around how this works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Search now accepts uppercase boolean operators (AND, OR) in addition to lowercase, including within parentheses and with prefixes (e.g., (file:yarn.lock OR file:package.json)).
* **Documentation**
  * Updated syntax reference to state boolean operators are case-insensitive.
  * Added examples demonstrating uppercase OR (e.g., foo OR bar) and combined prefix usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->