### PR TITLE
fix(bitbucket): Bitbucket Cloud pagination not working beyond first page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed Bitbucket Cloud pagination not working beyond first page. [#295](https://github.com/sourcebot-dev/sourcebot/issues/295)
+
 ## [4.6.7] - 2025-09-08
 
 ### Added


### PR DESCRIPTION
# Fix: Bitbucket Cloud pagination not working beyond first page

## Problem

Issue: #295 
When fetching repositories from Bitbucket Cloud workspaces with multiple pages of results, Sourcebot fails on the second page with the following error:

```
[dev:backend] 2025-09-09T19:11:45.876Z error: [bitbucket] Failed to get repos for workspace emilabs: Error: Failed to fetch projects for workspace emilabs: {"type":"error","error":{"message":"Resource not found","detail":"There is no API hosted at this URL.\n\nFor information about our API's, please refer to the documentation at: https://developer.atlassian.com/bitbucket/api/2/reference/"}}
```

This is caused by the Bitbucket Cloud API returning full URLs (e.g., `https://api.bitbucket.org/2.0/repositories/workspace?page=2`) in pagination `next` responses, but `openapi-fetch` expects separate path and query parameters. The current implementation was passing the full URL directly to the API client, which doesn't recognize the complete URL format.

## Solution

This PR implements proper URL parsing for Bitbucket Cloud pagination to separate paths and query parameters. The implementation includes:

### 1. **URL Parsing Function**

* Created `parseUrl()` function that properly extracts pathname and query parameters from full URLs
* Uses the native `URL` constructor for robust and performant parsing

### 2. **Updated Pagination Handlers**

* Updated `cloudGetReposForWorkspace()` to use parsed URL components
* Updated `cloudGetReposForProjects()` to use parsed URL components  
* Both functions now correctly pass `path` and `query` parameters separately to `openapi-fetch`

## Testing

* Manually tested with Bitbucket Cloud workspaces containing multiple pages of repositories
* Verified that pagination now works correctly beyond the first page
* Confirmed that single-page results continue to work as expected
* All existing tests are still passing

## Breaking Changes

None. The changes are backward compatible and only affect the internal pagination URL handling.

## Notes

* This fix specifically addresses Bitbucket Cloud pagination - Bitbucket Server has another implementation for pagination
* Debug logging includes the parsed path and query for troubleshooting pagination issues