### PR TITLE
Quote branches argument in zoekt.ts to fix Pipe

### DIFF
--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -63,7 +63,7 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, ctx: Ap
         `-index ${ctx.indexPath}`,
         `-max_trigram_count ${settings.maxTrigramCount}`,
         `-file_limit ${settings.maxFileSize}`,
-        `-branches ${revisions.join(',')}`,
+        `-branches "${revisions.join(',')}"`,
         `-tenant_id ${repo.orgId}`,
         `-repo_id ${repo.id}`,
         `-shard_prefix ${shardPrefix}`,


### PR DESCRIPTION
Adding quotes here fixes zoekt-git-index failing when a pipe is in a branch/tag

Fixes #505 