### PR TITLE
fix(azure): Set username in azuredevops clone url

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed sourcebot not pulling github forked repos [#499](https://github.com/sourcebot-dev/sourcebot/pull/499)
+- Fixed azure devop cloud pat issue [#524](https://github.com/sourcebot-dev/sourcebot/pull/524)
 
 ## [4.7.0] - 2025-09-17
 

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -218,6 +218,10 @@ export class RepoManager implements IRepoManager {
                 if (config.token) {
                     const token = await getTokenFromConfig(config.token, connection.orgId, db, logger);
                     return {
+                        // @note: If we don't provide a username, the password will be set as the username. This seems to work
+                        // for ADO cloud but not for ADO server. To fix this, we set a placeholder username to ensure the password
+                        // is set correctly
+                        username: 'user',
                         password: token,
                     }
                 }


### PR DESCRIPTION
It seems that ADO server doesn't support passing in the PAT in the username field (this may be a quirk in ADO cloud, because it worked in my testing). Set a placeholder username so that the PAT is properly embedded in the password field in the url

Fixes #522