### PR TITLE
chore(web): Remove join on connections for getRepos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Improved repository query performance by adding db indices. [#526](https://github.com/sourcebot-dev/sourcebot/pull/526)
+- Improved repository query performance by removing JOIN on `Connection` table. [#527](https://github.com/sourcebot-dev/sourcebot/pull/527)
 
 ## [4.7.1] - 2025-09-19
 

--- a/packages/mcp/src/schemas.ts
+++ b/packages/mcp/src/schemas.ts
@@ -110,10 +110,6 @@ export const repositoryQuerySchema = z.object({
     repoDisplayName: z.string().optional(),
     repoCloneUrl: z.string(),
     webUrl: z.string().optional(),
-    linkedConnections: z.array(z.object({
-        id: z.number(),
-        name: z.string(),
-    })),
     imageUrl: z.string().optional(),
     indexedAt: z.coerce.date().optional(),
     repoIndexingStatus: z.nativeEnum(RepoIndexingStatus),

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -654,13 +654,6 @@ export const getRepos = async (filter: { status?: RepoIndexingStatus[], connecti
                         }
                     }
                 } : {}),
-            },
-            include: {
-                connections: {
-                    include: {
-                        connection: true,
-                    }
-                }
             }
         });
 
@@ -671,10 +664,6 @@ export const getRepos = async (filter: { status?: RepoIndexingStatus[], connecti
             repoDisplayName: repo.displayName ?? undefined,
             repoCloneUrl: repo.cloneUrl,
             webUrl: repo.webUrl ?? undefined,
-            linkedConnections: repo.connections.map(({ connection }) => ({
-                id: connection.id,
-                name: connection.name,
-            })),
             imageUrl: repo.imageUrl ?? undefined,
             indexedAt: repo.indexedAt ?? undefined,
             repoIndexingStatus: repo.repoIndexingStatus,

--- a/packages/web/src/app/[domain]/components/errorNavIndicator.tsx
+++ b/packages/web/src/app/[domain]/components/errorNavIndicator.tsx
@@ -106,24 +106,20 @@ export const ErrorNavIndicator = () => {
                                 <TooltipProvider>
                                     {repos
                                         .slice(0, 10)
-                                        .filter(item => item.linkedConnections.length > 0) // edge case: don't show repos that are orphaned and awaiting gc.
                                         .map(repo => (
-                                            // Link to the first connection for the repo
-                                            <Link key={repo.repoId} href={`/${domain}/connections/${repo.linkedConnections[0].id}`} onClick={() => captureEvent('wa_error_nav_job_pressed', {})}>
-                                                <div className="flex items-center gap-2 px-3 py-2 bg-red-50 dark:bg-red-900/20 
-                                                                rounded-md text-sm text-red-700 dark:text-red-300 
-                                                                border border-red-200/50 dark:border-red-800/50
-                                                                hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors">
-                                                    <Tooltip>
-                                                        <TooltipTrigger asChild>
-                                                            <span className="text-sm font-medium truncate max-w-[200px]">{repo.repoName}</span>
-                                                        </TooltipTrigger>
-                                                        <TooltipContent>
-                                                            {repo.repoName}
-                                                        </TooltipContent>
-                                                    </Tooltip>
-                                                </div>
-                                            </Link>
+                                            <div key={repo.repoId} className="flex items-center gap-2 px-3 py-2 bg-red-50 dark:bg-red-900/20 
+                                                            rounded-md text-sm text-red-700 dark:text-red-300 
+                                                            border border-red-200/50 dark:border-red-800/50
+                                                            hover:bg-red-100 dark:hover:bg-red-900/30 transition-colors">
+                                                <Tooltip>
+                                                    <TooltipTrigger asChild>
+                                                        <span className="text-sm font-medium truncate max-w-[200px]">{repo.repoName}</span>
+                                                    </TooltipTrigger>
+                                                    <TooltipContent>
+                                                        {repo.repoName}
+                                                    </TooltipContent>
+                                                </Tooltip>
+                                            </div>
                                         ))}
                                 </TooltipProvider>
                                 {repos.length > 10 && (

--- a/packages/web/src/app/[domain]/components/progressNavIndicator.tsx
+++ b/packages/web/src/app/[domain]/components/progressNavIndicator.tsx
@@ -50,17 +50,13 @@ export const ProgressNavIndicator = () => {
                         <div className="flex flex-col gap-2 pl-4">
                             {
                                 inProgressRepos.slice(0, 10)
-                                .filter(item => item.linkedConnections.length > 0) // edge case: don't show repos that are orphaned and awaiting gc.
                                 .map(item => (
-                                    // Link to the first connection for the repo
-                                    <Link key={item.repoId} href={`/${domain}/connections/${item.linkedConnections[0].id}`} onClick={() => captureEvent('wa_progress_nav_job_pressed', {})}>
-                                        <div className="flex items-center gap-2 px-3 py-2 bg-green-50 dark:bg-green-900/20 
-                                                    rounded-md text-sm text-green-700 dark:text-green-300 
-                                                    border border-green-200/50 dark:border-green-800/50
-                                                    hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors">
-                                            <span className="font-medium truncate">{item.repoName}</span>
-                                        </div>
-                                    </Link>
+                                    <div key={item.repoId} className="flex items-center gap-2 px-3 py-2 bg-green-50 dark:bg-green-900/20 
+                                                rounded-md text-sm text-green-700 dark:text-green-300 
+                                                border border-green-200/50 dark:border-green-800/50
+                                                hover:bg-green-100 dark:hover:bg-green-900/30 transition-colors">
+                                        <span className="font-medium truncate">{item.repoName}</span>
+                                    </div>
                                 )
                             )}
                             {inProgressRepos.length > 10 && (

--- a/packages/web/src/app/[domain]/repos/columns.tsx
+++ b/packages/web/src/app/[domain]/repos/columns.tsx
@@ -4,7 +4,6 @@ import { Button } from "@/components/ui/button"
 import type { ColumnDef } from "@tanstack/react-table"
 import { ArrowUpDown, ExternalLink, Clock, Loader2, CheckCircle2, XCircle, Trash2, Check, ListFilter } from "lucide-react"
 import Image from "next/image"
-import { Badge } from "@/components/ui/badge"
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip"
 import { cn, getRepoImageSrc } from "@/lib/utils"
 import { RepoIndexingStatus } from "@sourcebot/db";
@@ -14,10 +13,6 @@ export type RepositoryColumnInfo = {
     repoId: number
     name: string
     imageUrl?: string
-    connections: {
-        id: number
-        name: string
-    }[]
     repoIndexingStatus: RepoIndexingStatus
     lastIndexed: string
     url: string
@@ -132,35 +127,6 @@ export const columns = (domain: string): ColumnDef<RepositoryColumnInfo>[] => [
                         </span>
                         {isRemoteRepo && <ExternalLink className="h-3.5 w-3.5 text-muted-foreground" />}
                     </div>
-                </div>
-            )
-        },
-    },
-    {
-        accessorKey: "connections",
-        header: () => <div className="w-[200px]">Connections</div>,
-        cell: ({ row }) => {
-            const connections = row.original.connections
-            
-            if (!connections || connections.length === 0) {
-                return <div className="text-muted-foreground text-sm">—</div>
-            }
-
-            return (
-                <div className="flex flex-wrap gap-1.5">
-                    {connections.map((connection) => (
-                        <Badge
-                            key={connection.id}
-                            variant="outline"
-                            className="text-xs px-2 py-0.5 hover:bg-muted cursor-pointer group flex items-center gap-1"
-                            onClick={() => {
-                                window.location.href = `/${domain}/connections/${connection.id}`
-                            }}
-                        >
-                            {connection.name}
-                            <ExternalLink className="h-3 w-3 text-muted-foreground opacity-50 group-hover:opacity-100 transition-opacity" />
-                        </Badge>
-                    ))}
                 </div>
             )
         },

--- a/packages/web/src/app/[domain]/repos/repositoryTable.tsx
+++ b/packages/web/src/app/[domain]/repos/repositoryTable.tsx
@@ -38,7 +38,6 @@ export const RepositoryTable = ({
         if (reposLoading) return Array(4).fill(null).map(() => ({
             repoId: 0,
             name: "",
-            connections: [],
             repoIndexingStatus: RepoIndexingStatus.NEW,
             lastIndexed: "",
             url: "",
@@ -50,7 +49,6 @@ export const RepositoryTable = ({
             repoId: repo.repoId,
             name: repo.repoDisplayName ?? repo.repoName,
             imageUrl: repo.imageUrl,
-            connections: repo.linkedConnections,
             repoIndexingStatus: repo.repoIndexingStatus as RepoIndexingStatus,
             lastIndexed: repo.indexedAt?.toISOString() ?? "",
             url: repo.webUrl ?? repo.repoCloneUrl,

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -20,10 +20,6 @@ export const repositoryQuerySchema = z.object({
     repoDisplayName: z.string().optional(),
     repoCloneUrl: z.string(),
     webUrl: z.string().optional(),
-    linkedConnections: z.array(z.object({
-        id: z.number(),
-        name: z.string(),
-    })),
     imageUrl: z.string().optional(),
     indexedAt: z.coerce.date().optional(),
     repoIndexingStatus: z.nativeEnum(RepoIndexingStatus),


### PR DESCRIPTION
This PR optimizes the `getRepos` action by removing a JOIN we were doing on the `Connection` table. In my brief testing, this improves query performance by 2-3x, which should improve initial page load times for large instances.

The side-effect of this is that certain UX elements (repository table, progress/error tracker) no longer link back to a connection.