### PR TITLE
fix(web): Change buttons into Links in various places

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved repository query performance by adding db indices. [#526](https://github.com/sourcebot-dev/sourcebot/pull/526)
 - Improved repository query performance by removing JOIN on `Connection` table. [#527](https://github.com/sourcebot-dev/sourcebot/pull/527)
 - Changed repo carousel and repo list links to redirect to the file browser. [#528](https://github.com/sourcebot-dev/sourcebot/pull/528)
+- Changed file headers, files/directories in file tree, and reference list buttons into links. [#532](https://github.com/sourcebot-dev/sourcebot/pull/532)
 
 ## [4.7.1] - 2025-09-19
 

--- a/packages/web/src/app/[domain]/browse/[...path]/components/pureTreePreviewPanel.tsx
+++ b/packages/web/src/app/[domain]/browse/[...path]/components/pureTreePreviewPanel.tsx
@@ -1,11 +1,12 @@
 'use client';
 
-import { useCallback, useRef } from "react";
+import { useRef } from "react";
 import { FileTreeItem } from "@/features/fileTree/actions";
 import { FileTreeItemComponent } from "@/features/fileTree/components/fileTreeItemComponent";
-import { useBrowseNavigation } from "../../hooks/useBrowseNavigation";
+import { getBrowsePath } from "../../hooks/useBrowseNavigation";
 import { ScrollArea } from "@/components/ui/scroll-area";
 import { useBrowseParams } from "../../hooks/useBrowseParams";
+import { useDomain } from "@/hooks/useDomain";
 
 interface PureTreePreviewPanelProps {
     items: FileTreeItem[];
@@ -13,18 +14,9 @@ interface PureTreePreviewPanelProps {
 
 export const PureTreePreviewPanel = ({ items }: PureTreePreviewPanelProps) => {
     const { repoName, revisionName } = useBrowseParams();
-    const { navigateToPath } = useBrowseNavigation();
     const scrollAreaRef = useRef<HTMLDivElement>(null);
-
-    const onNodeClicked = useCallback((node: FileTreeItem) => {
-        navigateToPath({
-            repoName: repoName,
-            revisionName: revisionName,
-            path: node.path,
-            pathType: node.type === 'tree' ? 'tree' : 'blob',
-        });
-    }, [navigateToPath, repoName, revisionName]);
-
+    const domain = useDomain();
+   
     return (
         <ScrollArea
             className="flex flex-col p-0.5"
@@ -37,8 +29,14 @@ export const PureTreePreviewPanel = ({ items }: PureTreePreviewPanelProps) => {
                     isActive={false}
                     depth={0}
                     isCollapseChevronVisible={false}
-                    onClick={() => onNodeClicked(item)}
                     parentRef={scrollAreaRef}
+                    href={getBrowsePath({
+                        repoName,
+                        revisionName,
+                        path: item.path,
+                        pathType: item.type === 'tree' ? 'tree' : 'blob',
+                        domain,
+                    })}
                 />
             ))}
         </ScrollArea>

--- a/packages/web/src/app/[domain]/search/components/searchResultsPanel/fileMatch.tsx
+++ b/packages/web/src/app/[domain]/search/components/searchResultsPanel/fileMatch.tsx
@@ -1,27 +1,22 @@
 'use client';
 
-import { useCallback } from "react";
 import { SearchResultFile, SearchResultChunk } from "@/features/search/types";
 import { LightweightCodeHighlighter } from "@/app/[domain]/components/lightweightCodeHighlighter";
+import Link from "next/link";
+import { getBrowsePath } from "@/app/[domain]/browse/hooks/useBrowseNavigation";
+import { useDomain } from "@/hooks/useDomain";
 
 
 interface FileMatchProps {
     match: SearchResultChunk;
     file: SearchResultFile;
-    onOpen: (startLineNumber: number, endLineNumber: number, isCtrlKeyPressed: boolean) => void;
 }
 
 export const FileMatch = ({
     match,
     file,
-    onOpen: _onOpen,
 }: FileMatchProps) => {
-    const onOpen = useCallback((isCtrlKeyPressed: boolean) => {
-        const startLineNumber = match.contentStart.lineNumber;
-        const endLineNumber = match.content.trimEnd().split('\n').length + startLineNumber - 1;
-
-        _onOpen(startLineNumber, endLineNumber, isCtrlKeyPressed);
-    }, [match.content, match.contentStart.lineNumber, _onOpen]);
+    const domain = useDomain();
 
     // If it's just the title, don't show a code preview
     if (match.matchRanges.length === 0) {
@@ -29,19 +24,24 @@ export const FileMatch = ({
     }
 
     return (
-        <div
+        <Link
             tabIndex={0}
             className="cursor-pointer focus:ring-inset focus:ring-4 bg-background hover:bg-editor-lineHighlight"
-            onKeyDown={(e) => {
-                if (e.key !== "Enter") {
-                    return;
+            href={getBrowsePath({
+                repoName: file.repository,
+                revisionName: file.branches?.[0] ?? 'HEAD',
+                path: file.fileName.text,
+                pathType: 'blob',
+                domain,
+                highlightRange: {
+                    start: {
+                        lineNumber: match.contentStart.lineNumber,
+                    },
+                    end: {
+                        lineNumber: match.content.trimEnd().split('\n').length + match.contentStart.lineNumber - 1,
+                    }
                 }
-
-                onOpen(e.metaKey || e.ctrlKey);
-            }}
-            onClick={(e) => {
-                onOpen(e.metaKey || e.ctrlKey);
-            }}
+            })}
             title="open file: click, open file preview: cmd/ctrl + click"
         >
             <LightweightCodeHighlighter
@@ -53,6 +53,6 @@ export const FileMatch = ({
             >
                 {match.content}
             </LightweightCodeHighlighter>
-        </div>
+        </Link>
     );
 }

--- a/packages/web/src/app/[domain]/search/components/searchResultsPanel/fileMatchContainer.tsx
+++ b/packages/web/src/app/[domain]/search/components/searchResultsPanel/fileMatchContainer.tsx
@@ -7,7 +7,6 @@ import { useMemo } from "react";
 import { FileMatch } from "./fileMatch";
 import { RepositoryInfo, SearchResultFile } from "@/features/search/types";
 import { Button } from "@/components/ui/button";
-import { useBrowseNavigation } from "@/app/[domain]/browse/hooks/useBrowseNavigation";
 
 export const MAX_MATCHES_TO_PREVIEW = 3;
 
@@ -33,7 +32,6 @@ export const FileMatchContainer = ({
     const matchCount = useMemo(() => {
         return file.chunks.length;
     }, [file]);
-    const { navigateToPath } = useBrowseNavigation();
 
     const matches = useMemo(() => {
         const sortedMatches = file.chunks.sort((a, b) => {
@@ -123,29 +121,6 @@ export const FileMatchContainer = ({
                     <FileMatch
                         match={match}
                         file={file}
-                        onOpen={(startLineNumber, endLineNumber, isCtrlKeyPressed) => {
-                            if (isCtrlKeyPressed) {
-                                const matchIndex = matches.slice(0, index).reduce((acc, match) => {
-                                    return acc + match.matchRanges.length;
-                                }, 0);
-                                onOpenFilePreview(matchIndex);
-                            } else {
-                                navigateToPath({
-                                    repoName: file.repository,
-                                    revisionName: file.branches?.[0] ?? 'HEAD',
-                                    path: file.fileName.text,
-                                    pathType: 'blob',
-                                    highlightRange: {
-                                        start: {
-                                            lineNumber: startLineNumber,
-                                        },
-                                        end: {
-                                            lineNumber: endLineNumber,
-                                        }
-                                    }
-                                });
-                            }
-                        }}
                     />
                     {(index !== matches.length - 1 || isMoreContentButtonVisible) && (
                         <Separator className="bg-accent" />

--- a/packages/web/src/ee/features/codeNav/components/exploreMenu/referenceList.tsx
+++ b/packages/web/src/ee/features/codeNav/components/exploreMenu/referenceList.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useBrowseNavigation } from "@/app/[domain]/browse/hooks/useBrowseNavigation";
+import { getBrowsePath } from "@/app/[domain]/browse/hooks/useBrowseNavigation";
 import { PathHeader } from "@/app/[domain]/components/pathHeader";
 import { LightweightCodeHighlighter } from "@/app/[domain]/components/lightweightCodeHighlighter";
 import { FindRelatedSymbolsResponse } from "@/features/codeNav/types";
@@ -8,6 +8,8 @@ import { RepositoryInfo, SourceRange } from "@/features/search/types";
 import { useMemo, useRef } from "react";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useVirtualizer } from "@tanstack/react-virtual";
+import Link from "next/link";
+import { useDomain } from "@/hooks/useDomain";
 
 interface ReferenceListProps {
     data: FindRelatedSymbolsResponse;
@@ -21,6 +23,7 @@ export const ReferenceList = ({
     data,
     revisionName,
 }: ReferenceListProps) => {
+    const domain = useDomain();
     const repoInfoMap = useMemo(() => {
         return data.repositoryInfo.reduce((acc, repo) => {
             acc[repo.id] = repo;
@@ -28,7 +31,6 @@ export const ReferenceList = ({
         }, {} as Record<number, RepositoryInfo>);
     }, [data.repositoryInfo]);
 
-    const { navigateToPath } = useBrowseNavigation();
     const captureEvent = useCaptureEvent();
 
     // Virtualization setup
@@ -38,7 +40,7 @@ export const ReferenceList = ({
         getScrollElement: () => parentRef.current,
         estimateSize: (index) => {
             const file = data.files[index];
-            
+
             const estimatedSize =
                 file.matches.length * ESTIMATED_LINE_HEIGHT_PX +
                 ESTIMATED_MATCH_CONTAINER_HEIGHT_PX;
@@ -103,22 +105,26 @@ export const ReferenceList = ({
                                 {file.matches
                                     .sort((a, b) => a.range.start.lineNumber - b.range.start.lineNumber)
                                     .map((match, index) => (
-                                        <ReferenceListItem
-                                            key={index}
-                                            lineContent={match.lineContent}
-                                            range={match.range}
-                                            language={file.language}
+                                        <Link
+                                            href={getBrowsePath({
+                                                repoName: file.repository,
+                                                revisionName,
+                                                path: file.fileName,
+                                                pathType: 'blob',
+                                                highlightRange: match.range,
+                                                domain,
+                                            })}
                                             onClick={() => {
                                                 captureEvent('wa_explore_menu_reference_clicked', {});
-                                                navigateToPath({
-                                                    repoName: file.repository,
-                                                    revisionName,
-                                                    path: file.fileName,
-                                                    pathType: 'blob',
-                                                    highlightRange: match.range,
-                                                })
                                             }}
-                                        />
+                                        >
+                                            <ReferenceListItem
+                                                key={index}
+                                                lineContent={match.lineContent}
+                                                range={match.range}
+                                                language={file.language}
+                                            />
+                                        </Link>
                                     ))}
                             </div>
                         </div>
@@ -134,21 +140,18 @@ interface ReferenceListItemProps {
     lineContent: string;
     range: SourceRange;
     language: string;
-    onClick: () => void;
 }
 
 const ReferenceListItem = ({
     lineContent,
     range,
     language,
-    onClick,
 }: ReferenceListItemProps) => {
     const highlightRanges = useMemo(() => [range], [range]);
 
     return (
         <div
             className="w-full hover:bg-accent py-1 cursor-pointer"
-            onClick={onClick}
         >
             <LightweightCodeHighlighter
                 language={language}

--- a/packages/web/src/ee/features/codeNav/components/exploreMenu/referenceList.tsx
+++ b/packages/web/src/ee/features/codeNav/components/exploreMenu/referenceList.tsx
@@ -117,9 +117,9 @@ export const ReferenceList = ({
                                             onClick={() => {
                                                 captureEvent('wa_explore_menu_reference_clicked', {});
                                             }}
+                                            key={index}
                                         >
                                             <ReferenceListItem
-                                                key={index}
                                                 lineContent={match.lineContent}
                                                 range={match.range}
                                                 language={file.language}

--- a/packages/web/src/features/fileTree/components/fileTreeItemComponent.tsx
+++ b/packages/web/src/features/fileTree/components/fileTreeItemComponent.tsx
@@ -6,6 +6,7 @@ import clsx from "clsx";
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { ChevronDownIcon, ChevronRightIcon } from "@radix-ui/react-icons";
 import { FileTreeItemIcon } from "./fileTreeItemIcon";
+import Link from "next/link";
 
 export const FileTreeItemComponent = ({
     node,
@@ -13,7 +14,9 @@ export const FileTreeItemComponent = ({
     depth,
     isCollapsed = false,
     isCollapseChevronVisible = true,
+    href,
     onClick,
+    onNavigate,
     parentRef,
 }: {
     node: FileTreeItem,
@@ -21,10 +24,12 @@ export const FileTreeItemComponent = ({
     depth: number,
     isCollapsed?: boolean,
     isCollapseChevronVisible?: boolean,
-    onClick: () => void,
+    href: string,
+    onClick?: (e: React.MouseEvent<HTMLAnchorElement>) => void,
+    onNavigate?: (e: { preventDefault: () => void }) => void,
     parentRef: React.RefObject<HTMLDivElement | null>,
 }) => {
-    const ref = useRef<HTMLDivElement>(null);
+    const ref = useRef<HTMLAnchorElement>(null);
 
     useEffect(() => {
         if (isActive && ref.current) {
@@ -51,20 +56,16 @@ export const FileTreeItemComponent = ({
     }, [isActive, parentRef]);
 
     return (
-        <div
+        <Link
             ref={ref}
+            href={href}
             className={clsx("flex flex-row gap-1 items-center hover:bg-accent hover:text-accent-foreground rounded-sm cursor-pointer p-0.5", {
                 'bg-accent': isActive,
             })}
             style={{ paddingLeft: `${depth * 16}px` }}
             tabIndex={0}
-            onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                    e.preventDefault();
-                    onClick();
-                }
-            }}
             onClick={onClick}
+            onNavigate={onNavigate}
         >
             <div
                 className="flex flex-row gap-1 cursor-pointer w-4 h-4 flex-shrink-0"
@@ -79,6 +80,6 @@ export const FileTreeItemComponent = ({
             </div>
             <FileTreeItemIcon item={node} />
             <span className="text-sm">{node.name}</span>
-        </div>
+        </Link>
     )
 }


### PR DESCRIPTION
Converted the following things into links:
- File headers (including breadcrumb dropdown)
- Files & directories in the file tree
- Reference list

Fixes #519 

The last remaining area I would like to turn into links is the code nav buttons (find all refs / defs). These are slightly more complicated, so I'll leave them for a separate PR.