### PR TITLE
[member approval] configurable via environment

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -23,6 +23,9 @@ AUTH_URL="http://localhost:3000"
 # AUTH_EE_GOOGLE_CLIENT_ID=""
 # AUTH_EE_GOOGLE_CLIENT_SECRET=""
 
+# FORCE_ENABLE_ANONYMOUS_ACCESS="false"
+# FORCE_MEMBER_APPROVAL_REQUIRED="false"
+
 DATA_CACHE_DIR=${PWD}/.sourcebot  # Path to the sourcebot cache dir (ex. ~/sourcebot/.sourcebot)
 SOURCEBOT_PUBLIC_KEY_PATH=${PWD}/public.pem
 # CONFIG_PATH=${PWD}/config.json # Path to the sourcebot config file (if one exists)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Enable configuration of member approval via Env Var. [#542](https://github.com/sourcebot-dev/sourcebot/pull/542)
 
 ## [4.7.2] - 2025-09-22
 

--- a/docs/docs/configuration/environment-variables.mdx
+++ b/docs/docs/configuration/environment-variables.mdx
@@ -22,6 +22,7 @@ The following environment variables allow you to configure your Sourcebot deploy
 | `DATABASE_URL` | `postgresql://postgres@ localhost:5432/sourcebot` | <p>Connection string of your Postgres database. By default, a Postgres database is automatically provisioned at startup within the container.</p><p>If you'd like to use a non-default schema, you can provide it as a parameter in the database url </p> |
 | `EMAIL_FROM_ADDRESS` | `-` | <p>The email address that transactional emails will be sent from. See [this doc](/docs/configuration/transactional-emails) for more info.</p> | 
 | `FORCE_ENABLE_ANONYMOUS_ACCESS` | `false` | <p>When enabled, [anonymous access](/docs/configuration/auth/access-settings#anonymous-access) to the organization will always be enabled</p>
+| `FORCE_MEMBER_APPROVAL_REQUIRED` | `-` | <p>When set to `true` or `false`, forces the member approval requirement setting and disables the UI toggle. When enabled, new users will need approval from an organization owner before they can access your deployment. See [access settings docs](/docs/configuration/auth/access-settings) for more info</p>
 | `REDIS_DATA_DIR` | `$DATA_CACHE_DIR/redis` | <p>The data directory for the default Redis instance.</p> |
 | `REDIS_URL` | `redis://localhost:6379` | <p>Connection string of your Redis instance. By default, a Redis database is automatically provisioned at startup within the container.</p> |
 | `REDIS_REMOVE_ON_COMPLETE` | `0` | <p>Controls how many completed jobs are allowed to remain in Redis queues</p> |

--- a/packages/web/src/app/components/memberApprovalRequiredToggle.tsx
+++ b/packages/web/src/app/components/memberApprovalRequiredToggle.tsx
@@ -10,9 +10,10 @@ import { useToast } from "@/components/hooks/use-toast"
 interface MemberApprovalRequiredToggleProps {
     memberApprovalRequired: boolean
     onToggleChange?: (checked: boolean) => void
+    forceMemberApprovalRequired?: string
 }
 
-export function MemberApprovalRequiredToggle({ memberApprovalRequired, onToggleChange }: MemberApprovalRequiredToggleProps) {
+export function MemberApprovalRequiredToggle({ memberApprovalRequired, onToggleChange, forceMemberApprovalRequired }: MemberApprovalRequiredToggleProps) {
     const [enabled, setEnabled] = useState(memberApprovalRequired)
     const [isLoading, setIsLoading] = useState(false)
     const { toast } = useToast()
@@ -45,6 +46,9 @@ export function MemberApprovalRequiredToggle({ memberApprovalRequired, onToggleC
         }
     }
 
+    const isDisabled = isLoading || forceMemberApprovalRequired !== undefined;
+    const showForceMessage = forceMemberApprovalRequired !== undefined;
+
     return (
         <div className="p-4 rounded-lg border border-[var(--border)] bg-[var(--card)]">
             <div className="flex items-start justify-between gap-4">
@@ -56,13 +60,35 @@ export function MemberApprovalRequiredToggle({ memberApprovalRequired, onToggleC
                         <p className="text-sm text-[var(--muted-foreground)] leading-relaxed">
                             When enabled, new users will need approval from an organization owner before they can access your deployment.
                         </p>
+                        {showForceMessage && (
+                            <div className="mt-3">
+                                <p className="flex items-start gap-2 text-sm text-[var(--muted-foreground)] p-3 rounded-md bg-[var(--muted)] border border-[var(--border)]">
+                                    <svg 
+                                        className="w-4 h-4 mt-0.5 flex-shrink-0" 
+                                        fill="none" 
+                                        stroke="currentColor" 
+                                        viewBox="0 0 24 24"
+                                    >
+                                        <path 
+                                            strokeLinecap="round" 
+                                            strokeLinejoin="round" 
+                                            strokeWidth={2} 
+                                            d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z" 
+                                        />
+                                    </svg>
+                                    <span>
+                                        The <code className="bg-[var(--secondary)] px-1 py-0.5 rounded text-xs font-mono">FORCE_MEMBER_APPROVAL_REQUIRED</code> environment variable is set, so this cannot be changed from the UI.
+                                    </span>
+                                </p>
+                            </div>
+                        )}
                     </div>
                 </div>
                 <div className="flex-shrink-0">
                     <Switch
                         checked={enabled}
                         onCheckedChange={handleToggle}
-                        disabled={isLoading}
+                        disabled={isDisabled}
                     />
                 </div>
             </div>

--- a/packages/web/src/app/components/organizationAccessSettings.tsx
+++ b/packages/web/src/app/components/organizationAccessSettings.tsx
@@ -24,6 +24,7 @@ export async function OrganizationAccessSettings() {
     const hasAnonymousAccessEntitlement = hasEntitlement("anonymous-access");
 
     const forceEnableAnonymousAccess = env.FORCE_ENABLE_ANONYMOUS_ACCESS === 'true';
+    const forceMemberApprovalRequired = env.FORCE_MEMBER_APPROVAL_REQUIRED;
 
     return (
         <div className="space-y-6">
@@ -37,6 +38,7 @@ export async function OrganizationAccessSettings() {
                 memberApprovalRequired={org.memberApprovalRequired}
                 inviteLinkEnabled={org.inviteLinkEnabled}
                 inviteLink={inviteLink}
+                forceMemberApprovalRequired={forceMemberApprovalRequired}
             />
         </div>
     )

--- a/packages/web/src/app/components/organizationAccessSettingsWrapper.tsx
+++ b/packages/web/src/app/components/organizationAccessSettingsWrapper.tsx
@@ -8,12 +8,14 @@ interface OrganizationAccessSettingsWrapperProps {
     memberApprovalRequired: boolean
     inviteLinkEnabled: boolean
     inviteLink: string | null
+    forceMemberApprovalRequired?: string
 }
 
 export function OrganizationAccessSettingsWrapper({ 
     memberApprovalRequired, 
     inviteLinkEnabled, 
-    inviteLink
+    inviteLink,
+    forceMemberApprovalRequired
 }: OrganizationAccessSettingsWrapperProps) {
     const [showInviteLink, setShowInviteLink] = useState(memberApprovalRequired)
     
@@ -27,6 +29,7 @@ export function OrganizationAccessSettingsWrapper({
                 <MemberApprovalRequiredToggle 
                     memberApprovalRequired={memberApprovalRequired}
                     onToggleChange={handleMemberApprovalToggle}
+                    forceMemberApprovalRequired={forceMemberApprovalRequired}
                 />
             </div>
             

--- a/packages/web/src/env.mjs
+++ b/packages/web/src/env.mjs
@@ -21,6 +21,7 @@ export const env = createEnv({
         
         // Auth
         FORCE_ENABLE_ANONYMOUS_ACCESS: booleanSchema.default('false'),
+        FORCE_MEMBER_APPROVAL_REQUIRED: booleanSchema.optional(),
         
         AUTH_SECRET: z.string(),
         AUTH_URL: z.string().url(),

--- a/packages/web/src/initialize.ts
+++ b/packages/web/src/initialize.ts
@@ -131,6 +131,19 @@ const syncDeclarativeConfig = async (configPath: string) => {
         }
     }
 
+    // Apply FORCE_MEMBER_APPROVAL_REQUIRED environment variable setting
+    if (env.FORCE_MEMBER_APPROVAL_REQUIRED !== undefined) {
+        const forceMemberApprovalRequired = env.FORCE_MEMBER_APPROVAL_REQUIRED === 'true';
+        const org = await getOrgFromDomain(SINGLE_TENANT_ORG_DOMAIN);
+        if (org) {
+            await prisma.org.update({
+                where: { id: org.id },
+                data: { memberApprovalRequired: forceMemberApprovalRequired },
+            });
+            logger.info(`Member approval required set to ${forceMemberApprovalRequired} via FORCE_MEMBER_APPROVAL_REQUIRED environment variable`);
+        }
+    }
+
     await syncConnections(config.connections);
     await syncSearchContexts({
         contexts: config.contexts,
@@ -180,6 +193,9 @@ const initSingleTenancy = async () => {
                     name: SINGLE_TENANT_ORG_NAME,
                     domain: SINGLE_TENANT_ORG_DOMAIN,
                     inviteLinkId: crypto.randomUUID(),
+                    memberApprovalRequired: env.FORCE_MEMBER_APPROVAL_REQUIRED === 'true' ? true : 
+                                          env.FORCE_MEMBER_APPROVAL_REQUIRED === 'false' ? false : 
+                                          true, // default to true if FORCE_MEMBER_APPROVAL_REQUIRED is not set
                 }
             });
         } else if (!org.inviteLinkId) {
@@ -217,6 +233,19 @@ const initSingleTenancy = async () => {
                 where: { id: org.id },
                 data: { metadata: mergedMetadata },
             });
+        }
+    }
+
+    // Apply FORCE_MEMBER_APPROVAL_REQUIRED environment variable setting
+    if (env.FORCE_MEMBER_APPROVAL_REQUIRED !== undefined) {
+        const forceMemberApprovalRequired = env.FORCE_MEMBER_APPROVAL_REQUIRED === 'true';
+        const org = await getOrgFromDomain(SINGLE_TENANT_ORG_DOMAIN);
+        if (org) {
+            await prisma.org.update({
+                where: { id: org.id },
+                data: { memberApprovalRequired: forceMemberApprovalRequired },
+            });
+            logger.info(`Member approval required set to ${forceMemberApprovalRequired} via FORCE_MEMBER_APPROVAL_REQUIRED environment variable`);
         }
     }
 


### PR DESCRIPTION
* Enable configuration of member approval via Env Var vs. a UI toggle.
* Follows the same pattern as `FORCE_ENABLE_ANONYMOUS_ACCESS`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added environment variables to control anonymous access and require member approval.
  - Organization access settings now reflect enforced member approval by disabling the toggle and showing an explanatory message.
  - Single-tenant setups automatically apply the member approval requirement based on configuration.

- Documentation
  - Documented the new member approval environment variable and its default.

- Chores
  - Updated the changelog to note that member approval can be configured via an environment variable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->