### PR TITLE
fix(ado): Manually pass token through http header for ado server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Manually pass auth token for ado server deployments. [#543](https://github.com/sourcebot-dev/sourcebot/pull/543)
+
 ## [4.7.2] - 2025-09-22
 
 ### Fixed

--- a/docs/docs/connections/ado-cloud.mdx
+++ b/docs/docs/connections/ado-cloud.mdx
@@ -15,6 +15,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             "repos": [
                 "organizationName/projectName/repoName",
                 "organizationName/projectName/repoName2
@@ -26,6 +27,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             "orgs": [
                 "organizationName",
                 "organizationName2
@@ -37,6 +39,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             "projects": [
                 "organizationName/projectName",
                 "organizationName/projectName2"
@@ -48,6 +51,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             // Include all repos in my-org...
             "orgs": [
                 "my-org"
@@ -91,6 +95,7 @@ Next, provide the access token via the `token` property, either as an environmen
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             "token": {
                 // note: this env var can be named anything. It
                 // doesn't need to be `ADO_TOKEN`.
@@ -121,6 +126,7 @@ Next, provide the access token via the `token` property, either as an environmen
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "cloud",
             "token": {
                 "secret": "mysecret"
             }

--- a/docs/docs/connections/ado-server.mdx
+++ b/docs/docs/connections/ado-server.mdx
@@ -16,7 +16,8 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
-            "useTfsPath": true
+            "deploymentType": "server",
+            "useTfsPath": true,
             "repos": [
                 "organizationName/projectName/repoName",
                 "organizationName/projectName/repoName2
@@ -28,6 +29,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             "repos": [
                 "organizationName/projectName/repoName",
                 "organizationName/projectName/repoName2
@@ -39,6 +41,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             "orgs": [
                 "collectionName",
                 "collectionName2"
@@ -50,6 +53,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             "projects": [
                 "collectionName/projectName",
                 "collectionName/projectName2"
@@ -61,6 +65,7 @@ If you're not familiar with Sourcebot [connections](/docs/connections/overview),
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             // Include all repos in my-org...
             "orgs": [
                 "my-org"
@@ -104,6 +109,7 @@ Next, provide the access token via the `token` property, either as an environmen
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             "token": {
                 // note: this env var can be named anything. It
                 // doesn't need to be `ADO_TOKEN`.
@@ -134,6 +140,7 @@ Next, provide the access token via the `token` property, either as an environmen
         ```json
         {
             "type": "azuredevops",
+            "deploymentType": "server",
             "token": {
                 "secret": "mysecret"
             }

--- a/docs/snippets/schemas/v3/azuredevops.schema.mdx
+++ b/docs/snippets/schemas/v3/azuredevops.schema.mdx
@@ -62,7 +62,6 @@
         "cloud",
         "server"
       ],
-      "default": "cloud",
       "description": "The type of Azure DevOps deployment"
     },
     "useTfsPath": {
@@ -199,7 +198,8 @@
   },
   "required": [
     "type",
-    "token"
+    "token",
+    "deploymentType"
   ],
   "additionalProperties": false
 }

--- a/docs/snippets/schemas/v3/connection.schema.mdx
+++ b/docs/snippets/schemas/v3/connection.schema.mdx
@@ -931,7 +931,6 @@
             "cloud",
             "server"
           ],
-          "default": "cloud",
           "description": "The type of Azure DevOps deployment"
         },
         "useTfsPath": {
@@ -1068,7 +1067,8 @@
       },
       "required": [
         "type",
-        "token"
+        "token",
+        "deploymentType"
       ],
       "additionalProperties": false
     },

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -1214,7 +1214,6 @@
                     "cloud",
                     "server"
                   ],
-                  "default": "cloud",
                   "description": "The type of Azure DevOps deployment"
                 },
                 "useTfsPath": {
@@ -1351,7 +1350,8 @@
               },
               "required": [
                 "type",
-                "token"
+                "token",
+                "deploymentType"
               ],
               "additionalProperties": false
             },

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -78,10 +78,6 @@ export const fetchRepository = async (
             "--prune",
             "--progress"
         ]);
-
-        if (authHeader) {
-            await git.raw(["config", "--unset", "http.extraHeader", authHeader]);
-        }
     } catch (error: unknown) {
         const baseLog = `Failed to fetch repository: ${path}`;
         if (env.SOURCEBOT_LOG_LEVEL !== "debug") {
@@ -91,6 +87,16 @@ export const fetchRepository = async (
             throw new Error(`${baseLog}. Reason: ${error.message}`);
         } else {
             throw new Error(`${baseLog}. Error: ${error}`);
+        }
+    } finally {
+        if (authHeader) {
+            const git = simpleGit({
+                progress: onProgress,
+            }).cwd({
+                path: path,
+            })
+
+            await git.raw(["config", "--unset", "http.extraHeader", authHeader]);
         }
     }
 }

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -78,6 +78,10 @@ export const fetchRepository = async (
             "--prune",
             "--progress"
         ]);
+
+        if (authHeader) {
+            await git.raw(["config", "--unset", "http.extraHeader", authHeader]);
+        }
     } catch (error: unknown) {
         const baseLog = `Failed to fetch repository: ${path}`;
         if (env.SOURCEBOT_LOG_LEVEL !== "debug") {

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -26,25 +26,12 @@ export const cloneRepository = async (
             path,
         })
 
-        if (authHeader) {
-            await git.clone(
-                cloneUrl,
-                path,
-                [
-                    "--bare",
-                    "-c",
-                    `http.extraHeader=${authHeader}`,
-                ]
-            )
-        } else {
-            await git.clone(
-                cloneUrl,
-                path,
-                [
-                    "--bare",
-                ]
-            )
-        }
+        const cloneArgs = [
+            "--bare",
+            ...(authHeader ? ["-c", `http.extraHeader=${authHeader}`] : [])
+        ];
+
+        await git.clone(cloneUrl, path, cloneArgs);
 
         await unsetGitConfig(path, ["remote.origin.url"]);
     } catch (error: unknown) {

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -1,7 +1,6 @@
 import { CheckRepoActions, GitConfigScope, simpleGit, SimpleGitProgressEvent } from 'simple-git';
 import { mkdir } from 'node:fs/promises';
 import { env } from './env.js';
-import { doesHaveEmbeddedToken } from './utils.js';
 
 type onProgressFn = (event: SimpleGitProgressEvent) => void;
 
@@ -28,10 +27,6 @@ export const cloneRepository = async (
         })
 
         if (authHeader) {
-            if (doesHaveEmbeddedToken(cloneUrl)) {
-                throw new Error("Cannot use auth header when clone URL has embedded token");
-            }
-
             await git.clone(
                 cloneUrl,
                 path,
@@ -87,10 +82,6 @@ export const fetchRepository = async (
         })
 
         if (authHeader) {
-            if (doesHaveEmbeddedToken(cloneUrl)) {
-                throw new Error("Cannot use auth header when clone URL has embedded token");
-            }
-
             await git.addConfig("http.extraHeader", authHeader);
         }
 

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -175,7 +175,7 @@ export class RepoManager {
 
         const credentials = await getAuthCredentialsForRepo(repo, this.db);
         const cloneUrlMaybeWithToken = credentials?.cloneUrlWithToken ?? repo.cloneUrl;
-        const authHeader = credentials?.authToken ?? undefined;
+        const authHeader = credentials?.authHeader ?? undefined;
 
         if (existsSync(repoPath) && !isReadOnly) {
             // @NOTE: in #483, we changed the cloning method s.t., we _no longer_

--- a/packages/backend/src/repoManager.ts
+++ b/packages/backend/src/repoManager.ts
@@ -175,6 +175,7 @@ export class RepoManager {
 
         const credentials = await getAuthCredentialsForRepo(repo, this.db);
         const cloneUrlMaybeWithToken = credentials?.cloneUrlWithToken ?? repo.cloneUrl;
+        const authHeader = credentials?.authToken ?? undefined;
 
         if (existsSync(repoPath) && !isReadOnly) {
             // @NOTE: in #483, we changed the cloning method s.t., we _no longer_
@@ -188,6 +189,7 @@ export class RepoManager {
             logger.info(`Fetching ${repo.displayName}...`);
             const { durationMs } = await measure(() => fetchRepository({
                 cloneUrl: cloneUrlMaybeWithToken,
+                authHeader,
                 path: repoPath,
                 onProgress: ({ method, stage, progress }) => {
                     logger.debug(`git.${method} ${stage} stage ${progress}% complete for ${repo.displayName}`)
@@ -203,6 +205,7 @@ export class RepoManager {
 
             const { durationMs } = await measure(() => cloneRepository({
                 cloneUrl: cloneUrlMaybeWithToken,
+                authHeader,
                 path: repoPath,
                 onProgress: ({ method, stage, progress }) => {
                     logger.debug(`git.${method} ${stage} stage ${progress}% complete for ${repo.displayName}`)

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -60,5 +60,5 @@ export type RepoAuthCredentials = {
     hostUrl?: string;
     token: string;
     cloneUrlWithToken?: string;
-    authToken?: string;
+    authHeader?: string;
 }

--- a/packages/backend/src/types.ts
+++ b/packages/backend/src/types.ts
@@ -59,5 +59,6 @@ export type RepoWithConnections = Repo & { connections: (RepoToConnection & { co
 export type RepoAuthCredentials = {
     hostUrl?: string;
     token: string;
-    cloneUrlWithToken: string;
+    cloneUrlWithToken?: string;
+    authToken?: string;
 }

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -196,12 +196,12 @@ export const getAuthCredentialsForRepo = async (repo: RepoWithConnections, db: P
 
                 // For ADO server, multiple auth schemes may be supported. If the ADO deployment supports NTLM, the git clone will default
                 // to this over basic auth. As a result, we cannot embed the token in the clone URL and must force basic auth by passing in the token
-                // appropriately in the header. To do this, we set the authToken field here
+                // appropriately in the header. To do this, we set the authHeader field here
                 if (config.deploymentType === 'server') {
                     return {
                         hostUrl: config.url,
                         token,
-                        authToken: "Authorization: Basic " + Buffer.from(`:${token}`).toString('base64')
+                        authHeader: "Authorization: Basic " + Buffer.from(`:${token}`).toString('base64')
                     }
                 } else {
                     return {

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -241,8 +241,3 @@ const createGitCloneUrlWithToken = (cloneUrl: string, credentials: { username?: 
     }
     return url.toString();
 }
-
-export const doesHaveEmbeddedToken = (cloneUrl: string) => {
-    const url = new URL(cloneUrl);
-    return url.username || url.password;
-}

--- a/packages/schemas/src/v3/azuredevops.schema.ts
+++ b/packages/schemas/src/v3/azuredevops.schema.ts
@@ -61,7 +61,6 @@ const schema = {
         "cloud",
         "server"
       ],
-      "default": "cloud",
       "description": "The type of Azure DevOps deployment"
     },
     "useTfsPath": {
@@ -198,7 +197,8 @@ const schema = {
   },
   "required": [
     "type",
-    "token"
+    "token",
+    "deploymentType"
   ],
   "additionalProperties": false
 } as const;

--- a/packages/schemas/src/v3/azuredevops.type.ts
+++ b/packages/schemas/src/v3/azuredevops.type.ts
@@ -28,7 +28,7 @@ export interface AzureDevOpsConnectionConfig {
   /**
    * The type of Azure DevOps deployment
    */
-  deploymentType?: "cloud" | "server";
+  deploymentType: "cloud" | "server";
   /**
    * Use legacy TFS path format (/tfs) in API URLs. Required for older TFS installations (TFS 2018 and earlier). When true, API URLs will include /tfs in the path (e.g., https://server/tfs/collection/_apis/...).
    */

--- a/packages/schemas/src/v3/connection.schema.ts
+++ b/packages/schemas/src/v3/connection.schema.ts
@@ -930,7 +930,6 @@ const schema = {
             "cloud",
             "server"
           ],
-          "default": "cloud",
           "description": "The type of Azure DevOps deployment"
         },
         "useTfsPath": {
@@ -1067,7 +1066,8 @@ const schema = {
       },
       "required": [
         "type",
-        "token"
+        "token",
+        "deploymentType"
       ],
       "additionalProperties": false
     },

--- a/packages/schemas/src/v3/connection.type.ts
+++ b/packages/schemas/src/v3/connection.type.ts
@@ -340,7 +340,7 @@ export interface AzureDevOpsConnectionConfig {
   /**
    * The type of Azure DevOps deployment
    */
-  deploymentType?: "cloud" | "server";
+  deploymentType: "cloud" | "server";
   /**
    * Use legacy TFS path format (/tfs) in API URLs. Required for older TFS installations (TFS 2018 and earlier). When true, API URLs will include /tfs in the path (e.g., https://server/tfs/collection/_apis/...).
    */

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -1213,7 +1213,6 @@ const schema = {
                     "cloud",
                     "server"
                   ],
-                  "default": "cloud",
                   "description": "The type of Azure DevOps deployment"
                 },
                 "useTfsPath": {
@@ -1350,7 +1349,8 @@ const schema = {
               },
               "required": [
                 "type",
-                "token"
+                "token",
+                "deploymentType"
               ],
               "additionalProperties": false
             },

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -473,7 +473,7 @@ export interface AzureDevOpsConnectionConfig {
   /**
    * The type of Azure DevOps deployment
    */
-  deploymentType?: "cloud" | "server";
+  deploymentType: "cloud" | "server";
   /**
    * Use legacy TFS path format (/tfs) in API URLs. Required for older TFS installations (TFS 2018 and earlier). When true, API URLs will include /tfs in the path (e.g., https://server/tfs/collection/_apis/...).
    */

--- a/schemas/v3/azuredevops.json
+++ b/schemas/v3/azuredevops.json
@@ -30,7 +30,6 @@
         "deploymentType": {
             "type": "string",
             "enum": ["cloud", "server"],
-            "default": "cloud",
             "description": "The type of Azure DevOps deployment"
         },
         "useTfsPath": {
@@ -129,7 +128,8 @@
     },
     "required": [
         "type",
-        "token"
+        "token",
+        "deploymentType"
     ],
     "additionalProperties": false
 }


### PR DESCRIPTION
Thank you @Shaoqi-Cen for proposing the solution for this and providing extremely useful context in https://github.com/sourcebot-dev/sourcebot/pull/533

This PR implements the same underlying logic but with the proposed structure. Putting up this PR so we can get this fix merged asap

This PR also makes the `deploymentType` field in the ADO config mandatory. This makes it much easier to tell with auth strategy to use. This will technically break deployments which don't pass this field in, but the error logs are very clear here and the behavior of the deployment won't change after the deploymentType is set, so I don't think it's worth pushing a major version 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Optionally send Azure DevOps Server auth token via HTTP header for clone/fetch operations.
- **Bug Fixes**
  - Fixed authentication flow for Azure DevOps Server deployments.
- **Documentation**
  - Updated Azure DevOps connection examples to include deploymentType ("cloud" or "server").
  - Changelog entry added noting the auth token handling fix.
- **Chores**
  - Schemas tightened: deploymentType is now required (no default) for Azure DevOps connections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->