### PR TITLE
fix: Fix git dubious ownership errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed "dubious ownership" errors when cloning / fetching repos. [#553](https://github.com/sourcebot-dev/sourcebot/pull/553)
+
 ### Changed
 - Remove spam "login page loaded" log. [#552](https://github.com/sourcebot-dev/sourcebot/pull/552)
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -233,6 +233,9 @@ COPY --from=shared-libs-builder /app/packages/shared ./packages/shared
 # Configure dependencies
 RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget supervisor uuidgen curl perl jq redis postgresql postgresql-contrib openssl util-linux unzip
 
+# Fixes git "dubious ownership" issues when the volume is mounted with different permissions to the container.
+RUN git config --global safe.directory "*"
+
 # Configure the database
 RUN mkdir -p /run/postgresql && \
     chown -R postgres:postgres /run/postgresql && \


### PR DESCRIPTION
Fixes git "dubious ownership" errors that occur when there is a mismatch in permissions between the host user (that mounts the `/data` volume) and the container user. This is a quick workaround that we should be able to remove when #510 merges.

Related:
#168 
#523  