### PR TITLE
chore: update demo deploy cadence to be on tag (instead of main)

### DIFF
--- a/.github/workflows/deploy-demo.yml
+++ b/.github/workflows/deploy-demo.yml
@@ -2,7 +2,7 @@ name: Deploy Demo
 
 on:
   push:
-    branches: ["main"]
+    tags: ["v*.*.*"]
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
Updates the demo deploy cadence to be on tag instead of main. The reasoning is that I would like to make breaking REST API changes (like in #555) without having to spin a new release. However, MCP depends on the demo instance's REST api not breaking (on non-version changes), so that complicates things.

Whether we should worry about breaking public MCP is a separate discussion. For now, let's avoid breaking it.