### PR TITLE
docs: convert HTML comment to markdown blockquote for GitHub visibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-<!-- @NOTE: On next release, please bump the MCP pacakge as there are breaking changes in this! -->
+> **Note:** On next release, please bump the MCP package as there are breaking changes in this!
 
 ### Added
 - Implement dynamic tab titles for files and folders in browse tab. [#560](https://github.com/sourcebot-dev/sourcebot/pull/560)
@@ -205,7 +205,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added audit logging. [#355](https://github.com/sourcebot-dev/sourcebot/pull/355)
-<!-- @NOTE: this release includes a API change that affects the MCP package (@sourcebot/mcp). On release, bump the MCP package's version and delete this message. -->
 
 ### Fixed
 - Delete account join request when redeeming an invite. [#352](https://github.com/sourcebot-dev/sourcebot/pull/352)


### PR DESCRIPTION
Replace invisible HTML comment syntax with markdown blockquote in CHANGELOG.md to ensure important release note is visible on GitHub.

## Changes
- Line 10: Converted HTML comment to markdown blockquote for MCP package release note
- Removed completed note about v4.4.0 API changes

## Rationale
HTML comments (`<!-- -->`) don't render on GitHub's markdown viewer, while markdown blockquotes (`> **Note:**`) are properly displayed to maintainers and contributors reviewing the changelog.

This ensures critical release coordination notes are visible to all team members.