### PR TITLE
chore: Specify shutdown order in supervisord.conf

### DIFF
--- a/supervisord.conf
+++ b/supervisord.conf
@@ -5,6 +5,7 @@ logfile_maxbytes=0
 
 [program:zoekt]
 command=./prefix-output.sh zoekt-webserver -index %(ENV_DATA_CACHE_DIR)s/index -rpc
+priority=10
 autostart=true
 autorestart=true
 startretries=3
@@ -14,6 +15,7 @@ redirect_stderr=true
 
 [program:web]
 command=./prefix-output.sh node packages/web/server.js
+priority=20
 autostart=true
 autorestart=true
 startretries=3
@@ -23,6 +25,7 @@ redirect_stderr=true
 
 [program:backend]
 command=./prefix-output.sh node packages/backend/dist/index.js
+priority=20
 autostart=true
 autorestart=true
 startretries=3
@@ -32,6 +35,7 @@ redirect_stderr=true
 
 [program:redis]
 command=redis-server --dir %(ENV_REDIS_DATA_DIR)s
+priority=10
 autostart=true
 autorestart=true
 startretries=3


### PR DESCRIPTION
This ensures Redis (and zoekt) will startup first and shutdown last, mitigating some ECONNREFUSED errors I was seeing.