### PR TITLE
docs: update link for telemetry docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ To configure Sourcebot (index your own repos, connect your LLMs, etc), check out
 
 > [!NOTE]
 > Sourcebot collects <a href="https://demo.sourcebot.dev/~/search?query=captureEvent%5C(%20repo%3Asourcebot">anonymous usage data</a> by default to help us improve the product. No sensitive data is collected, but if you'd like to disable this you can do so by setting the `SOURCEBOT_TELEMETRY_DISABLED` environment
-> variable to `true`. Please refer to our [telemetry docs](https://docs.sourcebot.dev/self-hosting/overview#telemetry) for more information.
+> variable to `true`. Please refer to our [telemetry docs](https://docs.sourcebot.dev/docs/overview#telemetry) for more information.
 
 # Build from source
 >[!NOTE]


### PR DESCRIPTION
Updated link for telemetry docs. Can add redirect in mintlify's docs.json if needed