### PR TITLE
Shrink Docker image size by ~1/3 by removing unnecessary ops

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -250,8 +250,10 @@ RUN mkdir -p /run/postgresql && \
 RUN chown -R sourcebot:sourcebot /data
 
 COPY supervisord.conf /etc/supervisor/conf.d/supervisord.conf
-COPY --chmod=+x prefix-output.sh ./prefix-output.sh
-COPY --chmod=+x entrypoint.sh ./entrypoint.sh
+COPY prefix-output.sh ./prefix-output.sh
+RUN chmod +x ./prefix-output.sh
+COPY entrypoint.sh ./entrypoint.sh
+RUN chmod +x ./entrypoint.sh
 
 # Note: for back-compat cases, we do _not_ set the USER directive here.
 # Instead, the user can be overridden at runtime with --user flag.


### PR DESCRIPTION
Current image does two very inefficient operations:

* It copies node_modules from `shared-libs-builder` stage to `backend-builder` stage and then in the `runner` stage copies node_modules from both stages again, even though the `backend-builder` stage now contains all the necessary modules.
* It chowns the whole of /app *after* COPYing the files from previous stages

Both of these result in duplicating all of the affected files in the `runner` stage layers, which gives you about 600Mb of wasted space.

By removing the duplicate COPY of node_modules, and performing the chown as part of the COPY operation, that space can be free, reducing the image size substantially.