### PR TITLE
fix: Fix release workflow

### DIFF
--- a/.github/workflows/release-sourcebot.yml
+++ b/.github/workflows/release-sourcebot.yml
@@ -25,11 +25,19 @@ jobs:
       version: ${{ steps.calculate_version.outputs.version }}
 
     steps:
+      - name: Generate GitHub App token
+        id: generate_token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
+
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
+          token: ${{ steps.generate_token.outputs.token }}
 
       - name: Calculate new version
         id: calculate_version
@@ -123,6 +131,8 @@ jobs:
           git tag -a "v$VERSION" -m "sourcebot v$VERSION"
 
       - name: Push changes
+        env:
+          GH_TOKEN: ${{ steps.generate_token.outputs.token }}
         run: |
           git push origin main
           git push origin --tags


### PR DESCRIPTION
The automated release workflow [was failing](https://github.com/sourcebot-dev/sourcebot/actions/runs/20466069272/job/58810032507) because the worker could not bypass the ruleset on main. This PR changes the workflow to use a GitHub app that has bypass permissions.