### PR TITLE
Repo name search bug

### DIFF
--- a/packages/web/src/features/search/parser.test.ts
+++ b/packages/web/src/features/search/parser.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { PrismaClient } from '@sourcebot/db';
+import { parseQuerySyntaxIntoIR } from './parser';
+
+describe('parseQuerySyntaxIntoIR', () => {
+    it('resolves anchored repo display names to repo_set queries', async () => {
+        const findMany = vi.fn().mockResolvedValue([
+            { name: 'gerrit.example.com:29418/zximgw/rcsiap2001' },
+        ]);
+
+        const prisma = {
+            repo: {
+                findMany,
+            },
+        } as unknown as PrismaClient;
+
+        const query = await parseQuerySyntaxIntoIR({
+            query: 'repo:"^zximgw/rcsiap2001$"',
+            options: {},
+            prisma,
+        });
+
+        expect(findMany).toHaveBeenCalledWith({
+            where: {
+                orgId: expect.any(Number),
+                OR: [
+                    { name: 'zximgw/rcsiap2001' },
+                    { displayName: 'zximgw/rcsiap2001' },
+                ],
+            },
+            select: { name: true },
+        });
+
+        expect(query.repo_set).toBeDefined();
+        expect(query.repo_set?.set).toEqual({
+            'gerrit.example.com:29418/zximgw/rcsiap2001': true,
+        });
+    });
+
+    it('falls back to regex handling when pattern is not a literal string', async () => {
+        const findMany = vi.fn();
+        const prisma = {
+            repo: {
+                findMany,
+            },
+        } as unknown as PrismaClient;
+
+        const query = await parseQuerySyntaxIntoIR({
+            query: 'repo:^gerrit.*$',
+            options: {},
+            prisma,
+        });
+
+        expect(findMany).not.toHaveBeenCalled();
+        expect(query.repo?.regexp).toEqual('^gerrit.*$');
+    });
+});


### PR DESCRIPTION
Resolve `repo:` filters with anchored literal repository names by mapping them to actual Zoekt repo names via Prisma, fixing search issues for repos with host/port in their names.

Previously, `repo:` filters using a human-friendly name (e.g., `zximgw/rcsiap2001`) would fail if the underlying Zoekt repository name included a host or port (e.g., `gerritro.zte.com.cn:29418/zximgw/rcsiap2001`). This change introduces a resolver for anchored literal `repo:` queries (e.g., `repo:"^zximgw/rcsiap2001$"`) that looks up matching repositories by `name` or `displayName` in the database and converts the filter to a `repo_set` query with the correct Zoekt name. This ensures accurate search results for such repositories.

---
Linear Issue: [SOU-175](https://linear.app/sourcebot/issue/SOU-175/bug-reponame-like-this-will-affect-problem-and-can-not-search-correct)

<a href="https://cursor.com/background-agent?bcId=bc-aec8d65c-6571-4252-b6a5-37b51ccf8f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aec8d65c-6571-4252-b6a5-37b51ccf8f34"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

