### PR TITLE
feat(web): Adding checkboxes to exclude archived and forked repos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Changed the default `/repos` pagination size to 20. [#706](https://github.com/sourcebot-dev/sourcebot/pull/706)
+- Added checkbox to exclude archived and forked repositories from settings dropdown in the query search tab. [#663](https://github.com/sourcebot-dev/sourcebot/issues/663)
 
 ## [4.10.7] - 2025-12-29
 

--- a/packages/mcp/src/schemas.ts
+++ b/packages/mcp/src/schemas.ts
@@ -27,6 +27,8 @@ export const searchOptionsSchema = z.object({
     whole: z.boolean().optional(),                    // Whether to return the whole file as part of the response.
     isRegexEnabled: z.boolean().optional(),           // Whether to enable regular expression search.
     isCaseSensitivityEnabled: z.boolean().optional(), // Whether to enable case sensitivity.
+    isArchivedExcluded: z.boolean().optional(),       // Whether to exclude archived repositories.
+    isForkedExcluded: z.boolean().optional(),         // Whether to exclude forked repositories.
 });
 
 export const searchRequestSchema = z.object({

--- a/packages/web/src/app/[domain]/components/searchBar/searchBar.tsx
+++ b/packages/web/src/app/[domain]/components/searchBar/searchBar.tsx
@@ -44,7 +44,14 @@ import { Toggle } from "@/components/ui/toggle";
 import { useDomain } from "@/hooks/useDomain";
 import { createAuditAction } from "@/ee/features/audit/actions";
 import tailwind from "@/tailwind";
-import { CaseSensitiveIcon, RegexIcon } from "lucide-react";
+import { CaseSensitiveIcon, RegexIcon, Settings2 } from "lucide-react";
+import {
+    DropdownMenu,
+    DropdownMenuTrigger,
+    DropdownMenuContent,
+    DropdownMenuLabel,
+    DropdownMenuCheckboxItem,
+} from "@/components/ui/dropdown-menu";
 
 interface SearchBarProps {
     className?: string;
@@ -52,6 +59,8 @@ interface SearchBarProps {
     defaults?: {
         isRegexEnabled?: boolean;
         isCaseSensitivityEnabled?: boolean;
+        isArchivedExcluded?: boolean;
+        isForkedExcluded?: boolean;
         query?: string;
     }
     autoFocus?: boolean;
@@ -99,6 +108,8 @@ export const SearchBar = ({
     defaults: {
         isRegexEnabled: defaultIsRegexEnabled = false,
         isCaseSensitivityEnabled: defaultIsCaseSensitivityEnabled = false,
+        isArchivedExcluded: defaultIsArchivedExcluded = false,
+        isForkedExcluded: defaultIsForkedExcluded = false,
         query: defaultQuery = "",
     } = {}
 }: SearchBarProps) => {
@@ -112,6 +123,8 @@ export const SearchBar = ({
     const [isHistorySearchEnabled, setIsHistorySearchEnabled] = useState(false);
     const [isRegexEnabled, setIsRegexEnabled] = useState(defaultIsRegexEnabled);
     const [isCaseSensitivityEnabled, setIsCaseSensitivityEnabled] = useState(defaultIsCaseSensitivityEnabled);
+    const [isArchivedExcluded, setIsArchivedExcluded] = useState(defaultIsArchivedExcluded);
+    const [isForkedExcluded, setIsForkedExcluded] = useState(defaultIsForkedExcluded);
 
     const focusEditor = useCallback(() => editorRef.current?.view?.focus(), []);
     const focusSuggestionsBox = useCallback(() => suggestionBoxRef.current?.focus(), []);
@@ -227,9 +240,11 @@ export const SearchBar = ({
             [SearchQueryParams.query, query],
             [SearchQueryParams.isRegexEnabled, isRegexEnabled ? "true" : null],
             [SearchQueryParams.isCaseSensitivityEnabled, isCaseSensitivityEnabled ? "true" : null],
+            [SearchQueryParams.isArchivedExcluded, isArchivedExcluded ? "true" : null],
+            [SearchQueryParams.isForkedExcluded, isForkedExcluded ? "true" : null],
         );
         router.push(url);
-    }, [domain, router, isRegexEnabled, isCaseSensitivityEnabled]);
+    }, [domain, router, isRegexEnabled, isCaseSensitivityEnabled, isArchivedExcluded, isForkedExcluded]);
 
     return (
         <div
@@ -288,6 +303,40 @@ export const SearchBar = ({
                 autoFocus={autoFocus ?? false}
             />
             <div className="flex flex-row items-center gap-1 ml-1">
+                <DropdownMenu>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <DropdownMenuTrigger asChild>
+                                <span>
+                                    <Toggle
+                                        className="h-7 w-7 min-w-7 p-0 cursor-pointer"
+                                        pressed={false}
+                                        onPressedChange={() => { }}
+                                    >
+                                        <Settings2 className="w-4 h-4" />
+                                    </Toggle>
+                                </span>
+                            </DropdownMenuTrigger>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">Search settings</TooltipContent>
+                    </Tooltip>
+
+                    <DropdownMenuContent align="start">
+                        <DropdownMenuLabel>Search</DropdownMenuLabel>
+                        <DropdownMenuCheckboxItem
+                            checked={isArchivedExcluded}
+                            onCheckedChange={(v: boolean | "mixed") => setIsArchivedExcluded(Boolean(v))}
+                        >
+                            Exclude archived repositories
+                        </DropdownMenuCheckboxItem>
+                        <DropdownMenuCheckboxItem
+                            checked={isForkedExcluded}
+                            onCheckedChange={(v: boolean | "mixed") => setIsForkedExcluded(Boolean(v))}
+                        >
+                            Exclude forked repositories
+                        </DropdownMenuCheckboxItem>
+                    </DropdownMenuContent>
+                </DropdownMenu>
                 <Tooltip>
                     <TooltipTrigger asChild>
                         <span>

--- a/packages/web/src/app/[domain]/search/components/searchResultsPage.tsx
+++ b/packages/web/src/app/[domain]/search/components/searchResultsPage.tsx
@@ -40,6 +40,8 @@ interface SearchResultsPageProps {
     defaultMaxMatchCount: number;
     isRegexEnabled: boolean;
     isCaseSensitivityEnabled: boolean;
+    isArchivedExcluded: boolean;
+    isForkedExcluded: boolean;
 }
 
 export const SearchResultsPage = ({
@@ -47,6 +49,8 @@ export const SearchResultsPage = ({
     defaultMaxMatchCount,
     isRegexEnabled,
     isCaseSensitivityEnabled,
+    isArchivedExcluded,
+    isForkedExcluded,
 }: SearchResultsPageProps) => {
     const router = useRouter();
     const { setSearchHistory } = useSearchHistory();
@@ -75,6 +79,8 @@ export const SearchResultsPage = ({
         whole: false,
         isRegexEnabled,
         isCaseSensitivityEnabled,
+        isArchivedExcluded,
+        isForkedExcluded,
     });
 
     useEffect(() => {
@@ -175,6 +181,8 @@ export const SearchResultsPage = ({
                     defaults={{
                         isRegexEnabled,
                         isCaseSensitivityEnabled,
+                        isArchivedExcluded,
+                        isForkedExcluded,
                         query: searchQuery,
                     }}
                     className="w-full"

--- a/packages/web/src/app/[domain]/search/page.tsx
+++ b/packages/web/src/app/[domain]/search/page.tsx
@@ -8,6 +8,8 @@ interface SearchPageProps {
         query?: string;
         isRegexEnabled?: "true" | "false";
         isCaseSensitivityEnabled?: "true" | "false";
+        isArchivedExcluded?: "true" | "false";
+        isForkedExcluded?: "true" | "false";
     }>;
 }
 
@@ -17,6 +19,8 @@ export default async function SearchPage(props: SearchPageProps) {
     const query = searchParams?.query;
     const isRegexEnabled = searchParams?.isRegexEnabled === "true";
     const isCaseSensitivityEnabled = searchParams?.isCaseSensitivityEnabled === "true";
+    const isArchivedExcluded = searchParams?.isArchivedExcluded === "true";
+    const isForkedExcluded = searchParams?.isForkedExcluded === "true";
 
     if (query === undefined || query.length === 0) {
         return <SearchLandingPage domain={domain} />
@@ -28,6 +32,8 @@ export default async function SearchPage(props: SearchPageProps) {
             defaultMaxMatchCount={env.DEFAULT_MAX_MATCH_COUNT}
             isRegexEnabled={isRegexEnabled}
             isCaseSensitivityEnabled={isCaseSensitivityEnabled}
+            isArchivedExcluded={isArchivedExcluded}
+            isForkedExcluded={isForkedExcluded}
         />
     )
 }

--- a/packages/web/src/app/[domain]/search/useStreamedSearch.ts
+++ b/packages/web/src/app/[domain]/search/useStreamedSearch.ts
@@ -27,6 +27,8 @@ const createCacheKey = (params: SearchRequest): string => {
         whole: params.whole,
         isRegexEnabled: params.isRegexEnabled,
         isCaseSensitivityEnabled: params.isCaseSensitivityEnabled,
+        isArchivedExcluded: params.isArchivedExcluded,
+        isForkedExcluded: params.isForkedExcluded,
     });
 };
 
@@ -34,7 +36,7 @@ const isCacheValid = (entry: CacheEntry): boolean => {
     return Date.now() - entry.timestamp < CACHE_TTL;
 };
 
-export const useStreamedSearch = ({ query, matches, contextLines, whole, isRegexEnabled, isCaseSensitivityEnabled }: SearchRequest) => {
+export const useStreamedSearch = ({ query, matches, contextLines, whole, isRegexEnabled, isCaseSensitivityEnabled, isArchivedExcluded, isForkedExcluded }: SearchRequest) => {
     const [state, setState] = useState<{
         isStreaming: boolean,
         isExhaustive: boolean,
@@ -86,6 +88,8 @@ export const useStreamedSearch = ({ query, matches, contextLines, whole, isRegex
                 whole,
                 isRegexEnabled,
                 isCaseSensitivityEnabled,
+                isArchivedExcluded,
+                isForkedExcluded,
             });
 
             // Check if we have a valid cached result. If so, use it.
@@ -129,6 +133,8 @@ export const useStreamedSearch = ({ query, matches, contextLines, whole, isRegex
                         whole,
                         isRegexEnabled,
                         isCaseSensitivityEnabled,
+                        isArchivedExcluded,
+                        isForkedExcluded,
                         source: 'sourcebot-web-client'
                     } satisfies SearchRequest),
                     signal: abortControllerRef.current.signal,
@@ -279,6 +285,8 @@ export const useStreamedSearch = ({ query, matches, contextLines, whole, isRegex
         whole,
         isRegexEnabled,
         isCaseSensitivityEnabled,
+        isArchivedExcluded,
+        isForkedExcluded,
         cancel,
     ]);
 

--- a/packages/web/src/components/ui/dropdown-menu.tsx
+++ b/packages/web/src/components/ui/dropdown-menu.tsx
@@ -105,9 +105,9 @@ const DropdownMenuCheckboxItem = React.forwardRef<
     checked={checked}
     {...props}
   >
-    <span className="absolute left-2 flex h-3.5 w-3.5 items-center justify-center">
-      <DropdownMenuPrimitive.ItemIndicator>
-        <Check className="h-4 w-4" />
+    <span className="absolute left-2 flex h-4 w-4 items-center justify-center rounded-sm border border-muted bg-transparent">
+      <DropdownMenuPrimitive.ItemIndicator className="flex items-center justify-center text-current">
+        <Check className="h-3.5 w-3.5" />
       </DropdownMenuPrimitive.ItemIndicator>
     </span>
     {children}

--- a/packages/web/src/features/search/parser.ts
+++ b/packages/web/src/features/search/parser.ts
@@ -62,13 +62,19 @@ export const parseQuerySyntaxIntoIR = async ({
     options: {
         isCaseSensitivityEnabled?: boolean;
         isRegexEnabled?: boolean;
+        isArchivedExcluded?: boolean;
+        isForkedExcluded?: boolean;
     },
     prisma: PrismaClient,
 }): Promise<QueryIR> => {
 
+    console.log("IS ARCHIVED EXCLUDED:", options.isArchivedExcluded);
+    console.log("IS FORKED EXCLUDED:", options.isForkedExcluded);
+
     try {
         // First parse the query into a Lezer tree.
         const tree = parser.parse(query);
+        // Debug logs removed - use structured logging if needed.
 
         // Then transform the tree into the intermediate representation.
         return transformTreeToIR({
@@ -76,6 +82,8 @@ export const parseQuerySyntaxIntoIR = async ({
             input: query,
             isCaseSensitivityEnabled: options.isCaseSensitivityEnabled ?? false,
             isRegexEnabled: options.isRegexEnabled ?? false,
+            isArchivedExcluded: options.isArchivedExcluded ?? false,
+            isForkedExcluded: options.isForkedExcluded ?? false,
             onExpandSearchContext: async (contextName: string) => {
                 const context = await prisma.searchContext.findUnique({
                     where: {
@@ -116,12 +124,16 @@ const transformTreeToIR = async ({
     input,
     isCaseSensitivityEnabled,
     isRegexEnabled,
+    isArchivedExcluded,
+    isForkedExcluded,
     onExpandSearchContext,
 }: {
     tree: Tree;
     input: string;
     isCaseSensitivityEnabled: boolean;
     isRegexEnabled: boolean;
+    isArchivedExcluded: boolean;
+    isForkedExcluded: boolean;
     onExpandSearchContext: (contextName: string) => Promise<string[]>;
 }): Promise<QueryIR> => {
     const transformNode = async (node: SyntaxNode): Promise<QueryIR> => {
@@ -320,6 +332,9 @@ const transformTreeToIR = async ({
             }
 
             case ArchivedExpr: {
+                // We'll set the value of isArchivedExcluded to false as the query takes precedence over checkbox.
+                isArchivedExcluded = false;
+                
                 const rawValue = value.toLowerCase();
 
                 if (!isArchivedValue(rawValue)) {
@@ -344,6 +359,9 @@ const transformTreeToIR = async ({
                 };
             }
             case ForkExpr: {
+                // We'll set the value of isForkedExcluded to false as the query takes precedence over checkbox.
+                isForkedExcluded = false;
+
                 const rawValue = value.toLowerCase();
 
                 if (!isForkValue(rawValue)) {
@@ -397,7 +415,52 @@ const transformTreeToIR = async ({
         }
     }
 
-    return transformNode(tree.topNode);
+    
+    // return await transformNode(tree.topNode);
+    const root = await transformNode(tree.topNode);
+
+    // If the tree does not contain explicit archived/fork prefixes, add
+    // default raw_config flags to exclude archived/forks by default.
+    const defaultNodes: QueryIR[] = [];
+
+    if (isArchivedExcluded) {
+        defaultNodes.push({
+            raw_config: {
+                flags: ['FLAG_NO_ARCHIVED']
+            },
+            query: 'raw_config'
+        });
+    }
+
+    if (isForkedExcluded) {
+        defaultNodes.push({
+            raw_config: {
+                flags: ['FLAG_NO_FORKS']
+            },
+            query: 'raw_config'
+        });
+    }
+
+    if (defaultNodes.length === 0) {
+        return root;
+    }
+
+    // If the root is already an AND, append defaults; otherwise create an AND
+    if (root.and && Array.isArray(root.and.children)) {
+        return {
+            and: {
+                children: [...root.and.children, ...defaultNodes]
+            },
+            query: 'and'
+        };
+    }
+
+    return {
+        and: {
+            children: [root, ...defaultNodes]
+        },
+        query: 'and'
+    };
 }
 
 const getChildren = (node: SyntaxNode): SyntaxNode[] => {

--- a/packages/web/src/features/search/parser.ts
+++ b/packages/web/src/features/search/parser.ts
@@ -68,13 +68,9 @@ export const parseQuerySyntaxIntoIR = async ({
     prisma: PrismaClient,
 }): Promise<QueryIR> => {
 
-    console.log("IS ARCHIVED EXCLUDED:", options.isArchivedExcluded);
-    console.log("IS FORKED EXCLUDED:", options.isForkedExcluded);
-
     try {
         // First parse the query into a Lezer tree.
         const tree = parser.parse(query);
-        // Debug logs removed - use structured logging if needed.
 
         // Then transform the tree into the intermediate representation.
         return transformTreeToIR({

--- a/packages/web/src/features/search/types.ts
+++ b/packages/web/src/features/search/types.ts
@@ -89,6 +89,8 @@ export const searchOptionsSchema = z.object({
     whole: z.boolean().optional(),                    // Whether to return the whole file as part of the response.
     isRegexEnabled: z.boolean().optional(),           // Whether to enable regular expression search.
     isCaseSensitivityEnabled: z.boolean().optional(), // Whether to enable case sensitivity.
+    isArchivedExcluded: z.boolean().optional(),       // Whether to exclude archived repositories.
+    isForkedExcluded: z.boolean().optional(),         // Whether to exclude forked repositories.
 });
 export type SearchOptions = z.infer<typeof searchOptionsSchema>;
 

--- a/packages/web/src/lib/types.ts
+++ b/packages/web/src/lib/types.ts
@@ -11,6 +11,8 @@ export enum SearchQueryParams {
     matches = "matches",
     isRegexEnabled = "isRegexEnabled",
     isCaseSensitivityEnabled = "isCaseSensitivityEnabled",
+    isArchivedExcluded = "isArchivedExcluded",
+    isForkedExcluded = "isForkedExcluded",
 }
 
 export type ApiKeyPayload = {


### PR DESCRIPTION
Fixes #663 
This PR introduces the following:
* Adding a couple of checkboxes `Exclude archived repositories` and `Exclude forked repositories`
* The queries `archived` and `fork` will always take precedence over these checkboxes



https://github.com/user-attachments/assets/92f4efa3-9e18-41a7-aeaf-a0a337572662

* The search results from the repository `calculator` are excluded above, as it's an archived repository.


https://github.com/user-attachments/assets/02879928-3ccb-4337-afb6-e88507ce3b3a

* Even though the `Exclude archived repositories` checkbox is selected, search results will include archived repos, as `archived` keyword takes precedence.

