### PR TITLE
Path `...` tree preview

### DIFF
--- a/packages/web/src/features/fileTree/api.ts
+++ b/packages/web/src/features/fileTree/api.ts
@@ -93,7 +93,11 @@ export const getFolderContents = async (params: { repoName: string, revisionName
 
         // @note: we don't allow directory traversal
         // or null bytes in the path.
-        if (path.includes('..') || path.includes('\0')) {
+        // We split by '/' and check if any segment starts with '..'
+        // to allow legitimate paths containing '..' (e.g., '[...path]')
+        // while still blocking directory traversal attempts.
+        const pathSegments = path.split('/');
+        if (pathSegments.some(segment => segment.startsWith('..')) || path.includes('\0')) {
             return notFound();
         }
 


### PR DESCRIPTION
Fix 'Error loading tree preview' for paths containing `...` by refining the directory traversal check.

The previous check `path.includes('..')` was overly broad, preventing legitimate paths like `[...path]` (Next.js catch-all routes) from being viewed. The updated logic now splits the path into segments and only flags a path as invalid if any segment *starts with* `..`, effectively preventing directory traversal (`../`) while allowing `..` within a filename.

---
Linear Issue: [SOU-73](https://linear.app/sourcebot/issue/SOU-73/bug-error-loading-tree-preview-when-viewing-a-directory-with)

<a href="https://cursor.com/background-agent?bcId=bc-aa38c64d-a7ec-4809-b055-d6993a10130f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-aa38c64d-a7ec-4809-b055-d6993a10130f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

