### PR TITLE
feat(gerrit): add basic authentication support (#596)

### DIFF
--- a/packages/backend/src/gerrit.test.ts
+++ b/packages/backend/src/gerrit.test.ts
@@ -1,0 +1,136 @@
+
+import { expect, test, vi, describe, beforeEach } from 'vitest';
+import { getGerritReposFromConfig } from './gerrit';
+import fetch from 'cross-fetch';
+
+vi.mock('cross-fetch', () => {
+    return {
+        default: vi.fn(),
+    };
+});
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+vi.mock('./utils', () => ({
+    measure: async (fn: () => any) => {
+        const data = await fn();
+        return { durationMs: 0, data };
+    },
+    fetchWithRetry: async (fn: () => any) => fn(),
+}));
+
+describe('getGerritReposFromConfig', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('sends Basic Auth header when username and password are provided', async () => {
+        const mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValue({
+            ok: true,
+            text: async () => '[]',
+            json: async () => ([]),
+        });
+
+        const config = {
+            type: 'gerrit' as const,
+            url: 'https://gerrit.example.com',
+            username: 'user',
+            password: 'password',
+        };
+
+        await getGerritReposFromConfig(config);
+
+        const expectedToken = Buffer.from('user:password').toString('base64');
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('https://gerrit.example.com/projects/?S=0'),
+            expect.objectContaining({
+                headers: {
+                    Authorization: `Basic ${expectedToken}`,
+                },
+            })
+        );
+    });
+
+    test('does not send Authorization header when credentials are missing', async () => {
+        const mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValue({
+            ok: true,
+            text: async () => '[]',
+            json: async () => ([]),
+        });
+
+        const config = {
+            type: 'gerrit' as const,
+            url: 'https://gerrit.example.com',
+        };
+
+        await getGerritReposFromConfig(config);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('https://gerrit.example.com/projects/?S=0'),
+            expect.objectContaining({
+                headers: {},
+            })
+        );
+    });
+
+    test('does not send Authorization header when only one credential is provided', async () => {
+        const mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValue({
+            ok: true,
+            text: async () => '[]',
+            json: async () => ([]),
+        });
+
+        const config = {
+            type: 'gerrit' as const,
+            url: 'https://gerrit.example.com',
+            username: 'user',
+        };
+
+        await getGerritReposFromConfig(config);
+
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('https://gerrit.example.com/projects/?S=0'),
+            expect.objectContaining({
+                headers: {},
+            })
+        );
+    });
+
+    test('correctly encodes credentials with special characters', async () => {
+        const mockFetch = fetch as unknown as ReturnType<typeof vi.fn>;
+        mockFetch.mockResolvedValue({
+            ok: true,
+            text: async () => '[]',
+            json: async () => ([]),
+        });
+
+        const config = {
+            type: 'gerrit' as const,
+            url: 'https://gerrit.example.com',
+            username: 'user@example.com',
+            password: 'p@ss:w0rd',
+        };
+
+        await getGerritReposFromConfig(config);
+
+        const expectedToken = Buffer.from('user@example.com:p@ss:w0rd').toString('base64');
+        expect(mockFetch).toHaveBeenCalledWith(
+            expect.stringContaining('https://gerrit.example.com/projects/?S=0'),
+            expect.objectContaining({
+                headers: {
+                    Authorization: `Basic ${expectedToken}`,
+                },
+            })
+        );
+    });
+});

--- a/schemas/v3/gerrit.json
+++ b/schemas/v3/gerrit.json
@@ -16,6 +16,14 @@
             ],
             "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$"
         },
+        "username": {
+            "type": "string",
+            "description": "The username to use for authentication."
+        },
+        "password": {
+            "type": "string",
+            "description": "The password (or HTTP password) to use for authentication."
+        },
         "projects": {
             "type": "array",
             "items": {


### PR DESCRIPTION
Fixes:#596
This PR addresses issue #596 by adding Basic Authentication support to the Gerrit connection configuration, allowing Sourcebot to index repositories from Gerrit instances that require a username and password or HTTP token.

The approach consisted of updates across the schema, backend implementation, and testing. On the schema side, schemas/v3/gerrit.json was modified to include optional username and password fields in GerritConnectionConfig. After making this change, the schema types were regenerated by running yarn workspace @sourcebot/schemas build.

On the backend, changes were made in packages/backend/src/gerrit.ts. Both getGerritReposFromConfig and fetchAllProjects were updated to accept the new credential fields. Logic was added to construct a standard Basic Authentication header in the format Authorization: Basic base64(username:password). This header is injected into the fetch request only when both the username and password are provided, ensuring that existing behavior for public Gerrit instances remains unchanged and fully backward compatible.

For validation, a new and dedicated test suite was implemented in packages/backend/src/gerrit.test.ts to strictly verify the authentication logic. The tests confirm that the correct Authorization header is sent when both username and password are present, that no header is sent when credentials are missing, that partial credentials (such as only a username) do not trigger the header, and that credentials containing special characters (for example @ or :) are correctly Base64 encoded. All four tests passed successfully when run using the command yarn workspace @sourcebot/backend test src/gerrit.test.ts.