### PR TITLE
chore: Pin postgres version to 17 in docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,7 @@ services:
       # https://docs.sourcebot.dev/docs/configuration/environment-variables
 
   postgres:
-    image: docker.io/postgres:${POSTGRES_VERSION:-latest}
+    image: docker.io/postgres:${POSTGRES_VERSION:-17}
     restart: always
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]


### PR DESCRIPTION
The default PGDATA path in the official postgresql image has changed in version 18 and above. This PR pins the version of postgres to 17 as a quick workaround.

See: https://github.com/docker-library/postgres/pull/1259
