### PR TITLE
Feat/zoekt binary index

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/zoekt"]
 	path = vendor/zoekt
-	url = https://github.com/sourcebot-dev/zoekt
+	url = https://github.com/sudhanshu112233shukla/zoekt
 	branch=main


### PR DESCRIPTION
Fixes:#575
## Summary
This PR updates the `vendor/zoekt` submodule to support indexing binary files and exposes this functionality via a new CLI flag.

## Changes
- Updated `vendor/zoekt` submodule to include changes from [Link to your Zoekt PR].
- Added `-allow_binary` flag to `cmd/zoekt-git-index/main.go`.
- Mapped the new CLI flag to `gitOpts.BuildOptions.AllowBinary`.

Addresses the need to index files that may contain null bytes (like PDFs or generated files) which were previously skipped by the indexer.