### PR TITLE
Shell expansion index patterns

### DIFF
--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -23,7 +23,7 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, revisio
         `-tenant_id ${repo.orgId}`,
         `-repo_id ${repo.id}`,
         `-shard_prefix ${shardPrefix}`,
-        ...largeFileGlobPatterns.map((pattern) => `-large_file ${pattern}`),
+        ...largeFileGlobPatterns.map((pattern) => `-large_file "${pattern}"`),
         repoPath
     ].join(' ');
 


### PR DESCRIPTION
Quote `large_file` glob patterns to prevent shell expansion when `zoekt-git-index` is executed.

---
Linear Issue: [SOU-247](https://linear.app/sourcebot/issue/SOU-247/bug-always-index-file-patterns-env-var-not-being-honored-due-to-shell)

<a href="https://cursor.com/background-agent?bcId=bc-c40fc7a6-bd74-467c-9d67-5032a1ba6176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c40fc7a6-bd74-467c-9d67-5032a1ba6176"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

