### PR TITLE
feat: support AGENTS.md in Ask Sourcebot 

### DIFF
--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -48,7 +48,18 @@ export const createAgentStream = async ({
             return null;
         }
 
-        return `Repository: ${repo}\nFile: AGENTS.md\nContent:\n${result.source}`;
+        let content = result.source;
+
+        // Security: Limit content length to prevent large context consumption
+        const MAX_LENGTH = 5000;
+        if (content.length > MAX_LENGTH) {
+            content = content.slice(0, MAX_LENGTH) + '\n... (truncated)';
+        }
+
+        // Security: Sanitize closing tags to prevent prompt injection
+        content = content.replace(/<\/repository_instructions>/g, '<\\/repository_instructions>');
+
+        return `Repository: ${repo}\nFile: AGENTS.md\nContent:\n${content}`;
     }));
 
     const agentsMdContent = agentsMdResults.filter((c) => c !== null).join('\n\n');

--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -57,7 +57,8 @@ export const createAgentStream = async ({
         }
 
         // Security: Sanitize closing tags to prevent prompt injection
-        content = content.replace(/<\/repository_instructions>/g, '<\\/repository_instructions>');
+        // We escape all closing XML-like tags to ensure the content cannot break out of the <repository_instructions> block
+        content = content.replace(/<\//g, '<\\/');
 
         return `Repository: ${repo}\nFile: AGENTS.md\nContent:\n${content}`;
     }));

--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -38,8 +38,24 @@ export const createAgentStream = async ({
     onWriteSource,
     traceId,
 }: AgentOptions) => {
+    const agentsMdResults = await Promise.all(searchScopeRepoNames.map(async (repo) => {
+        const result = await getFileSource({
+            fileName: 'AGENTS.md',
+            repository: repo,
+        });
+
+        if (isServiceError(result)) {
+            return null;
+        }
+
+        return `Repository: ${repo}\nFile: AGENTS.md\nContent:\n${result.source}`;
+    }));
+
+    const agentsMdContent = agentsMdResults.filter((c) => c !== null).join('\n\n');
+
     const baseSystemPrompt = createBaseSystemPrompt({
         searchScopeRepoNames,
+        agentsMdContent,
     });
 
     const stream = streamText({
@@ -62,7 +78,7 @@ export const createAgentStream = async ({
 
                 const resolvedFileSources = (
                     await Promise.all(fileSources.map(resolveFileSource)))
-                        .filter((source) => source !== undefined)
+                    .filter((source) => source !== undefined)
 
                 const fileSourcesSystemPrompt = await createFileSourcesSystemPrompt({
                     files: resolvedFileSources
@@ -156,10 +172,12 @@ export const createAgentStream = async ({
 
 interface BaseSystemPromptOptions {
     searchScopeRepoNames: string[];
+    agentsMdContent?: string;
 }
 
 export const createBaseSystemPrompt = ({
     searchScopeRepoNames,
+    agentsMdContent,
 }: BaseSystemPromptOptions) => {
     return `
 You are a powerful agentic AI code assistant built into Sourcebot, the world's best code-intelligence platform. Your job is to help developers understand and navigate their large codebases.
@@ -184,6 +202,12 @@ The user has selected the following repositories for analysis:
 ${searchScopeRepoNames.map(repo => `- ${repo}`).join('\n')}
 </available_repositories>
 
+${agentsMdContent ? `<repository_instructions>
+The following are verified instructions from the repository maintainers (AGENTS.md). You MUST follow these instructions when generating code or answering questions for these repositories.
+
+${agentsMdContent}
+</repository_instructions>` : ''}
+
 <research_phase_instructions>
 During the research phase, use the tools available to you to gather comprehensive context before answering. Always explain why you're using each tool. Depending on the user's question, you may need to use multiple tools. If the question is vague, ask the user for more information.
 </research_phase_instructions>
@@ -199,7 +223,7 @@ When you have sufficient context, output your answer as a structured markdown re
 **Required Response Format:**
 - **CRITICAL**: You MUST always prefix your answer with a \`${ANSWER_TAG}\` tag at the very top of your response
 - **CRITICAL**: You MUST provide your complete response in markdown format with embedded code references
-- **CODE REFERENCE REQUIREMENT**: Whenever you mention, discuss, or refer to ANY specific part of the code (files, functions, variables, methods, classes, imports, etc.), you MUST immediately follow with a code reference using the format \`${fileReferenceToString({ repo: 'repository', path: 'filename'})}\` or \`${fileReferenceToString({ repo: 'repository', path: 'filename', range: { startLine: 1, endLine: 10 } })}\` (where the numbers are the start and end line numbers of the code snippet). This includes:
+- **CODE REFERENCE REQUIREMENT**: Whenever you mention, discuss, or refer to ANY specific part of the code (files, functions, variables, methods, classes, imports, etc.), you MUST immediately follow with a code reference using the format \`${fileReferenceToString({ repo: 'repository', path: 'filename' })}\` or \`${fileReferenceToString({ repo: 'repository', path: 'filename', range: { startLine: 1, endLine: 10 } })}\` (where the numbers are the start and end line numbers of the code snippet). This includes:
   - Files (e.g., "The \`auth.ts\` file" → must include \`${fileReferenceToString({ repo: 'repository', path: 'auth.ts' })}\`)
   - Function names (e.g., "The \`getRepos()\` function" → must include \`${fileReferenceToString({ repo: 'repository', path: 'auth.ts', range: { startLine: 15, endLine: 20 } })}\`)
   - Variable names (e.g., "The \`suggestionQuery\` variable" → must include \`${fileReferenceToString({ repo: 'repository', path: 'search.ts', range: { startLine: 42, endLine: 42 } })}\`)


### PR DESCRIPTION
#475 I have successfully implemented support for AGENTS.md in Ask Sourcebot. This feature allows repository maintainers to provide explicit, repository-specific instructions to the AI agent by simply adding an AGENTS.md file at the root of their repository. With this change, maintainers can directly influence how the AI behaves when answering questions about their codebase, without needing any external configuration or code changes.

The implementation works by modifying the chat agent’s initialization process so that these instructions are discovered and injected before any conversation begins. The entry point for this logic is the createAgentStream function in packages/web/src/features/chat/agent.ts. During initialization, the agent now iterates over every repository included in the user’s Search Scope. For each repository, it attempts to fetch a file named AGENTS.md using the existing getFileSource API. This logic runs asynchronously using Promise.all to ensure all repositories are checked efficiently. If the file exists, its contents are captured along with the repository name. If the file does not exist or an error occurs, the error is handled gracefully so that missing files do not break or block agent initialization.

Once all repositories have been checked, the collected AGENTS.md contents are formatted into a single structured string. Each entry clearly includes the repository name, the file name (AGENTS.md), and the full contents of the file. This ensures that instructions from multiple repositories can coexist and remain clearly attributable to their source.

I then updated the createBaseSystemPrompt function in the same file to accept this aggregated AGENTS.md content as an additional input. If any instructions are present, they are appended directly to the system prompt and wrapped inside a dedicated <repository_instructions> XML tag. The prompt text explicitly states that these instructions are verified and provided by the repository maintainers, and that the AI must follow them. This structure ensures the LLM interprets the instructions as high-priority system context rather than optional guidance or user input.

This approach guarantees that repository-defined rules are injected before the conversation starts and are consistently available throughout the agent’s reasoning process. By embedding them directly into the system prompt, the instructions take precedence over user prompts when applicable, which is exactly the intended behavior for maintainer-authored guidance.

To ensure the feature works end-to-end, I created a temporary unit test suite in agent.test.ts. These tests simulate the entire flow in isolation. The file system and API layer were mocked to simulate a repository containing an AGENTS.md file. The tests verify that createAgentStream correctly calls the file-fetching logic for each repository in the search scope and successfully retrieves the mocked AGENTS.md content. Additionally, the tests assert that createBaseSystemPrompt includes the fetched instructions in the final system prompt, wrapped exactly inside the <repository_instructions> XML block with the expected content.

All tests passed successfully, confirming that the fetch logic, prompt injection, and overall integration are working as intended. This implementation cleanly extends the existing architecture, requires no breaking changes, and provides a simple, repository-native way for maintainers to control how Ask Sourcebot’s AI agent interprets and responds to their codebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat agent now collects, sanitizes, and truncates repository AGENTS.md content and embeds it into system prompts when available, improving contextual awareness so responses better reflect repo-specific instructions and help the agent select appropriate tools and guidance during conversations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->