### PR TITLE
[SOU-301] Fix branch filtering to use short names instead of refs/heads

### DIFF
--- a/packages/backend/src/repoIndexManager.ts
+++ b/packages/backend/src/repoIndexManager.ts
@@ -404,8 +404,7 @@ export class RepoIndexManager {
             const allBranches = await getBranches(repoPath);
             const matchingBranches =
                 allBranches
-                    .filter((branch) => micromatch.isMatch(branch, branchGlobs))
-                    .map((branch) => `refs/heads/${branch}`);
+                    .filter((branch) => micromatch.isMatch(branch, branchGlobs));
 
             revisions = [
                 ...revisions,


### PR DESCRIPTION
## Problem
Searching on filtered branches was returning no results because branch names were being stored with the `refs/heads/` prefix when they should have been stored as short names only.

## Solution
Remove the unnecessary mapping that prefixed branch names with `refs/heads/` in the branch filtering logic. The zoekt index stores branch references as short names (e.g., `main`, `develop`), so the filtering logic should match this format.

## Changes
- Removed `.map((branch) => \`refs/heads/${branch}\`)` from branch filtering in `repoIndexManager.ts`
- Branch names are now correctly passed as short names to match indexed branch references

This fixes the issue where the `rev:` query syntax was not finding any results when filtering on indexed branches.

Fixes #800 

---
[View Niteshift Task](https://niteshift.dev/repo/sourcebot-dev__sourcebot/task_ubfqugon-r_l0cjb3azzl)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository branch selection processing for indexing operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->