### PR TITLE
chore(devenv): Skip claude onboarding in dev container

### DIFF
--- a/.devcontainer/scripts/post-create.sh
+++ b/.devcontainer/scripts/post-create.sh
@@ -10,16 +10,16 @@ cd /workspaces/sourcebot
 
 # 1. Initialize git submodules (in case initializeCommand didn't run)
 echo ""
-echo "[1/4] Initializing git submodules..."
+echo "[1/5] Initializing git submodules..."
 git submodule update --init --recursive
 
 # 2. Build Zoekt and install dependencies (uses Makefile)
 echo ""
-echo "[2/4] Building Zoekt and installing dependencies..."
+echo "[2/5] Building Zoekt and installing dependencies..."
 make
 
 echo ""
-echo "[3/4] Running database migrations..."
+echo "[3/5] Running database migrations..."
 yarn dev:prisma:migrate:dev
 
 echo ""


### PR DESCRIPTION
Sets the `hasCompletedOnboarding` to `true` in the home `.claude.json` file s.t., we skip over the onboarding steps when trying to use claude in a code workspace

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Claude Code onboarding configuration step to development environment setup.
  * Enhanced default configuration to include GitHub repository connections.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->