### PR TITLE
fix: improve UX for empty repositories (#821)

### DIFF
--- a/packages/web/src/app/[domain]/browse/[...path]/components/treePreviewPanel.tsx
+++ b/packages/web/src/app/[domain]/browse/[...path]/components/treePreviewPanel.tsx
@@ -1,10 +1,10 @@
-
 import { Separator } from "@/components/ui/separator";
 import { getRepoInfoByName } from "@/actions";
 import { PathHeader } from "@/app/[domain]/components/pathHeader";
 import { getFolderContents } from "@/features/fileTree/api";
 import { isServiceError } from "@/lib/utils";
 import { PureTreePreviewPanel } from "./pureTreePreviewPanel";
+import { FolderOpen } from "lucide-react";
 
 interface TreePreviewPanelProps {
     path: string;
@@ -24,6 +24,33 @@ export const TreePreviewPanel = async ({ path, repoName, revisionName }: TreePre
 
     if (isServiceError(folderContentsResponse) || isServiceError(repoInfoResponse)) {
         return <div>Error loading tree preview</div>
+    }
+
+    if (folderContentsResponse.length === 0) {
+        return (
+            <>
+                <div className="flex flex-row py-1 px-2 items-center justify-between">
+                    <PathHeader
+                        path={path}
+                        repo={{
+                            name: repoName,
+                            codeHostType: repoInfoResponse.codeHostType,
+                            displayName: repoInfoResponse.displayName,
+                            externalWebUrl: repoInfoResponse.externalWebUrl,
+                        }}
+                        pathType="tree"
+                        isFileIconVisible={false}
+                        revisionName={revisionName}
+                    />
+                </div>
+                <Separator />
+                <div className="flex flex-col items-center justify-center h-full text-muted-foreground">
+                    <FolderOpen className="w-16 h-16 mb-4" />
+                    <p className="text-sm font-medium">No commits yet</p>
+                    <p className="text-xs mt-1">This repository doesn&apos;t have any code yet</p>
+                </div>
+            </>
+        )
     }
 
     return (

--- a/packages/web/src/features/fileTree/api.ts
+++ b/packages/web/src/features/fileTree/api.ts
@@ -39,6 +39,13 @@ export const getTree = async (params: { repoName: string, revisionName: string, 
 
         const normalizedPaths = paths.map(path => normalizePath(path));
 
+        // Verify that the revision is not empty
+        try{
+            await git.raw(["rev-parse","--verify",revisionName])
+        }catch(_error){
+            return {tree:{}}
+        }
+
         let result: string = '';
         try {
 
@@ -105,6 +112,13 @@ export const getFolderContents = async (params: { repoName: string, revisionName
             return notFound();
         }
         const normalizedPath = normalizePath(path);
+
+        // Verify that the revision is not empty
+        try{
+            await git.raw(["rev-parse","--verify",revisionName])
+        } catch(_error){
+            return [];
+        }
 
         let result: string;
         try {

--- a/packages/web/src/features/fileTree/components/fileTreePanel.tsx
+++ b/packages/web/src/features/fileTree/components/fileTreePanel.tsx
@@ -13,6 +13,7 @@ import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { measure, unwrapServiceError } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
 import { SearchIcon } from "lucide-react";
+import { FolderOpen } from "lucide-react";
 import { useCallback, useEffect, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import {
@@ -55,7 +56,7 @@ export const FileTreePanel = ({ order }: FileTreePanelProps) => {
                     paths: Array.from(openPaths),
                 })
             ), 'getTree');
-
+            
             captureEvent('wa_file_tree_loaded', {
                 durationMs: result.durationMs,
             });
@@ -188,6 +189,12 @@ export const FileTreePanel = ({ order }: FileTreePanelProps) => {
                         isError ? (
                             <div className="flex flex-col items-center justify-center h-full">
                                 <p>Error loading file tree</p>
+                            </div>
+                        ) : !data.tree.children || data.tree.children.length === 0 ? (
+                            <div className="flex flex-col items-center justify-center h-full text-muted-foreground px-4">
+                                <FolderOpen className="w-12 h-12 mb-3" />
+                                <p className="text-sm font-medium">No files yet</p>
+                                <p className="text-xs mt-1 text-center">This repository doesn&apos;t have any code yet</p>
                             </div>
                         ) : (
                             <PureFileTreePanel

--- a/packages/web/src/features/fileTree/components/pureFileTreePanel.tsx
+++ b/packages/web/src/features/fileTree/components/pureFileTreePanel.tsx
@@ -31,6 +31,10 @@ export const PureFileTreePanel = ({ tree, openPaths, path, onTreeNodeClicked }: 
     const domain = useDomain();
 
     const renderTree = useCallback((nodes: FileTreeNode, depth = 0): React.ReactNode => {
+        if (!nodes.children || nodes.children.length === 0) {
+            return null;
+        }
+
         return (
             <>
                 {nodes.children.map((node) => {


### PR DESCRIPTION
Fix: Improve UX for empty repositories
Fixes #821

## Problem
When viewing an empty repository, Sourcebot displayed generic error messages like "Error loading tree preview" or "Error loading file tree". This confused users by suggesting sync issues or internal errors when the repository simply had no commits yet.

## Solution
This PR improves the user experience by:

Detecting empty repositories through revision verification
Displaying clear, user-friendly empty state UI
Replacing misleading error messages with helpful context
Changes Made
1. Backend - Revision Verification (api.ts)
Added git rev-parse --verify checks in both getTree() and getFolderContents()
Gracefully handles empty repositories by returning empty data structures instead of throwing errors
2. File Tree Panel (fileTreePanel.tsx)
Added empty state UI with FolderOpen icon
Displays "No files yet" message with explanatory text
Only shown when tree has no children (distinct from loading or error states)
3. Tree Preview Panel (treePreviewPanel.tsx)
Added empty state UI for folder preview
Shows "No commits yet" message with helpful context
Maintains PathHeader for navigation consistency
4. Pure File Tree Panel (pureFileTreePanel.tsx)
Added null check to prevent rendering errors
Safely handles nodes with no children

### User Experience
Before: Generic error message suggesting a problem
After: Clear "No commits yet" / "No files yet" message with folder icon

<img width="1918" height="927" alt="Screenshot from 2026-02-01 13-19-38" src="https://github.com/user-attachments/assets/a65095fe-fa95-42fd-b882-c9d1ecd81825" />





<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of empty file trees and commit histories with user-friendly empty-state messaging
  * Enhanced robustness when accessing folder contents and revision data to prevent rendering errors

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->