### PR TITLE
fix(web): add type guard to prevent crash with 'constructor' folder name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Improved stability for connection and repo indexing workers. [#860](https://github.com/sourcebot-dev/sourcebot/pull/860)
 
+### Fixed
+- Fixed issue where certain file and folder names would cause type errors. [#862](https://github.com/sourcebot-dev/sourcebot/pull/862)
+
 ## [4.10.27] - 2026-02-05
 
 ### Fixed

--- a/packages/web/src/app/components/vscodeFileIcon.tsx
+++ b/packages/web/src/app/components/vscodeFileIcon.tsx
@@ -13,12 +13,12 @@ interface VscodeFileIconProps {
 export const VscodeFileIcon = ({ fileName, className }: VscodeFileIconProps) => {
     const iconName = useMemo(() => {
         const icon = getIconForFile(fileName);
-        if (icon) {
+        if (icon && typeof icon === 'string') {
             const iconName = `vscode-icons:${icon.substring(0, icon.indexOf('.')).replaceAll('_', '-')}`;
             return iconName;
         }
 
-        return "vscode-icons:file-type-unknown";
+        return "vscode-icons:default-file";
     }, [fileName]);
 
     return <Icon icon={iconName} className={cn("w-4 h-4 flex-shrink-0", className)} />;

--- a/packages/web/src/app/components/vscodeFolderIcon.tsx
+++ b/packages/web/src/app/components/vscodeFolderIcon.tsx
@@ -18,7 +18,7 @@ export const VscodeFolderIcon = ({ folderName, className }: VscodeFolderIconProp
                 return iconName;
         }
 
-        return "vscode-icons:folder";
+        return "vscode-icons:default-folder";
     }, [folderName]);
 
     return <Icon icon={iconName} className={cn("w-4 h-4 flex-shrink-0", className)} />;


### PR DESCRIPTION
Fixes #861

When a folder is named 'constructor', `getIconForFolder` returns an object (`Object.prototype.constructor`) instead of a string, causing a runtime error when calling `.indexOf()` on it. Added a type check to ensure the icon is a string before processing.

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved robustness of folder icon handling: invalid or missing icon values now validate and fall back to the default folder icon instead of causing errors.
  * Improved robustness of file icon handling: non-string or invalid icon values now fall back to the default file icon.
  * Fixed issue where certain file/folder names could trigger type-related errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->