### PR TITLE
feat(web): add browser notification for askgh indexing completion

### DIFF
--- a/packages/web/src/hooks/useBrowserNotification.ts
+++ b/packages/web/src/hooks/useBrowserNotification.ts
@@ -1,0 +1,69 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type NotificationPermission = 'default' | 'granted' | 'denied';
+
+interface NotificationOptions {
+    title: string;
+    body?: string;
+    icon?: string;
+    onClick?: () => void;
+}
+
+interface UseBrowserNotificationReturn {
+    permission: NotificationPermission;
+    isSupported: boolean;
+    requestPermission: () => Promise<NotificationPermission>;
+    showNotification: (options: NotificationOptions) => Notification | null;
+}
+
+export function useBrowserNotification(): UseBrowserNotificationReturn {
+    const isSupported = typeof window !== 'undefined' && 'Notification' in window;
+
+    const [permission, setPermission] = useState<NotificationPermission>(() => {
+        if (!isSupported) return 'denied';
+        return Notification.permission as NotificationPermission;
+    });
+
+    // Sync permission state if it changes externally
+    useEffect(() => {
+        if (!isSupported) return;
+        setPermission(Notification.permission as NotificationPermission);
+    }, [isSupported]);
+
+    const requestPermission = useCallback(async (): Promise<NotificationPermission> => {
+        if (!isSupported) return 'denied';
+
+        const result = await Notification.requestPermission();
+        setPermission(result as NotificationPermission);
+        return result as NotificationPermission;
+    }, [isSupported]);
+
+    const showNotification = useCallback((options: NotificationOptions): Notification | null => {
+        if (!isSupported || permission !== 'granted') {
+            return null;
+        }
+
+        const notification = new Notification(options.title, {
+            body: options.body,
+            icon: options.icon,
+        });
+
+        if (options.onClick) {
+            notification.onclick = () => {
+                options.onClick?.();
+                notification.close();
+            };
+        }
+
+        return notification;
+    }, [isSupported, permission]);
+
+    return {
+        permission,
+        isSupported,
+        requestPermission,
+        showNotification,
+    };
+}


### PR DESCRIPTION
## Summary
- Add `useBrowserNotification` hook for managing browser notification permissions
- Request notification permission when viewing a repo that's being indexed
- Show browser notification with repo name and icon when indexing completes
- Focus the browser window when notification is clicked

This allows users to be notified when repository indexing completes even when the askgh tab is in the background.

## Test plan
- [ ] Navigate to `/default/askgh/{owner}/{repo}` for a repo that hasn't been indexed
- [ ] Accept notification permission when prompted
- [ ] Switch to another browser tab while indexing is in progress
- [ ] Verify browser notification appears when indexing completes
- [ ] Click notification and verify tab is focused
- [ ] Test with notification permission denied - verify no errors occur
- [ ] Visit an already-indexed repo and verify no permission prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

**New Features**
* **Browser Notifications**: Users now receive notifications when repositories are successfully processed and ready for use
* Notifications display repository details and can be clicked to bring the application into focus
* The application automatically requests notification permissions, ensuring seamless functionality without manual setup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->