### PR TITLE
Fixes #911: handle prompt too long errors

### DIFF
--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -231,6 +231,8 @@ export const env = createEnv({
 
         SOURCEBOT_CHAT_MODEL_TEMPERATURE: numberSchema.default(0.3),
         SOURCEBOT_CHAT_MAX_STEP_COUNT: numberSchema.default(20),
+        SOURCEBOT_CHAT_FILE_MAX_CHARACTERS: numberSchema.default(100_000),
+        SOURCEBOT_CHAT_MAX_MESSAGE_HISTORY: numberSchema.default(50),
 
         DEBUG_WRITE_CHAT_MESSAGES_TO_FILE: booleanSchema.default('false'),
 

--- a/packages/web/src/features/chat/components/chatThread/errorBanner.tsx
+++ b/packages/web/src/features/chat/components/chatThread/errorBanner.tsx
@@ -2,6 +2,7 @@
 
 import { Button } from '@/components/ui/button';
 import { serviceErrorSchema } from '@/lib/serviceError';
+import { CONTEXT_WINDOW_USER_MESSAGE } from '@/features/chat/utils';
 import { AlertCircle, X } from "lucide-react";
 import { useMemo } from 'react';
 
@@ -33,7 +34,7 @@ export const ErrorBanner = ({ error, isVisible, onClose }: ErrorBannerProps) => 
                     <div className="flex items-center gap-2">
                         <AlertCircle className="h-4 w-4 text-red-600 dark:text-red-400" />
                         <span className="text-sm font-medium text-red-800 dark:text-red-200">
-                            Error occurred
+                            {errorMessage === CONTEXT_WINDOW_USER_MESSAGE ? 'Context limit exceeded' : 'Error occurred'}
                         </span>
                         <span className="text-sm text-red-600 dark:text-red-400">
                             {errorMessage}


### PR DESCRIPTION
fix(chat): handle prompt too long errors by truncating files and limiting history

Prevent context window overflow by truncating large file contents (default 100K chars) and capping message history (default 50 messages). When a context window error still occurs, detect provider-specific error messages and show a user-friendly message with actionable guidance.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Files are now automatically truncated when exceeding configured character limits. Users are notified when truncation occurs and can retrieve full content using dedicated tools.
  * Enhanced error detection and messaging for context window limit scenarios with clearer user feedback.

* **Improvements**
  * Message history is intelligently trimmed to maintain conversation size within configured limits.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->