### PR TITLE
New chat button visibility

### DIFF
--- a/packages/web/src/app/[domain]/chat/components/chatSidePanel.tsx
+++ b/packages/web/src/app/[domain]/chat/components/chatSidePanel.tsx
@@ -231,7 +231,7 @@ export const ChatSidePanel = ({
 
             </ResizablePanel >
             {isCollapsed && (
-                <div className="flex flex-col items-center h-full p-2">
+                <div className="flex flex-col items-center h-full p-2 gap-1">
                     <Tooltip
                         delayDuration={100}
                     >
@@ -251,6 +251,25 @@ export const ChatSidePanel = ({
                             <KeyboardShortcutHint shortcut="mod+b" />
                             <Separator orientation="vertical" className="h-4" />
                             <span>Open side panel</span>
+                        </TooltipContent>
+                    </Tooltip>
+                    <Tooltip
+                        delayDuration={100}
+                    >
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8"
+                                onClick={() => {
+                                    router.push(`/${SINGLE_TENANT_ORG_DOMAIN}/chat`);
+                                }}
+                            >
+                                <CirclePlusIcon className="w-4 h-4" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent side="bottom">
+                            <span>New Chat</span>
                         </TooltipContent>
                     </Tooltip>
                 </div>


### PR DESCRIPTION
Add a "New Chat" icon to the collapsed sidebar view to make it easier to create new chats.

---
Linear Issue: [SOU-567](https://linear.app/sourcebot/issue/SOU-567/make-it-easier-to-create-new-chat-without-left-side-bar-expanded)

<p><a href="https://cursor.com/agents/bc-d1001751-2f2c-4b89-a457-4634232c85b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d1001751-2f2c-4b89-a457-4634232c85b7"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</p>

