### PR TITLE
fix(worker): guard against stale public flags when Bitbucket Server feature.public.access is disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - [EE] Fixed account-driven permission sync silently wiping all Bitbucket Server repository permissions when the OAuth token expires on instances with anonymous access enabled. [#998](https://github.com/sourcebot-dev/sourcebot/pull/998)
+- [EE] Fixed Bitbucket Server repos being incorrectly treated as public in Sourcebot when the instance-level `feature.public.access` flag is disabled but per-repo public flags were not reset. [#999](https://github.com/sourcebot-dev/sourcebot/pull/999)
 
 ## [4.15.5] - 2026-03-12
 

--- a/packages/backend/src/bitbucket.ts
+++ b/packages/backend/src/bitbucket.ts
@@ -783,6 +783,33 @@ export const getUserPermissionsForServerRepo = async (
 };
 
 /**
+ * Checks if the Bitbucket Server instance has the `feature.public.access` flag enabled
+ * by making a single unauthenticated request to a repo that the API reports as public.
+ */
+export const isBitbucketServerPublicAccessEnabled = async (
+    serverUrl: string,
+    publicRepo: ServerRepository,
+): Promise<boolean> => {
+    const projectKey = publicRepo.project?.key;
+    const repoSlug = publicRepo.slug;
+    if (!projectKey || !repoSlug) {
+        return false;
+    }
+
+    const url = `${serverUrl}/rest/api/1.0/projects/${projectKey}/repos/${repoSlug}`;
+    try {
+        const response = await fetch(url, {
+            headers: { Accept: 'application/json' },
+            // Intentionally no Authorization header - we want to test anonymous access
+        });
+        return response.ok;
+    } catch (e) {
+        logger.warn(`Failed to probe public access for ${projectKey}/${repoSlug}: ${e}`);
+        return false;
+    }
+};
+
+/**
  * Returns true if the Bitbucket Server client is authenticated as a real user,
  * false if the token is expired, invalid, or the request is being treated as anonymous.
  */

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -3,7 +3,7 @@ import { getGitHubReposFromConfig, OctokitRepository } from "./github.js";
 import { getGitLabReposFromConfig } from "./gitlab.js";
 import { getGiteaReposFromConfig } from "./gitea.js";
 import { getGerritReposFromConfig } from "./gerrit.js";
-import { BitbucketRepository, getBitbucketReposFromConfig } from "./bitbucket.js";
+import { BitbucketRepository, getBitbucketReposFromConfig, isBitbucketServerPublicAccessEnabled } from "./bitbucket.js";
 import { getAzureDevOpsReposFromConfig } from "./azuredevops.js";
 import { SchemaRestRepository as BitbucketServerRepository } from "@coderabbitai/bitbucket/server/openapi";
 import { SchemaRepository as BitbucketCloudRepository } from "@coderabbitai/bitbucket/cloud/openapi";
@@ -401,6 +401,22 @@ export const compileBitbucketConfig = async (
         .toString()
         .replace(/^https?:\/\//, '');
 
+    // For Bitbucket Server, verify that the instance-level `feature.public.access` flag is
+    // actually enabled. When it is disabled, per-repo `public` flags may still be stale
+    // (i.e., remain `true` from before the flag was turned off) but repos are no longer
+    // anonymously accessible. We detect this by making a single unauthenticated probe
+    // request to one of the repos the API reports as public.
+    let isServerPublicAccessEnabled = true;
+    if (config.deploymentType === 'server') {
+        const firstPublicRepo = bitbucketRepos.find(repo => (repo as BitbucketServerRepository).public === true);
+        if (firstPublicRepo) {
+            isServerPublicAccessEnabled = await isBitbucketServerPublicAccessEnabled(hostUrl, firstPublicRepo as BitbucketServerRepository);
+            if (!isServerPublicAccessEnabled) {
+                logger.warn(`Bitbucket Server at ${hostUrl} has repos marked as public but they are not anonymously accessible. The feature.public.access flag may be disabled. Treating all repos as private.`);
+            }
+        }
+    }
+
     const getCloneUrl = (repo: BitbucketRepository) => {
         if (!repo.links) {
             throw new Error(`No clone links found for server repo ${repo.name}`);
@@ -467,7 +483,9 @@ export const compileBitbucketConfig = async (
             }
         })();
         const externalId = isServer ? (repo as BitbucketServerRepository).id!.toString() : (repo as BitbucketCloudRepository).uuid!;
-        const isPublic = isServer ? (repo as BitbucketServerRepository).public : (repo as BitbucketCloudRepository).is_private === false;
+        const isPublic = isServer
+            ? (isServerPublicAccessEnabled && (repo as BitbucketServerRepository).public === true)
+            : (repo as BitbucketCloudRepository).is_private === false;
         const isArchived = isServer ? (repo as BitbucketServerRepository).archived === true : false;
         const isFork = isServer ? (repo as BitbucketServerRepository).origin !== undefined : (repo as BitbucketCloudRepository).parent !== undefined;
         const repoName = path.join(repoNameRoot, displayName);


### PR DESCRIPTION
## Summary
- When `feature.public.access` is disabled on a Bitbucket Server instance, per-repo `public` flags are not reset by Bitbucket — repos that were previously public remain `public: true` in the API response.
- This caused Sourcebot's permission filter (clause 3 in `getRepoPermissionFilterForUser`) to treat those repos as genuinely public, potentially exposing them to users who no longer have access on the code host.
- Fix: during Bitbucket Server compilation, make a single unauthenticated probe request to one of the reportedly-public repos. If the probe fails (401/403), the `feature.public.access` flag is assumed disabled and all repos on that instance are treated as private.

## Test plan
- [x] Verify that a Bitbucket Server connection with `feature.public.access=true` and public repos correctly marks those repos as `isPublic: true`
- [x] Verify that a Bitbucket Server connection with `feature.public.access=false` (but stale `public: true` repo flags) marks all repos as `isPublic: false`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Bitbucket Server repositories being incorrectly marked as public when the instance-level public access feature is disabled. Repository visibility now properly respects the instance-level configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->