### PR TITLE
fix(sso/jumpcloud): Ensure that `state` param is passed

### DIFF
--- a/packages/web/src/ee/features/sso/sso.ts
+++ b/packages/web/src/ee/features/sso/sso.ts
@@ -442,6 +442,7 @@ const createJumpCloudProvider = (clientId: string, clientSecret: string, issuer:
         clientId: clientId,
         clientSecret: clientSecret,
         issuer: issuer,
+        checks: ["pkce", "state"],
         allowDangerousEmailAccountLinking: env.AUTH_EE_ALLOW_EMAIL_ACCOUNT_LINKING === 'true',
     } as Provider;
 }


### PR DESCRIPTION
This commit updates the JumpCloud SSO provider implmentation in-order to ensure that the `state` and `pkce` params are included in the generated auth redirect.

Ref: https://app.sourcebot.dev/~/chat/cmmyp5bsc0001n37tvx8dz4bp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved JumpCloud SSO authentication security with additional verification checks to strengthen protection during the login process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->