### PR TITLE
chore: add macOS universal-ctags v6.1.0 install script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,14 +36,24 @@ Want to take on an issue? Leave a comment and a maintainer may assign it to you 
 
 1. Install <a href="https://go.dev/doc/install"><img src="https://go.dev/favicon.ico" width="16" height="16"> go</a>, <a href="https://docs.docker.com/get-started/get-docker/"><img src="https://www.docker.com/favicon.ico" width="16" height="16"> docker</a>, and <a href="https://nodejs.org/"><img src="https://nodejs.org/favicon.ico" width="16" height="16"> NodeJS</a>. Note that a NodeJS version of at least `24` is required.
 
-2. Install [ctags](https://github.com/universal-ctags/ctags) (required by zoekt)
-    ```sh
-    // macOS:
-    brew install universal-ctags
+2. Install [universal-ctags](https://github.com/universal-ctags/ctags) v6.1.0 (required by zoekt). Version 6.1.0 is required — newer versions have a known incompatibility with zoekt.
 
-    // Linux:
-    snap install universal-ctags
+    **macOS:** Run the provided install script:
+    ```sh
+    ./install-ctags-macos.sh
     ```
+
+    **Linux and other platforms:** Build from source:
+    ```sh
+    curl https://codeload.github.com/universal-ctags/ctags/tar.gz/v6.1.0 | tar xz -C /tmp
+    cd /tmp/ctags-6.1.0
+    ./autogen.sh
+    ./configure --program-prefix=universal- --enable-json
+    make -j$(nproc)
+    sudo make install
+    ```
+
+    After installing, set `CTAGS_COMMAND` in your `.env.development.local` to the path of the installed binary (e.g. `/usr/local/bin/universal-ctags`).
 
 3. Install corepack:
     ```sh

--- a/install-ctags-macos.sh
+++ b/install-ctags-macos.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# This script installs universal-ctags v6.1.0 on macOS.
+# This version is pinned to match the version used in the Sourcebot Docker image.
+# See vendor/zoekt/install-ctags-alpine.sh for the Alpine equivalent.
+
+CTAGS_VERSION=v6.1.0
+CTAGS_ARCHIVE_TOP_LEVEL_DIR=ctags-6.1.0
+INSTALL_DIR=/usr/local/bin
+
+cleanup() {
+  cd /
+  rm -rf /tmp/ctags-$CTAGS_VERSION
+}
+
+trap cleanup EXIT
+
+set -eux
+
+# Ensure required build tools are available
+if ! command -v brew >/dev/null 2>&1; then
+  echo "Homebrew is required to install build dependencies. See https://brew.sh."
+  exit 1
+fi
+
+brew install autoconf automake pkg-config jansson
+
+curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
+cd /tmp/$CTAGS_ARCHIVE_TOP_LEVEL_DIR
+./autogen.sh
+./configure --program-prefix=universal- --enable-json
+make -j"$(sysctl -n hw.ncpu)"
+sudo make install
+
+echo ""
+echo "universal-ctags installed to $INSTALL_DIR/universal-ctags"
+echo "Add the following to your .env.development.local:"
+echo "  CTAGS_COMMAND=$INSTALL_DIR/universal-ctags"


### PR DESCRIPTION
## Summary

- Adds `install-ctags-macos.sh` to build and install universal-ctags v6.1.0 from source on macOS
- Updates `CONTRIBUTING.md` to replace the `brew install universal-ctags` instruction with the new script for macOS, and adds build-from-source instructions for Linux and other platforms

## Why v6.1.0?

universal-ctags 6.2.1 (the current Homebrew version) has a known incompatibility with zoekt: it emits JSON `_type: "error"` warning messages about the Cargo subparser at startup when Rust is in the language list. The `go-ctags` library treats any `_type: error` response as fatal, causing indexing to silently fall back to no symbol extraction. v6.1.0 is the version pinned in `vendor/zoekt/install-ctags-alpine.sh` and does not have this issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated contributor setup instructions with new installation requirements and platform-specific guidance.

* **Chores**
  * Added automated installation script for developer environment setup on macOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->