### PR TITLE
fix(shared): improve config validation error message for local git connections

### DIFF
--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -107,7 +107,18 @@ export const loadConfig = async (configPath?: string): Promise<SourcebotConfig> 
     const config = JSON.parse(stripJsonComments(configContent)) as SourcebotConfig;
     const isValidConfig = ajv.validate(indexSchema, config);
     if (!isValidConfig) {
-        throw new Error(`Config file '${configPath}' is invalid: ${ajv.errorsText(ajv.errors)}`);
+        const fileUrlConnections = Object.entries((config as any)?.connections ?? {})
+            .filter(([, conn]: [string, any]) => conn?.url?.startsWith('file://'))
+            .map(([name]) => name);
+
+        const hint = fileUrlConnections.length > 0
+            ? ` Hint: connection(s) [${fileUrlConnections.join(', ')}] use a file:// URL. ` +
+              `Make sure the local repository is mounted into the Docker container and ` +
+              `the URL reflects the container-internal path (e.g. file:///repos/my-repo), ` +
+              `not the host machine path.`
+            : '';
+
+        throw new Error(`Config file '${configPath}' is invalid: ${ajv.errorsText(ajv.errors)}.${hint}`);
     }
     return config;
 }


### PR DESCRIPTION
When a user configures a local git connection with a file:// URL but forgets to mount the repo into the Docker container, the error thrown is raw AJV output which is hard to understand.

This PR appends a plain-English hint to the error when a file:// URL is detected, telling the user to mount the repo and use the container-internal path.

Fixes #1044

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced configuration validation error messages. When configuration validation fails and local file connections are detected, the system now provides additional guidance about mounting local repositories into Docker containers and using the correct container-internal file paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->