### PR TITLE
chore(docker): improve Docker build caching

### DIFF
--- a/.github/workflows/pr-gate.yml
+++ b/.github/workflows/pr-gate.yml
@@ -17,8 +17,13 @@ jobs:
         with:
           submodules: "true"
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Build Docker image
         id: build
         uses: docker/build-push-action@v6
         with:
           context: .
+          cache-from: type=gha,scope=pr-gate
+          cache-to: type=gha,mode=max,scope=pr-gate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved Docker build performance by enabling BuildKit cache mounts for Yarn and Go steps and by reusing Docker layer caches in the PR gate workflow. [#1094](https://github.com/sourcebot-dev/sourcebot/pull/1094)
+
 ## [4.16.7] - 2026-04-03
 
 ### Fixed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-# syntax=docker/dockerfile:1
+# syntax=docker/dockerfile:1.7
 # ------ Global scope variables ------
 
 # Set of global build arguments.
@@ -24,9 +24,13 @@ FROM go-alpine AS zoekt-builder
 RUN apk add --no-cache ca-certificates
 WORKDIR /zoekt
 COPY vendor/zoekt/go.mod vendor/zoekt/go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=sourcebot-go-mod-cache,target=/go/pkg/mod \
+    --mount=type=cache,id=sourcebot-go-build-cache,target=/root/.cache/go-build \
+    go mod download
 COPY vendor/zoekt ./
-RUN CGO_ENABLED=0 GOOS=linux go build -o /cmd/ ./cmd/...
+RUN --mount=type=cache,id=sourcebot-go-mod-cache,target=/go/pkg/mod \
+    --mount=type=cache,id=sourcebot-go-build-cache,target=/root/.cache/go-build \
+    CGO_ENABLED=0 GOOS=linux go build -o /cmd/ ./cmd/...
 # -------------------------
 
 # ------ Build shared libraries ------
@@ -40,10 +44,14 @@ COPY ./packages/schemas ./packages/schemas
 COPY ./packages/shared ./packages/shared
 COPY ./packages/queryLanguage ./packages/queryLanguage
 
-RUN yarn workspace @sourcebot/db install
-RUN yarn workspace @sourcebot/schemas install
-RUN yarn workspace @sourcebot/shared install
-RUN yarn workspace @sourcebot/query-language install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/db install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/schemas install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/shared install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/query-language install
 # ------------------------------------
 
 # ------ Build Web ------
@@ -89,7 +97,8 @@ COPY --from=shared-libs-builder /app/packages/shared ./packages/shared
 COPY --from=shared-libs-builder /app/packages/queryLanguage ./packages/queryLanguage
 
 # Fixes arm64 timeouts
-RUN yarn workspace @sourcebot/web install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/web install
 
 ENV NEXT_TELEMETRY_DISABLED=1
 RUN yarn workspace @sourcebot/web build
@@ -126,7 +135,8 @@ COPY --from=shared-libs-builder /app/packages/db ./packages/db
 COPY --from=shared-libs-builder /app/packages/schemas ./packages/schemas
 COPY --from=shared-libs-builder /app/packages/shared ./packages/shared
 COPY --from=shared-libs-builder /app/packages/queryLanguage ./packages/queryLanguage
-RUN yarn workspace @sourcebot/backend install
+RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+    yarn workspace @sourcebot/backend install
 RUN yarn workspace @sourcebot/backend build
 
 # Upload source maps to Sentry if we have the necessary build-time args.

--- a/Dockerfile
+++ b/Dockerfile
@@ -44,13 +44,13 @@ COPY ./packages/schemas ./packages/schemas
 COPY ./packages/shared ./packages/shared
 COPY ./packages/queryLanguage ./packages/queryLanguage
 
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/db install
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/schemas install
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/shared install
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/query-language install
 # ------------------------------------
 
@@ -97,7 +97,7 @@ COPY --from=shared-libs-builder /app/packages/shared ./packages/shared
 COPY --from=shared-libs-builder /app/packages/queryLanguage ./packages/queryLanguage
 
 # Fixes arm64 timeouts
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/web install
 
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -135,7 +135,7 @@ COPY --from=shared-libs-builder /app/packages/db ./packages/db
 COPY --from=shared-libs-builder /app/packages/schemas ./packages/schemas
 COPY --from=shared-libs-builder /app/packages/shared ./packages/shared
 COPY --from=shared-libs-builder /app/packages/queryLanguage ./packages/queryLanguage
-RUN --mount=type=cache,id=sourcebot-yarn-cache,target=/app/.yarn/cache \
+RUN --mount=type=cache,id=sourcebot-yarn-cache,sharing=locked,target=/app/.yarn/cache \
     yarn workspace @sourcebot/backend install
 RUN yarn workspace @sourcebot/backend build
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- enable Dockerfile frontend `1.7` to support BuildKit cache mounts
- add persistent BuildKit cache mounts for Go module/build caches in Zoekt build steps
- add persistent BuildKit cache mounts for Yarn cache during workspace installs in Docker build stages
- use `sharing=locked` on shared Yarn cache mounts to avoid concurrent write races in parallel build stages
- enable GitHub Actions cache import/export in `pr-gate` docker builds so PR checks benefit from the same layer cache mechanism as release builds
- add an `[Unreleased]` `CHANGELOG.md` entry for this PR

## Validation
- cold build benchmark before/after and image size comparison captured in:
  - [docker_build_benchmark_summary.txt](https://cursor.com/agents/bc-e8815b6c-1142-4996-80bf-f834dd7e98f9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdocker_build_benchmark_summary.txt)
- container smoke test performed against optimized image with a valid config file:
  - container starts, migrations apply, backend/web/zoekt/redis all report running
  - `curl -sSL -o /tmp/sourcebot-app-body.txt -w '%{http_code}' http://localhost:3900/~` => `200`

## Results
- baseline cold build: `259.552s`
- optimized cold build: `231.894s` (about 10.7% faster)
- optimized warm build: `1.196s` (full cache hit)
- baseline image size: `1890947560` bytes
- optimized image size: `1890947576` bytes (delta `+16` bytes, effectively unchanged)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e8815b6c-1142-4996-80bf-f834dd7e98f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e8815b6c-1142-4996-80bf-f834dd7e98f9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

