### PR TITLE
feat(web): add per-model temperature configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Linear issue links in chat responses now render as a rich card-style UI showing the Linear logo, issue identifier, and title instead of plain hyperlinks. [#1060](https://github.com/sourcebot-dev/sourcebot/pull/1060)
 - Added `reasoningEffort` configuration option for the Azure OpenAI provider. [#1101](https://github.com/sourcebot-dev/sourcebot/pull/1101)
 - Added `reasoningSummary` configuration option for the OpenAI and Azure OpenAI providers. [#1102](https://github.com/sourcebot-dev/sourcebot/pull/1102)
+- Added per-model `temperature` configuration option for all language model providers. [#1103](https://github.com/sourcebot-dev/sourcebot/pull/1103)
 
 ### Changed
 - Links in Ask Sourcebot chat responses now open in a new tab with a subtle external link icon indicator. [#1059](https://github.com/sourcebot-dev/sourcebot/pull/1059)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Links in Ask Sourcebot chat responses now open in a new tab with a subtle external link icon indicator. [#1059](https://github.com/sourcebot-dev/sourcebot/pull/1059)
 - Removed `/~` from the root of most app URLs. [#1076](https://github.com/sourcebot-dev/sourcebot/pull/1076)
+- Deprecated `SOURCEBOT_CHAT_MODEL_TEMPERATURE` environment variable in favor of per-model `temperature` config. It no longer defaults to `0.3`; if unset and no per-model temperature is configured, temperature is not sent to the API. [#1103](https://github.com/sourcebot-dev/sourcebot/pull/1103)
 
 ## [4.16.7] - 2026-04-03
 

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -1813,6 +1813,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -1947,6 +1951,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2078,6 +2086,10 @@
                   "detailed"
                 ]
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2181,6 +2193,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2283,6 +2299,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2402,6 +2422,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2524,6 +2548,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2626,6 +2654,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2755,6 +2787,10 @@
                   "auto",
                   "detailed"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2959,6 +2995,10 @@
                   "thinking",
                   "reasoning"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               }
             },
             "required": [
@@ -3019,6 +3059,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3126,6 +3170,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3303,6 +3351,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3437,6 +3489,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3568,6 +3624,10 @@
                   "detailed"
                 ]
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3671,6 +3731,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3773,6 +3837,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3892,6 +3960,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4014,6 +4086,10 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -4116,6 +4192,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4245,6 +4325,10 @@
                   "auto",
                   "detailed"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4449,6 +4533,10 @@
                   "thinking",
                   "reasoning"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               }
             },
             "required": [
@@ -4509,6 +4597,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4616,6 +4708,10 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",

--- a/docs/snippets/schemas/v3/languageModel.schema.mdx
+++ b/docs/snippets/schemas/v3/languageModel.schema.mdx
@@ -127,6 +127,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -261,6 +265,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -392,6 +400,10 @@
             "detailed"
           ]
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -495,6 +507,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -597,6 +613,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -716,6 +736,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -838,6 +862,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -940,6 +968,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1069,6 +1101,10 @@
             "auto",
             "detailed"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1273,6 +1309,10 @@
             "thinking",
             "reasoning"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         }
       },
       "required": [
@@ -1333,6 +1373,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1440,6 +1484,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1617,6 +1665,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1751,6 +1803,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1882,6 +1938,10 @@
             "detailed"
           ]
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1985,6 +2045,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -2087,6 +2151,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2206,6 +2274,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2328,6 +2400,10 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -2430,6 +2506,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2559,6 +2639,10 @@
             "auto",
             "detailed"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2763,6 +2847,10 @@
             "thinking",
             "reasoning"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         }
       },
       "required": [
@@ -2823,6 +2911,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2930,6 +3022,10 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -1812,6 +1812,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -1946,6 +1950,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2077,6 +2085,10 @@ const schema = {
                   "detailed"
                 ]
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2180,6 +2192,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2282,6 +2298,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2401,6 +2421,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2523,6 +2547,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -2625,6 +2653,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2754,6 +2786,10 @@ const schema = {
                   "auto",
                   "detailed"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -2958,6 +2994,10 @@ const schema = {
                   "thinking",
                   "reasoning"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               }
             },
             "required": [
@@ -3018,6 +3058,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3125,6 +3169,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3302,6 +3350,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3436,6 +3488,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3567,6 +3623,10 @@ const schema = {
                   "detailed"
                 ]
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3670,6 +3730,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -3772,6 +3836,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -3891,6 +3959,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4013,6 +4085,10 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
               "headers": {
                 "type": "object",
                 "description": "Optional headers to use with the model.",
@@ -4115,6 +4191,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4244,6 +4324,10 @@ const schema = {
                   "auto",
                   "detailed"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4448,6 +4532,10 @@ const schema = {
                   "thinking",
                   "reasoning"
                 ]
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               }
             },
             "required": [
@@ -4508,6 +4596,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",
@@ -4615,6 +4707,10 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
               },
               "headers": {
                 "type": "object",

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -749,6 +749,10 @@ export interface AmazonBedrockLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 /**
@@ -825,6 +829,10 @@ export interface AnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface AzureLanguageModel {
@@ -876,6 +884,10 @@ export interface AzureLanguageModel {
    * Controls whether the model returns its reasoning process. Set to 'auto' for a condensed summary, 'detailed' for more comprehensive reasoning, or 'none' to disable. Defaults to 'auto'.
    */
   reasoningSummary?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface DeepSeekLanguageModel {
@@ -911,6 +923,10 @@ export interface DeepSeekLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleGenerativeAILanguageModel {
@@ -946,6 +962,10 @@ export interface GoogleGenerativeAILanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexAnthropicLanguageModel {
@@ -989,6 +1009,10 @@ export interface GoogleVertexAnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexLanguageModel {
@@ -1032,6 +1056,10 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface MistralLanguageModel {
@@ -1067,6 +1095,10 @@ export interface MistralLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface OpenAILanguageModel {
@@ -1110,6 +1142,10 @@ export interface OpenAILanguageModel {
    * Controls whether the model returns its reasoning process. Set to 'auto' for a condensed summary, 'detailed' for more comprehensive reasoning, or 'none' to disable. Defaults to 'auto'.
    */
   reasoningSummary?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface OpenAICompatibleLanguageModel {
@@ -1151,6 +1187,10 @@ export interface OpenAICompatibleLanguageModel {
    * The name of the XML tag to extract reasoning from (without angle brackets). Defaults to `think`.
    */
   reasoningTag?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
 }
 /**
  * Optional query parameters to include in the request url.
@@ -1210,6 +1250,10 @@ export interface OpenRouterLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface XaiLanguageModel {
@@ -1245,6 +1289,10 @@ export interface XaiLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GitHubAppConfig {

--- a/packages/schemas/src/v3/languageModel.schema.ts
+++ b/packages/schemas/src/v3/languageModel.schema.ts
@@ -126,6 +126,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -260,6 +264,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -391,6 +399,10 @@ const schema = {
             "detailed"
           ]
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -494,6 +506,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -596,6 +612,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -715,6 +735,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -837,6 +861,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -939,6 +967,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1068,6 +1100,10 @@ const schema = {
             "auto",
             "detailed"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1272,6 +1308,10 @@ const schema = {
             "thinking",
             "reasoning"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         }
       },
       "required": [
@@ -1332,6 +1372,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1439,6 +1483,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -1616,6 +1664,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1750,6 +1802,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1881,6 +1937,10 @@ const schema = {
             "detailed"
           ]
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -1984,6 +2044,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -2086,6 +2150,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2205,6 +2273,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2327,6 +2399,10 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
         "headers": {
           "type": "object",
           "description": "Optional headers to use with the model.",
@@ -2429,6 +2505,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2558,6 +2638,10 @@ const schema = {
             "auto",
             "detailed"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2762,6 +2846,10 @@ const schema = {
             "thinking",
             "reasoning"
           ]
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         }
       },
       "required": [
@@ -2822,6 +2910,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",
@@ -2929,6 +3021,10 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
         },
         "headers": {
           "type": "object",

--- a/packages/schemas/src/v3/languageModel.type.ts
+++ b/packages/schemas/src/v3/languageModel.type.ts
@@ -83,6 +83,10 @@ export interface AmazonBedrockLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 /**
@@ -159,6 +163,10 @@ export interface AnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface AzureLanguageModel {
@@ -210,6 +218,10 @@ export interface AzureLanguageModel {
    * Controls whether the model returns its reasoning process. Set to 'auto' for a condensed summary, 'detailed' for more comprehensive reasoning, or 'none' to disable. Defaults to 'auto'.
    */
   reasoningSummary?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface DeepSeekLanguageModel {
@@ -245,6 +257,10 @@ export interface DeepSeekLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleGenerativeAILanguageModel {
@@ -280,6 +296,10 @@ export interface GoogleGenerativeAILanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexAnthropicLanguageModel {
@@ -323,6 +343,10 @@ export interface GoogleVertexAnthropicLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface GoogleVertexLanguageModel {
@@ -366,6 +390,10 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface MistralLanguageModel {
@@ -401,6 +429,10 @@ export interface MistralLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface OpenAILanguageModel {
@@ -444,6 +476,10 @@ export interface OpenAILanguageModel {
    * Controls whether the model returns its reasoning process. Set to 'auto' for a condensed summary, 'detailed' for more comprehensive reasoning, or 'none' to disable. Defaults to 'auto'.
    */
   reasoningSummary?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface OpenAICompatibleLanguageModel {
@@ -485,6 +521,10 @@ export interface OpenAICompatibleLanguageModel {
    * The name of the XML tag to extract reasoning from (without angle brackets). Defaults to `think`.
    */
   reasoningTag?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
 }
 /**
  * Optional query parameters to include in the request url.
@@ -544,6 +584,10 @@ export interface OpenRouterLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }
 export interface XaiLanguageModel {
@@ -579,5 +623,9 @@ export interface XaiLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
   headers?: LanguageModelHeaders;
 }

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -229,7 +229,10 @@ const options = {
         AWS_SESSION_TOKEN: z.string().optional(),
         AWS_REGION: z.string().optional(),
 
-        SOURCEBOT_CHAT_MODEL_TEMPERATURE: numberSchema.default(0.3),
+        /**
+         * @deprecated Use per-model `temperature` in the language model config instead.
+         */
+        SOURCEBOT_CHAT_MODEL_TEMPERATURE: numberSchema.optional(),
         SOURCEBOT_CHAT_MAX_STEP_COUNT: numberSchema.default(100),
 
         DEBUG_WRITE_CHAT_MESSAGES_TO_FILE: booleanSchema.default('false'),

--- a/packages/web/src/app/api/(server)/chat/route.ts
+++ b/packages/web/src/app/api/(server)/chat/route.ts
@@ -77,7 +77,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 } satisfies ServiceError;
             }
 
-            const { model, providerOptions } = await getAISDKLanguageModelAndOptions(languageModelConfig);
+            const { model, providerOptions, temperature } = await getAISDKLanguageModelAndOptions(languageModelConfig);
 
             const expandedRepos = (await Promise.all(selectedSearchScopes.map(async (scope) => {
                 if (scope.type === 'repo') return [scope.value];
@@ -108,6 +108,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 model,
                 modelName: languageModelConfig.displayName ?? languageModelConfig.model,
                 modelProviderOptions: providerOptions,
+                modelTemperature: temperature,
                 onFinish: async ({ messages }) => {
                     await updateChatMessages({ chatId: id, messages, prisma });
                 },

--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -42,6 +42,7 @@ interface CreateMessageStreamResponseProps {
     onFinish: UIMessageStreamOnFinishCallback<SBChatMessage>;
     onError: (error: unknown) => string;
     modelProviderOptions?: Record<string, Record<string, JSONValue>>;
+    modelTemperature?: number;
     metadata?: Partial<SBChatMessageMetadata>;
 }
 
@@ -53,6 +54,7 @@ export const createMessageStream = async ({
     model,
     modelName,
     modelProviderOptions,
+    modelTemperature,
     onFinish,
     onError,
 }: CreateMessageStreamResponseProps) => {
@@ -96,6 +98,7 @@ export const createMessageStream = async ({
             const researchStream = await createAgentStream({
                 model,
                 providerOptions: modelProviderOptions,
+                temperature: modelTemperature,
                 inputMessages: messageHistory,
                 inputSources: sources,
                 selectedRepos,
@@ -145,6 +148,7 @@ export const createMessageStream = async ({
 interface AgentOptions {
     model: LanguageModel;
     providerOptions?: ProviderOptions;
+    temperature?: number;
     selectedRepos: string[];
     inputMessages: ModelMessage[];
     inputSources: Source[];
@@ -156,6 +160,7 @@ interface AgentOptions {
 const createAgentStream = async ({
     model,
     providerOptions,
+    temperature,
     inputMessages,
     inputSources,
     selectedRepos,
@@ -199,7 +204,7 @@ const createAgentStream = async ({
         messages: inputMessages,
         system: systemPrompt,
         tools: createTools({ source: 'sourcebot-ask-agent', selectedRepos }),
-        temperature: env.SOURCEBOT_CHAT_MODEL_TEMPERATURE,
+        temperature: temperature ?? env.SOURCEBOT_CHAT_MODEL_TEMPERATURE,
         stopWhen: [
             stepCountIsGTE(env.SOURCEBOT_CHAT_MAX_STEP_COUNT),
         ],

--- a/packages/web/src/features/chat/utils.server.ts
+++ b/packages/web/src/features/chat/utils.server.ts
@@ -160,6 +160,7 @@ User question: ${message}`;
 export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Promise<{
     model: AISDKLanguageModelV3,
     providerOptions?: Record<string, Record<string, JSONValue>>,
+    temperature?: number,
 }> => {
     const { provider, model: modelId } = config;
 
@@ -426,6 +427,7 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
     return {
         model,
         providerOptions,
+        temperature: config.temperature,
     };
 }
 

--- a/packages/web/src/features/mcp/askCodebase.ts
+++ b/packages/web/src/features/mcp/askCodebase.ts
@@ -70,7 +70,7 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
                 languageModelConfig = matchingModel;
             }
 
-            const { model, providerOptions } = await getAISDKLanguageModelAndOptions(languageModelConfig);
+            const { model, providerOptions, temperature } = await getAISDKLanguageModelAndOptions(languageModelConfig);
             const modelName = languageModelConfig.displayName ?? languageModelConfig.model;
 
             const chatVisibility = (requestedVisibility && user)
@@ -156,6 +156,7 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
                 model,
                 modelName,
                 modelProviderOptions: providerOptions,
+                modelTemperature: temperature,
                 onFinish: async ({ messages }) => {
                     finalMessages = messages;
                 },

--- a/schemas/v3/languageModel.json
+++ b/schemas/v3/languageModel.json
@@ -44,6 +44,10 @@
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
                 },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
@@ -82,6 +86,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
@@ -146,6 +154,10 @@
                         "detailed"
                     ]
                 },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
@@ -181,6 +193,10 @@
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
                 },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
@@ -215,6 +231,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
@@ -266,6 +286,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
@@ -320,6 +344,10 @@
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
                 },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
@@ -354,6 +382,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
@@ -416,6 +448,10 @@
                         "detailed"
                     ]
                 },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
                 }
@@ -469,6 +505,10 @@
                         "thinking",
                         "reasoning"
                     ]
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 }
             },
             "required": [
@@ -502,6 +542,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"
@@ -541,6 +585,10 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
                 },
                 "headers": {
                     "$ref": "./shared.json#/definitions/LanguageModelHeaders"


### PR DESCRIPTION
## Summary
- Adds an optional `temperature` field to all 12 language model provider schemas, allowing temperature to be set per model
- Per-model temperature takes precedence over the `SOURCEBOT_CHAT_MODEL_TEMPERATURE` env var, which is now deprecated and defaults to `undefined`
- Threads `temperature` through `getAISDKLanguageModelAndOptions` → `createMessageStream` → `createAgentStream` → `streamText`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional per-model temperature configuration for all supported language model providers, enabling granular control of model behavior.

* **Changed**
  * The `SOURCEBOT_CHAT_MODEL_TEMPERATURE` environment variable is deprecated. Use per-model temperature configuration instead. When not configured, temperature defaults to API provider settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->