### PR TITLE
fix: improve Ask view layout adjustment for narrow/split windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
-- Fixed Ask view layout becoming unusable in narrow/split window mode by adding automatic vertical layout switching and a toggle button to collapse/expand code references. [#1107](https://github.com/sourcebot-dev/sourcebot/pull/1107)
+- Fixed Ask view layout becoming unusable in narrow/split window mode by reducing panel minimum sizes to allow better resizing. [#1107](https://github.com/sourcebot-dev/sourcebot/pull/1107)
 
 ## [4.16.8] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed Ask view layout becoming unusable in narrow/split window mode by adding automatic vertical layout switching and a toggle button to collapse/expand code references. [#1107](https://github.com/sourcebot-dev/sourcebot/pull/1107)
+
 ## [4.16.8] - 2026-04-09
 
 ### Added

--- a/packages/web/src/features/chat/components/chatThread/chatThreadListItem.tsx
+++ b/packages/web/src/features/chat/components/chatThread/chatThreadListItem.tsx
@@ -3,9 +3,7 @@
 import { AnimatedResizableHandle } from '@/components/ui/animatedResizableHandle';
 import { ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Button } from '@/components/ui/button';
-import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
-import { CheckCircle, Loader2, PanelLeftClose, PanelLeft } from 'lucide-react';
+import { CheckCircle, Loader2 } from 'lucide-react';
 import { CSSProperties, forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { Reference, referenceSchema, SBChatMessage, Source } from "../../types";
@@ -17,9 +15,6 @@ import { MarkdownRenderer, REFERENCE_PAYLOAD_ATTRIBUTE } from './markdownRendere
 import { ReferencedSourcesListView } from './referencedSourcesListView';
 import isEqual from "fast-deep-equal/react";
 import { ANSWER_TAG } from '../../constants';
-
-// Minimum width in pixels for the horizontal layout to work well
-const MIN_HORIZONTAL_LAYOUT_WIDTH = 768;
 
 interface ChatThreadListItemProps {
     userMessage: SBChatMessage;
@@ -38,7 +33,6 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     chatId,
     index,
 }, ref) => {
-    const containerRef = useRef<HTMLDivElement>(null);
     const leftPanelRef = useRef<HTMLDivElement>(null);
     const [leftPanelHeight, setLeftPanelHeight] = useState<number | null>(null);
     const answerRef = useRef<HTMLDivElement>(null);
@@ -48,32 +42,6 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     const [isDetailsPanelExpanded, _setIsDetailsPanelExpanded] = useState(isStreaming);
     const hasAutoCollapsed = useRef(false);
     const userHasManuallyExpanded = useRef(false);
-
-    // Layout state: track container width and user preference
-    const [containerWidth, setContainerWidth] = useState<number | null>(null);
-    const [isReferencePanelCollapsed, setIsReferencePanelCollapsed] = useState(false);
-
-    // Determine if we should use vertical layout based on container width
-    const shouldUseVerticalLayout = containerWidth !== null && containerWidth < MIN_HORIZONTAL_LAYOUT_WIDTH;
-
-    // Monitor container width for responsive layout
-    useEffect(() => {
-        if (!containerRef.current) {
-            return;
-        }
-
-        const resizeObserver = new ResizeObserver((entries) => {
-            for (const entry of entries) {
-                setContainerWidth(entry.contentRect.width);
-            }
-        });
-
-        resizeObserver.observe(containerRef.current);
-
-        return () => {
-            resizeObserver.disconnect();
-        };
-    }, []);
 
     const userQuestion = useMemo(() => {
         return userMessage.parts.length > 0 && userMessage.parts[0].type === 'text' ? userMessage.parts[0].text : '';
@@ -337,162 +305,10 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     }, [references, sources]);
 
 
-    // Content for the answer/question panel
-    const answerPanelContent = (
-        <div
-            ref={leftPanelRef}
-            className="py-4 h-full"
-        >
-            <div className="flex flex-row gap-2 mb-4">
-                {isStreaming ? (
-                    <Loader2 className="w-4 h-4 animate-spin flex-shrink-0 mt-1.5" />
-                ) : (
-                    <CheckCircle className="w-4 h-4 text-green-700 flex-shrink-0 mt-1.5" />
-                )}
-                <MarkdownRenderer
-                    content={userQuestion.trim()}
-                    className="prose-p:m-0"
-                    escapeHtml={true}
-                />
-            </div>
-
-            {isThinking && (
-                <div className="space-y-4 mb-4">
-                    <Skeleton className="h-4 max-w-32" />
-                    <div className="space-y-2">
-                        <Skeleton className="h-3 max-w-72" />
-                        <Skeleton className="h-3 max-w-64" />
-                        <Skeleton className="h-3 max-w-56" />
-                    </div>
-                </div>
-            )}
-
-            <DetailsCard
-                chatId={chatId}
-                isExpanded={isDetailsPanelExpanded}
-                onExpandedChanged={onExpandDetailsPanel}
-                isThinking={isThinking}
-                isStreaming={isStreaming}
-                thinkingSteps={uiVisibleThinkingSteps}
-                metadata={assistantMessage?.metadata}
-            />
-
-            {(answerPart && assistantMessage) ? (
-                <AnswerCard
-                    ref={answerRef}
-                    answerText={answerPart.text}
-                    chatId={chatId}
-                    messageId={assistantMessage.id}
-                    traceId={assistantMessage.metadata?.traceId}
-                />
-            ) : !isStreaming && (
-                <p className="text-destructive">Error: No answer response was provided</p>
-            )}
-        </div>
-    );
-
-    // Content for the references panel
-    const referencesPanelContent = (
-        <>
-            {referencedFileSources.length > 0 ? (
-                <ReferencedSourcesListView
-                    index={index}
-                    references={references}
-                    sources={referencedFileSources}
-                    hoveredReference={hoveredReference}
-                    selectedReference={selectedReference}
-                    onSelectedReferenceChanged={setSelectedReference}
-                    onHoveredReferenceChanged={setHoveredReference}
-                    style={shouldUseVerticalLayout || isReferencePanelCollapsed ? {} : rightPanelStyle}
-                />
-            ) : isStreaming ? (
-                <div className="space-y-4">
-                    {Array.from({ length: 3 }).map((_, index) => (
-                        <Skeleton key={index} className="w-full h-48" />
-                    ))}
-                </div>
-            ) : (
-                <div className="p-4 text-center text-muted-foreground text-sm">
-                    No file references found
-                </div>
-            )}
-        </>
-    );
-
-    // Layout toggle button for narrow containers
-    const layoutToggleButton = referencedFileSources.length > 0 && (
-        <Tooltip>
-            <TooltipTrigger asChild>
-                <Button
-                    variant="ghost"
-                    size="sm"
-                    className="h-7 w-7 p-0"
-                    onClick={() => setIsReferencePanelCollapsed(!isReferencePanelCollapsed)}
-                >
-                    {isReferencePanelCollapsed ? (
-                        <PanelLeft className="h-4 w-4" />
-                    ) : (
-                        <PanelLeftClose className="h-4 w-4" />
-                    )}
-                </Button>
-            </TooltipTrigger>
-            <TooltipContent side="bottom">
-                {isReferencePanelCollapsed ? 'Show code references' : 'Hide code references'}
-            </TooltipContent>
-        </Tooltip>
-    );
-
-    // Vertical layout for narrow containers
-    if (shouldUseVerticalLayout) {
-        return (
-            <div
-                className="flex flex-col relative"
-                ref={(node) => {
-                    // Handle both refs
-                    containerRef.current = node;
-                    if (typeof ref === 'function') {
-                        ref(node);
-                    } else if (ref) {
-                        ref.current = node;
-                    }
-                }}
-            >
-                {/* Answer panel with toggle button */}
-                <div className="relative">
-                    {referencedFileSources.length > 0 && (
-                        <div className="absolute top-4 right-0 z-10">
-                            {layoutToggleButton}
-                        </div>
-                    )}
-                    {answerPanelContent}
-                </div>
-
-                {/* References panel - collapsible in vertical layout */}
-                {!isReferencePanelCollapsed && referencedFileSources.length > 0 && (
-                    <div className="border-t pt-4 mt-4">
-                        <div className="text-sm font-medium text-muted-foreground mb-3">Code References</div>
-                        <div className="max-h-[50vh] overflow-y-auto">
-                            {referencesPanelContent}
-                        </div>
-                    </div>
-                )}
-            </div>
-        );
-    }
-
-    // Horizontal layout for wider containers
     return (
         <div
-            className="flex flex-col relative min-h-[calc(100vh-250px)]"
-            ref={(node) => {
-                // Handle both refs
-                containerRef.current = node;
-                if (typeof ref === 'function') {
-                    ref(node);
-                } else if (ref) {
-                    ref.current = node;
-                }
-            }}
+            className="flex flex-col md:flex-row relative min-h-[calc(100vh-250px)]"
+            ref={ref}
         >
             <ResizablePanelGroup
                 direction="horizontal"
@@ -503,42 +319,103 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
             >
                 <ResizablePanel
                     order={1}
-                    minSize={isReferencePanelCollapsed ? 100 : 30}
-                    maxSize={isReferencePanelCollapsed ? 100 : 70}
-                    defaultSize={isReferencePanelCollapsed ? 100 : 50}
+                    minSize={20}
+                    maxSize={80}
+                    defaultSize={50}
                     style={{
                         overflow: 'visible',
                     }}
                 >
-                    <div className="relative">
-                        {referencedFileSources.length > 0 && (
-                            <div className="absolute top-4 right-0 z-10">
-                                {layoutToggleButton}
+                    <div
+                        ref={leftPanelRef}
+                        className="py-4 h-full"
+                    >
+                        <div className="flex flex-row gap-2 mb-4">
+                            {isStreaming ? (
+                                <Loader2 className="w-4 h-4 animate-spin flex-shrink-0 mt-1.5" />
+                            ) : (
+                                <CheckCircle className="w-4 h-4 text-green-700 flex-shrink-0 mt-1.5" />
+                            )}
+                            <MarkdownRenderer
+                                content={userQuestion.trim()}
+                                className="prose-p:m-0"
+                                escapeHtml={true}
+                            />
+                        </div>
+
+                        {isThinking && (
+                            <div className="space-y-4 mb-4">
+                                <Skeleton className="h-4 max-w-32" />
+                                <div className="space-y-2">
+                                    <Skeleton className="h-3 max-w-72" />
+                                    <Skeleton className="h-3 max-w-64" />
+                                    <Skeleton className="h-3 max-w-56" />
+                                </div>
                             </div>
                         )}
-                        {answerPanelContent}
+
+                        <DetailsCard
+                            chatId={chatId}
+                            isExpanded={isDetailsPanelExpanded}
+                            onExpandedChanged={onExpandDetailsPanel}
+                            isThinking={isThinking}
+                            isStreaming={isStreaming}
+                            thinkingSteps={uiVisibleThinkingSteps}
+                            metadata={assistantMessage?.metadata}
+                        />
+
+                        {(answerPart && assistantMessage) ? (
+                            <AnswerCard
+                                ref={answerRef}
+                                answerText={answerPart.text}
+                                chatId={chatId}
+                                messageId={assistantMessage.id}
+                                traceId={assistantMessage.metadata?.traceId}
+                            />
+                        ) : !isStreaming && (
+                            <p className="text-destructive">Error: No answer response was provided</p>
+                        )}
                     </div>
                 </ResizablePanel>
-                {!isReferencePanelCollapsed && (
-                    <>
-                        <AnimatedResizableHandle className='mx-4' />
-                        <ResizablePanel
-                            order={2}
-                            minSize={30}
-                            maxSize={70}
-                            defaultSize={50}
-                            style={{
-                                overflow: 'clip',
-                                maxHeight: '100%',
-                                minWidth: 0,
-                            }}
-                        >
-                            <div className="sticky top-0">
-                                {referencesPanelContent}
+                <AnimatedResizableHandle className='mx-4' />
+                <ResizablePanel
+                    order={2}
+                    minSize={20}
+                    maxSize={80}
+                    defaultSize={50}
+                    style={{
+                        overflow: 'clip',
+                        maxHeight: '100%',
+                        minWidth: 0,
+                    }}
+                >
+                    <div
+                        className="sticky top-0"
+                    >
+                        {referencedFileSources.length > 0 ? (
+                            <ReferencedSourcesListView
+                                index={index}
+                                references={references}
+                                sources={referencedFileSources}
+                                hoveredReference={hoveredReference}
+                                selectedReference={selectedReference}
+                                onSelectedReferenceChanged={setSelectedReference}
+                                onHoveredReferenceChanged={setHoveredReference}
+                                style={rightPanelStyle}
+                            />
+                        ) : isStreaming ? (
+                            <div className="space-y-4">
+                                {Array.from({ length: 3 }).map((_, index) => (
+                                    <Skeleton key={index} className="w-full h-48" />
+                                ))}
                             </div>
-                        </ResizablePanel>
-                    </>
-                )}
+                        ) : (
+                            <div className="p-4 text-center text-muted-foreground text-sm">
+                                No file references found
+                            </div>
+                        )}
+                    </div>
+                </ResizablePanel>
             </ResizablePanelGroup>
         </div>
     )

--- a/packages/web/src/features/chat/components/chatThread/chatThreadListItem.tsx
+++ b/packages/web/src/features/chat/components/chatThread/chatThreadListItem.tsx
@@ -3,7 +3,9 @@
 import { AnimatedResizableHandle } from '@/components/ui/animatedResizableHandle';
 import { ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { Skeleton } from '@/components/ui/skeleton';
-import { CheckCircle, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { CheckCircle, Loader2, PanelLeftClose, PanelLeft } from 'lucide-react';
 import { CSSProperties, forwardRef, memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import scrollIntoView from 'scroll-into-view-if-needed';
 import { Reference, referenceSchema, SBChatMessage, Source } from "../../types";
@@ -15,6 +17,9 @@ import { MarkdownRenderer, REFERENCE_PAYLOAD_ATTRIBUTE } from './markdownRendere
 import { ReferencedSourcesListView } from './referencedSourcesListView';
 import isEqual from "fast-deep-equal/react";
 import { ANSWER_TAG } from '../../constants';
+
+// Minimum width in pixels for the horizontal layout to work well
+const MIN_HORIZONTAL_LAYOUT_WIDTH = 768;
 
 interface ChatThreadListItemProps {
     userMessage: SBChatMessage;
@@ -33,6 +38,7 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     chatId,
     index,
 }, ref) => {
+    const containerRef = useRef<HTMLDivElement>(null);
     const leftPanelRef = useRef<HTMLDivElement>(null);
     const [leftPanelHeight, setLeftPanelHeight] = useState<number | null>(null);
     const answerRef = useRef<HTMLDivElement>(null);
@@ -42,6 +48,32 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     const [isDetailsPanelExpanded, _setIsDetailsPanelExpanded] = useState(isStreaming);
     const hasAutoCollapsed = useRef(false);
     const userHasManuallyExpanded = useRef(false);
+
+    // Layout state: track container width and user preference
+    const [containerWidth, setContainerWidth] = useState<number | null>(null);
+    const [isReferencePanelCollapsed, setIsReferencePanelCollapsed] = useState(false);
+
+    // Determine if we should use vertical layout based on container width
+    const shouldUseVerticalLayout = containerWidth !== null && containerWidth < MIN_HORIZONTAL_LAYOUT_WIDTH;
+
+    // Monitor container width for responsive layout
+    useEffect(() => {
+        if (!containerRef.current) {
+            return;
+        }
+
+        const resizeObserver = new ResizeObserver((entries) => {
+            for (const entry of entries) {
+                setContainerWidth(entry.contentRect.width);
+            }
+        });
+
+        resizeObserver.observe(containerRef.current);
+
+        return () => {
+            resizeObserver.disconnect();
+        };
+    }, []);
 
     const userQuestion = useMemo(() => {
         return userMessage.parts.length > 0 && userMessage.parts[0].type === 'text' ? userMessage.parts[0].text : '';
@@ -305,10 +337,162 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
     }, [references, sources]);
 
 
+    // Content for the answer/question panel
+    const answerPanelContent = (
+        <div
+            ref={leftPanelRef}
+            className="py-4 h-full"
+        >
+            <div className="flex flex-row gap-2 mb-4">
+                {isStreaming ? (
+                    <Loader2 className="w-4 h-4 animate-spin flex-shrink-0 mt-1.5" />
+                ) : (
+                    <CheckCircle className="w-4 h-4 text-green-700 flex-shrink-0 mt-1.5" />
+                )}
+                <MarkdownRenderer
+                    content={userQuestion.trim()}
+                    className="prose-p:m-0"
+                    escapeHtml={true}
+                />
+            </div>
+
+            {isThinking && (
+                <div className="space-y-4 mb-4">
+                    <Skeleton className="h-4 max-w-32" />
+                    <div className="space-y-2">
+                        <Skeleton className="h-3 max-w-72" />
+                        <Skeleton className="h-3 max-w-64" />
+                        <Skeleton className="h-3 max-w-56" />
+                    </div>
+                </div>
+            )}
+
+            <DetailsCard
+                chatId={chatId}
+                isExpanded={isDetailsPanelExpanded}
+                onExpandedChanged={onExpandDetailsPanel}
+                isThinking={isThinking}
+                isStreaming={isStreaming}
+                thinkingSteps={uiVisibleThinkingSteps}
+                metadata={assistantMessage?.metadata}
+            />
+
+            {(answerPart && assistantMessage) ? (
+                <AnswerCard
+                    ref={answerRef}
+                    answerText={answerPart.text}
+                    chatId={chatId}
+                    messageId={assistantMessage.id}
+                    traceId={assistantMessage.metadata?.traceId}
+                />
+            ) : !isStreaming && (
+                <p className="text-destructive">Error: No answer response was provided</p>
+            )}
+        </div>
+    );
+
+    // Content for the references panel
+    const referencesPanelContent = (
+        <>
+            {referencedFileSources.length > 0 ? (
+                <ReferencedSourcesListView
+                    index={index}
+                    references={references}
+                    sources={referencedFileSources}
+                    hoveredReference={hoveredReference}
+                    selectedReference={selectedReference}
+                    onSelectedReferenceChanged={setSelectedReference}
+                    onHoveredReferenceChanged={setHoveredReference}
+                    style={shouldUseVerticalLayout || isReferencePanelCollapsed ? {} : rightPanelStyle}
+                />
+            ) : isStreaming ? (
+                <div className="space-y-4">
+                    {Array.from({ length: 3 }).map((_, index) => (
+                        <Skeleton key={index} className="w-full h-48" />
+                    ))}
+                </div>
+            ) : (
+                <div className="p-4 text-center text-muted-foreground text-sm">
+                    No file references found
+                </div>
+            )}
+        </>
+    );
+
+    // Layout toggle button for narrow containers
+    const layoutToggleButton = referencedFileSources.length > 0 && (
+        <Tooltip>
+            <TooltipTrigger asChild>
+                <Button
+                    variant="ghost"
+                    size="sm"
+                    className="h-7 w-7 p-0"
+                    onClick={() => setIsReferencePanelCollapsed(!isReferencePanelCollapsed)}
+                >
+                    {isReferencePanelCollapsed ? (
+                        <PanelLeft className="h-4 w-4" />
+                    ) : (
+                        <PanelLeftClose className="h-4 w-4" />
+                    )}
+                </Button>
+            </TooltipTrigger>
+            <TooltipContent side="bottom">
+                {isReferencePanelCollapsed ? 'Show code references' : 'Hide code references'}
+            </TooltipContent>
+        </Tooltip>
+    );
+
+    // Vertical layout for narrow containers
+    if (shouldUseVerticalLayout) {
+        return (
+            <div
+                className="flex flex-col relative"
+                ref={(node) => {
+                    // Handle both refs
+                    containerRef.current = node;
+                    if (typeof ref === 'function') {
+                        ref(node);
+                    } else if (ref) {
+                        ref.current = node;
+                    }
+                }}
+            >
+                {/* Answer panel with toggle button */}
+                <div className="relative">
+                    {referencedFileSources.length > 0 && (
+                        <div className="absolute top-4 right-0 z-10">
+                            {layoutToggleButton}
+                        </div>
+                    )}
+                    {answerPanelContent}
+                </div>
+
+                {/* References panel - collapsible in vertical layout */}
+                {!isReferencePanelCollapsed && referencedFileSources.length > 0 && (
+                    <div className="border-t pt-4 mt-4">
+                        <div className="text-sm font-medium text-muted-foreground mb-3">Code References</div>
+                        <div className="max-h-[50vh] overflow-y-auto">
+                            {referencesPanelContent}
+                        </div>
+                    </div>
+                )}
+            </div>
+        );
+    }
+
+    // Horizontal layout for wider containers
     return (
         <div
-            className="flex flex-col md:flex-row relative min-h-[calc(100vh-250px)]"
-            ref={ref}
+            className="flex flex-col relative min-h-[calc(100vh-250px)]"
+            ref={(node) => {
+                // Handle both refs
+                containerRef.current = node;
+                if (typeof ref === 'function') {
+                    ref(node);
+                } else if (ref) {
+                    ref.current = node;
+                }
+            }}
         >
             <ResizablePanelGroup
                 direction="horizontal"
@@ -319,103 +503,42 @@ const ChatThreadListItemComponent = forwardRef<HTMLDivElement, ChatThreadListIte
             >
                 <ResizablePanel
                     order={1}
-                    minSize={30}
-                    maxSize={70}
-                    defaultSize={50}
+                    minSize={isReferencePanelCollapsed ? 100 : 30}
+                    maxSize={isReferencePanelCollapsed ? 100 : 70}
+                    defaultSize={isReferencePanelCollapsed ? 100 : 50}
                     style={{
                         overflow: 'visible',
                     }}
                 >
-                    <div
-                        ref={leftPanelRef}
-                        className="py-4 h-full"
-                    >
-                        <div className="flex flex-row gap-2 mb-4">
-                            {isStreaming ? (
-                                <Loader2 className="w-4 h-4 animate-spin flex-shrink-0 mt-1.5" />
-                            ) : (
-                                <CheckCircle className="w-4 h-4 text-green-700 flex-shrink-0 mt-1.5" />
-                            )}
-                            <MarkdownRenderer
-                                content={userQuestion.trim()}
-                                className="prose-p:m-0"
-                                escapeHtml={true}
-                            />
-                        </div>
-
-                        {isThinking && (
-                            <div className="space-y-4 mb-4">
-                                <Skeleton className="h-4 max-w-32" />
-                                <div className="space-y-2">
-                                    <Skeleton className="h-3 max-w-72" />
-                                    <Skeleton className="h-3 max-w-64" />
-                                    <Skeleton className="h-3 max-w-56" />
-                                </div>
+                    <div className="relative">
+                        {referencedFileSources.length > 0 && (
+                            <div className="absolute top-4 right-0 z-10">
+                                {layoutToggleButton}
                             </div>
                         )}
-
-                        <DetailsCard
-                            chatId={chatId}
-                            isExpanded={isDetailsPanelExpanded}
-                            onExpandedChanged={onExpandDetailsPanel}
-                            isThinking={isThinking}
-                            isStreaming={isStreaming}
-                            thinkingSteps={uiVisibleThinkingSteps}
-                            metadata={assistantMessage?.metadata}
-                        />
-
-                        {(answerPart && assistantMessage) ? (
-                            <AnswerCard
-                                ref={answerRef}
-                                answerText={answerPart.text}
-                                chatId={chatId}
-                                messageId={assistantMessage.id}
-                                traceId={assistantMessage.metadata?.traceId}
-                            />
-                        ) : !isStreaming && (
-                            <p className="text-destructive">Error: No answer response was provided</p>
-                        )}
+                        {answerPanelContent}
                     </div>
                 </ResizablePanel>
-                <AnimatedResizableHandle className='mx-4' />
-                <ResizablePanel
-                    order={2}
-                    minSize={30}
-                    maxSize={70}
-                    defaultSize={50}
-                    style={{
-                        overflow: 'clip',
-                        maxHeight: '100%',
-                        minWidth: 0,
-                    }}
-                >
-                    <div
-                        className="sticky top-0"
-                    >
-                        {referencedFileSources.length > 0 ? (
-                            <ReferencedSourcesListView
-                                index={index}
-                                references={references}
-                                sources={referencedFileSources}
-                                hoveredReference={hoveredReference}
-                                selectedReference={selectedReference}
-                                onSelectedReferenceChanged={setSelectedReference}
-                                onHoveredReferenceChanged={setHoveredReference}
-                                style={rightPanelStyle}
-                            />
-                        ) : isStreaming ? (
-                            <div className="space-y-4">
-                                {Array.from({ length: 3 }).map((_, index) => (
-                                    <Skeleton key={index} className="w-full h-48" />
-                                ))}
+                {!isReferencePanelCollapsed && (
+                    <>
+                        <AnimatedResizableHandle className='mx-4' />
+                        <ResizablePanel
+                            order={2}
+                            minSize={30}
+                            maxSize={70}
+                            defaultSize={50}
+                            style={{
+                                overflow: 'clip',
+                                maxHeight: '100%',
+                                minWidth: 0,
+                            }}
+                        >
+                            <div className="sticky top-0">
+                                {referencesPanelContent}
                             </div>
-                        ) : (
-                            <div className="p-4 text-center text-muted-foreground text-sm">
-                                No file references found
-                            </div>
-                        )}
-                    </div>
-                </ResizablePanel>
+                        </ResizablePanel>
+                    </>
+                )}
             </ResizablePanelGroup>
         </div>
     )


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR fixes the Ask view layout issues when the window is in split view mode (e.g., half screen). Previously, the horizontal split layout with code citations would become cramped and hard to use in narrow windows because the minimum panel sizes were too large (30%).

## Changes

- Reduced `minSize` for both answer and code references panels from 30% to 20%
- Increased `maxSize` for both panels from 70% to 80%
- This allows better resizing flexibility in narrow containers without breaking the layout

The fix is minimal and focused: it simply allows the resizable panels to shrink more, which prevents the layout from becoming unusable in split window mode.

## How to test

1. Navigate to the Ask/Chat page with an existing conversation that has code references
2. Resize the browser window to be narrow (split window mode)
3. Verify the panels can resize properly and the layout remains usable
4. Drag the resize handle to adjust the split between answer and code references

Fixes SOU-845
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-845](https://linear.app/sourcebot/issue/SOU-845/improve-ask-view-layout-adjustment-when-in-split-window)

<div><a href="https://cursor.com/agents/bc-7f171777-1a0b-432b-96d6-f1adc3d48f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7f171777-1a0b-432b-96d6-f1adc3d48f63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

