### PR TITLE
feat: add thinkingLevel and thinkingBudget config for Gemini models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Deprecated `GOOGLE_VERTEX_THINKING_BUDGET_TOKENS` environment variable in favor of per-model `thinkingBudget` config. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
+- Removed `GOOGLE_VERTEX_INCLUDE_THOUGHTS` environment variable. Thoughts are now always included. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
 
 ## [4.16.8] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added `thinkingLevel` and `thinkingBudget` configuration options for Google Generative AI and Google Vertex providers. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
+
+### Changed
+- Deprecated `GOOGLE_VERTEX_THINKING_BUDGET_TOKENS` environment variable in favor of per-model `thinkingBudget` config. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
+
 ## [4.16.8] - 2026-04-09
 
 ### Added

--- a/docs/docs/configuration/language-model-providers.mdx
+++ b/docs/docs/configuration/language-model-providers.mdx
@@ -157,6 +157,10 @@ The `reasoningSummary` field controls whether the model returns its reasoning pr
 
 [Vercel AI SDK Google Generative AI Docs](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai)
 
+The `thinkingLevel` field controls the depth of reasoning for Gemini 3 models. Valid values are `minimal`, `low`, `medium`, and `high`. See [thinking levels](https://ai.google.dev/gemini-api/docs/thinking#thinking-levels).
+
+The `thinkingBudget` field sets the number of thinking tokens for Gemini 2.5 models. Set to `-1` for dynamic thinking. See [thinking budget](https://ai.google.dev/gemini-api/docs/thinking#set-budget).
+
 ```json wrap icon="code" Example config with Google Generative AI provider
 {
     "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/v3/index.json",
@@ -168,7 +172,9 @@ The `reasoningSummary` field controls whether the model returns its reasoning pr
             "token": {
                 "env": "GOOGLE_GENERATIVE_AI_API_KEY"
             },
-            "baseUrl": "OPTIONAL_BASE_URL"
+            "baseUrl": "OPTIONAL_BASE_URL",
+            "thinkingLevel": "high", // "minimal" | "low" | "medium" | "high" (Gemini 3 models)
+            "thinkingBudget": -1 // number of thinking tokens, -1 for dynamic (Gemini 2.5 models)
         }
     ] 
 }
@@ -180,6 +186,10 @@ The `reasoningSummary` field controls whether the model returns its reasoning pr
 <Note>The `credentials` parameter here expects a **path** to a [credentials](https://console.cloud.google.com/apis/credentials) file. This file **must be in a volume mounted by Sourcebot** for it to be readable.</Note>
 
 [Vercel AI SDK Google Vertex AI Docs](https://ai-sdk.dev/providers/ai-sdk-providers/google-vertex)
+
+The `thinkingLevel` field controls the depth of reasoning for Gemini 3 models. Valid values are `minimal`, `low`, `medium`, and `high`. See [thinking levels](https://ai.google.dev/gemini-api/docs/thinking#thinking-levels).
+
+The `thinkingBudget` field sets the number of thinking tokens for Gemini 2.5 models. Set to `-1` for dynamic thinking. See [thinking budget](https://ai.google.dev/gemini-api/docs/thinking#set-budget).
 
 ```json wrap icon="code" Example config with Google Vertex provider
 {
@@ -194,7 +204,9 @@ The `reasoningSummary` field controls whether the model returns its reasoning pr
             "credentials": {
                 "env": "GOOGLE_APPLICATION_CREDENTIALS"
             },
-            "baseUrl": "OPTIONAL_BASE_URL"
+            "baseUrl": "OPTIONAL_BASE_URL",
+            "thinkingLevel": "high", // "minimal" | "low" | "medium" | "high" (Gemini 3 models)
+            "thinkingBudget": -1 // number of thinking tokens, -1 for dynamic (Gemini 2.5 models)
         }
     ] 
 }

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -2300,6 +2300,20 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+              },
               "temperature": {
                 "type": "number",
                 "description": "Optional temperature setting to use with the model."
@@ -2547,6 +2561,20 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
               },
               "temperature": {
                 "type": "number",
@@ -3838,6 +3866,20 @@
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+              },
               "temperature": {
                 "type": "number",
                 "description": "Optional temperature setting to use with the model."
@@ -4085,6 +4127,20 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
               },
               "temperature": {
                 "type": "number",

--- a/docs/snippets/schemas/v3/languageModel.schema.mdx
+++ b/docs/snippets/schemas/v3/languageModel.schema.mdx
@@ -614,6 +614,20 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+        },
         "temperature": {
           "type": "number",
           "description": "Optional temperature setting to use with the model."
@@ -861,6 +875,20 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
         },
         "temperature": {
           "type": "number",
@@ -2152,6 +2180,20 @@
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+        },
         "temperature": {
           "type": "number",
           "description": "Optional temperature setting to use with the model."
@@ -2399,6 +2441,20 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
         },
         "temperature": {
           "type": "number",

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -2299,6 +2299,20 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+              },
               "temperature": {
                 "type": "number",
                 "description": "Optional temperature setting to use with the model."
@@ -2546,6 +2560,20 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
               },
               "temperature": {
                 "type": "number",
@@ -3837,6 +3865,20 @@ const schema = {
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
               },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+              },
               "temperature": {
                 "type": "number",
                 "description": "Optional temperature setting to use with the model."
@@ -4084,6 +4126,20 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "thinkingLevel": {
+                "type": "string",
+                "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                "enum": [
+                  "minimal",
+                  "low",
+                  "medium",
+                  "high"
+                ]
+              },
+              "thinkingBudget": {
+                "type": "integer",
+                "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
               },
               "temperature": {
                 "type": "number",

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -963,6 +963,14 @@ export interface GoogleGenerativeAILanguageModel {
    */
   baseUrl?: string;
   /**
+   * Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
+   */
+  thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  /**
+   * Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget
+   */
+  thinkingBudget?: number;
+  /**
    * Optional temperature setting to use with the model.
    */
   temperature?: number;
@@ -1056,6 +1064,14 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
+   */
+  thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  /**
+   * Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget
+   */
+  thinkingBudget?: number;
   /**
    * Optional temperature setting to use with the model.
    */

--- a/packages/schemas/src/v3/languageModel.schema.ts
+++ b/packages/schemas/src/v3/languageModel.schema.ts
@@ -613,6 +613,20 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+        },
         "temperature": {
           "type": "number",
           "description": "Optional temperature setting to use with the model."
@@ -860,6 +874,20 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
         },
         "temperature": {
           "type": "number",
@@ -2151,6 +2179,20 @@ const schema = {
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
         },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+        },
         "temperature": {
           "type": "number",
           "description": "Optional temperature setting to use with the model."
@@ -2398,6 +2440,20 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "thinkingLevel": {
+          "type": "string",
+          "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+          "enum": [
+            "minimal",
+            "low",
+            "medium",
+            "high"
+          ]
+        },
+        "thinkingBudget": {
+          "type": "integer",
+          "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
         },
         "temperature": {
           "type": "number",

--- a/packages/schemas/src/v3/languageModel.type.ts
+++ b/packages/schemas/src/v3/languageModel.type.ts
@@ -297,6 +297,14 @@ export interface GoogleGenerativeAILanguageModel {
    */
   baseUrl?: string;
   /**
+   * Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
+   */
+  thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  /**
+   * Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget
+   */
+  thinkingBudget?: number;
+  /**
    * Optional temperature setting to use with the model.
    */
   temperature?: number;
@@ -390,6 +398,14 @@ export interface GoogleVertexLanguageModel {
    * Optional base URL.
    */
   baseUrl?: string;
+  /**
+   * Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels
+   */
+  thinkingLevel?: "minimal" | "low" | "medium" | "high";
+  /**
+   * Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget
+   */
+  thinkingBudget?: number;
   /**
    * Optional temperature setting to use with the model.
    */

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -221,7 +221,6 @@ const options = {
         GOOGLE_VERTEX_PROJECT: z.string().optional(),
         GOOGLE_VERTEX_REGION: z.string().default('us-central1'),
         GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
-        GOOGLE_VERTEX_INCLUDE_THOUGHTS: booleanSchema.default('true'),
 
         /**
          * @deprecated Use `thinkingBudget` in the language model config instead.

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -221,8 +221,12 @@ const options = {
         GOOGLE_VERTEX_PROJECT: z.string().optional(),
         GOOGLE_VERTEX_REGION: z.string().default('us-central1'),
         GOOGLE_APPLICATION_CREDENTIALS: z.string().optional(),
-        GOOGLE_VERTEX_THINKING_BUDGET_TOKENS: numberSchema.default(-1),
         GOOGLE_VERTEX_INCLUDE_THOUGHTS: booleanSchema.default('true'),
+
+        /**
+         * @deprecated Use `thinkingBudget` in the language model config instead.
+         */
+        GOOGLE_VERTEX_THINKING_BUDGET_TOKENS: numberSchema.optional(),
 
         AWS_ACCESS_KEY_ID: z.string().optional(),
         AWS_SECRET_ACCESS_KEY: z.string().optional(),

--- a/packages/web/src/features/chat/utils.server.ts
+++ b/packages/web/src/features/chat/utils.server.ts
@@ -6,7 +6,7 @@ import { createAmazonBedrock } from '@ai-sdk/amazon-bedrock';
 import { AnthropicProviderOptions, createAnthropic } from '@ai-sdk/anthropic';
 import { createAzure } from '@ai-sdk/azure';
 import { createDeepSeek } from '@ai-sdk/deepseek';
-import { createGoogleGenerativeAI } from '@ai-sdk/google';
+import { createGoogleGenerativeAI, GoogleLanguageModelOptions } from '@ai-sdk/google';
 import { createVertex } from '@ai-sdk/google-vertex';
 import { createVertexAnthropic } from '@ai-sdk/google-vertex/anthropic';
 import { createMistral } from '@ai-sdk/mistral';
@@ -270,6 +270,15 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
 
                 return {
                     model: google(modelId),
+                    providerOptions: {
+                        google: {
+                            thinkingConfig: {
+                                includeThoughts: true,
+                                thinkingBudget: config.thinkingBudget,
+                                thinkingLevel: config.thinkingLevel
+                            }
+                        } satisfies GoogleLanguageModelOptions
+                    }
                 };
             }
             case 'google-vertex': {
@@ -291,10 +300,13 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
                     providerOptions: {
                         vertex: {
                             thinkingConfig: {
-                                thinkingBudget: env.GOOGLE_VERTEX_THINKING_BUDGET_TOKENS,
-                                includeThoughts: env.GOOGLE_VERTEX_INCLUDE_THOUGHTS === 'true',
+                                includeThoughts: true,
+                                thinkingBudget:
+                                    config.thinkingBudget ??
+                                    env.GOOGLE_VERTEX_THINKING_BUDGET_TOKENS,
+                                thinkingLevel: config.thinkingLevel,
                             }
-                        }
+                        } satisfies GoogleLanguageModelOptions
                     },
                 };
             }

--- a/schemas/v3/languageModel.json
+++ b/schemas/v3/languageModel.json
@@ -232,6 +232,20 @@
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
                 },
+                "thinkingLevel": {
+                    "type": "string",
+                    "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                    "enum": [
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ]
+                },
+                "thinkingBudget": {
+                    "type": "integer",
+                    "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
+                },
                 "temperature": {
                     "type": "number",
                     "description": "Optional temperature setting to use with the model."
@@ -343,6 +357,20 @@
                     "format": "url",
                     "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                     "description": "Optional base URL."
+                },
+                "thinkingLevel": {
+                    "type": "string",
+                    "description": "Optional thinking level for Gemini 3 models. Controls the depth of reasoning the model performs. See https://ai.google.dev/gemini-api/docs/thinking#thinking-levels",
+                    "enum": [
+                        "minimal",
+                        "low",
+                        "medium",
+                        "high"
+                    ]
+                },
+                "thinkingBudget": {
+                    "type": "integer",
+                    "description": "Optional thinking budget for Gemini 2.5 models. Sets the number of thinking tokens the model can use when generating a response. Set to -1 for dynamic thinking. See https://ai.google.dev/gemini-api/docs/thinking#set-budget"
                 },
                 "temperature": {
                     "type": "number",


### PR DESCRIPTION
## Summary
- Adds `thinkingLevel` and `thinkingBudget` parameters to the `GoogleGenerativeAILanguageModel` and `GoogleVertexLanguageModel` schema definitions, allowing per-model thinking configuration.
- `thinkingLevel` (enum: `minimal`, `low`, `medium`, `high`) controls reasoning depth for Gemini 3 models. `thinkingBudget` (integer, `-1` for dynamic) sets the thinking token budget for Gemini 2.5 models.
- Wires the new config through to the AI SDK provider options for both `google-generative-ai` and `google-vertex` providers.
- Deprecates the `GOOGLE_VERTEX_THINKING_BUDGET_TOKENS` env var in favor of the new per-model config, with env var fallback for backward compatibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added thinkingLevel (minimal|low|medium|high) and thinkingBudget (integer, -1 = dynamic) model config options for Google Generative AI and Google Vertex providers.

* **Breaking Changes**
  * Removed GOOGLE_VERTEX_INCLUDE_THOUGHTS — thoughts are always included.
  * Deprecated GOOGLE_VERTEX_THINKING_BUDGET_TOKENS in favor of per-model thinkingBudget.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->