### PR TITLE
chore: upgrade Go toolchain 1.25 & zoekt version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated `GOOGLE_VERTEX_THINKING_BUDGET_TOKENS` environment variable in favor of per-model `thinkingBudget` config. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
 - Removed `GOOGLE_VERTEX_INCLUDE_THOUGHTS` environment variable. Thoughts are now always included. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
 - Renamed and consolidated PostHog chat events (`wa_chat_thread_created` -> `ask_thread_created`, `wa_chat_message_sent` -> `ask_message_sent`, `wa_chat_tool_used` -> `tool_used`), added unified `tool_used` tracking across the ask agent and MCP server, and removed the redundant `api_code_search_request` event. [#1111](https://github.com/sourcebot-dev/sourcebot/pull/1111)
-- Upgraded Go toolchain from 1.23.4 to 1.25, resolving CVE-2025-68121 (CRITICAL) and multiple HIGH/MEDIUM Go stdlib CVEs. [#1112](https://github.com/sourcebot-dev/sourcebot/pull/1112)
 
 ## [4.16.8] - 2026-04-09
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Deprecated `GOOGLE_VERTEX_THINKING_BUDGET_TOKENS` environment variable in favor of per-model `thinkingBudget` config. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
 - Removed `GOOGLE_VERTEX_INCLUDE_THOUGHTS` environment variable. Thoughts are now always included. [#1110](https://github.com/sourcebot-dev/sourcebot/pull/1110)
 - Renamed and consolidated PostHog chat events (`wa_chat_thread_created` -> `ask_thread_created`, `wa_chat_message_sent` -> `ask_message_sent`, `wa_chat_tool_used` -> `tool_used`), added unified `tool_used` tracking across the ask agent and MCP server, and removed the redundant `api_code_search_request` event. [#1111](https://github.com/sourcebot-dev/sourcebot/pull/1111)
+- Upgraded Go toolchain from 1.23.4 to 1.25, resolving CVE-2025-68121 (CRITICAL) and multiple HIGH/MEDIUM Go stdlib CVEs. [#1112](https://github.com/sourcebot-dev/sourcebot/pull/1112)
 
 ## [4.16.8] - 2026-04-09
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ ARG NEXT_PUBLIC_LANGFUSE_BASE_URL
 ARG NEXT_PUBLIC_BUILD_COMMIT_SHA
 
 FROM node:24-alpine3.23 AS node-alpine
-FROM golang:1.23.4-alpine3.19 AS go-alpine
+FROM golang:1.25-alpine AS go-alpine
 # ----------------------------------
 
 # ------ Build Zoekt ------


### PR DESCRIPTION
bump zoekt dependency & upgrade to go 1.25

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Patched critical and high-severity security vulnerabilities in Go standard library through an upgrade to Go toolchain version 1.25, addressing CVE-2025-68121 and multiple additional Go standard library CVEs affecting the runtime and security subsystems.

* **Chores**
  * Updated vendored dependencies and build infrastructure to maintain compatibility with the latest Go toolchain version, ensuring secure and stable operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->