### PR TITLE
fix: upgrade Alpine packages to resolve CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -180,7 +180,8 @@ ENV SOURCEBOT_LOG_LEVEL=info
 # ENV SOURCEBOT_TELEMETRY_DISABLED=1
 
 # Configure dependencies
-RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget supervisor uuidgen curl perl jq redis postgresql16 postgresql16-contrib openssl util-linux unzip
+RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget supervisor uuidgen curl perl jq redis postgresql16 postgresql16-contrib openssl util-linux unzip && \
+    apk upgrade --no-cache
 
 ARG UID=1500
 ARG GID=1500


### PR DESCRIPTION
## Summary
- Adds `apk upgrade --no-cache` to the runner stage in the Dockerfile to pull in patched Alpine packages
- Fixes 4 CVEs flagged by Trivy (2 HIGH, 2 MEDIUM) in `musl-utils` and `zlib`:
  - **CVE-2026-40200** (HIGH) — musl: arbitrary code execution via stack-based overflow
  - **CVE-2026-6042** (MEDIUM) — musl: denial of service via inefficient GB18030 decoding
  - **CVE-2026-22184** (HIGH) — zlib: arbitrary code execution via buffer overflow in untgz
  - **CVE-2026-27171** (MEDIUM) — zlib: denial of service via infinite loop in CRC32 combine


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker build process to include Alpine package index upgrade during dependency installation, ensuring fresher and more patched versions of packages in the containerized environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->