### PR TITLE
fix(web): Add support for adaptive thinking parameters

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Bumped AI SDK and associated packages version. [#1126](https://github.com/sourcebot-dev/sourcebot/pull/1126)
 
+### Fixed
+- Fixed issue where claude-opus-4-7 was returning "error occurred "thinking.type.enabled" is not supported for this model". [#1123](https://github.com/sourcebot-dev/sourcebot/issues/1123)
+
 ## [4.16.9] - 2026-04-15
 
 ### Added

--- a/packages/web/src/features/chat/utils.server.ts
+++ b/packages/web/src/features/chat/utils.server.ts
@@ -210,11 +210,17 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
                         : undefined,
                 });
 
+                const isAdaptiveThinkingSupported =
+                    modelId === 'claude-opus-4-7';
+
                 return {
                     model: anthropic(modelId),
                     providerOptions: {
                         anthropic: {
-                            thinking: {
+                            thinking: isAdaptiveThinkingSupported ? {
+                                type: "adaptive",
+                                "display": "summarized"
+                            } : {
                                 type: "enabled",
                                 budgetTokens: env.ANTHROPIC_THINKING_BUDGET_TOKENS,
                             }

--- a/packages/web/src/features/chat/utils.server.ts
+++ b/packages/web/src/features/chat/utils.server.ts
@@ -211,7 +211,7 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
                 });
 
                 const isAdaptiveThinkingSupported =
-                    modelId === 'claude-opus-4-7';
+                    modelId.startsWith('claude-opus-4-7');
 
                 return {
                     model: anthropic(modelId),
@@ -219,7 +219,7 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
                         anthropic: {
                             thinking: isAdaptiveThinkingSupported ? {
                                 type: "adaptive",
-                                "display": "summarized"
+                                display: "summarized"
                             } : {
                                 type: "enabled",
                                 budgetTokens: env.ANTHROPIC_THINKING_BUDGET_TOKENS,


### PR DESCRIPTION
Fixes #1123

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Anthropic models: Claude Opus 4.7 now uses an adaptive "thinking" mode with summarized display; other Anthropic models continue using the enabled thinking mode with token-budget controls.
* **Bug Fixes**
  * Fixed an error that occurred when using Claude Opus 4.7 with the previous thinking configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->