### PR TITLE
fix(backend): stop Gitea/Forgejo pagination on empty page response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed revision selection so the 64-revision cap prefers the newest matching branches and tags instead of pruning by ref-name order. [#1122](https://github.com/sourcebot-dev/sourcebot/pull/1122)
+- Fixed infinite pagination loop in Gitea/Forgejo when an API token can only see a subset of org repos (the `x-total-count` header reports org total while token returns fewer items). [#1130](https://github.com/sourcebot-dev/sourcebot/pull/1130)
 
 ## [4.16.11] - 2026-04-17
 

--- a/packages/backend/src/gitea.ts
+++ b/packages/backend/src/gitea.ts
@@ -254,6 +254,9 @@ const paginate = async <T>(request: (page: number) => Promise<HttpResponse<T[], 
     while (output.length < totalCount) {
         page++;
         const result = await request(page);
+        if (result.data.length === 0) {
+            break;
+        }
         output.push(...result.data);
     }
 


### PR DESCRIPTION
When an API token can only see a subset of org repos, the `x-total-count` header reports the org total while the token returns fewer items. The previous loop condition (`output.length < totalCount`) would never be satisfied for the visible subset, causing infinite pagination and effectively DoS-ing the Gitea/Forgejo instance.

The fix breaks out of the loop when the API returns an empty page, matching the Gitea API pagination docs recommendation.

Fixes #1108

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed infinite pagination loops in Gitea/Forgejo integrations that occurred when API tokens had restricted access to certain repositories. The pagination system now correctly detects when all available results have been retrieved and terminates appropriately, preventing endless looping and excessive API requests while significantly improving overall system stability, reliability, and performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->