### PR TITLE
fix: add explicit empty permissions to docs-broken-links workflow

### DIFF
--- a/.github/workflows/docs-broken-links.yml
+++ b/.github/workflows/docs-broken-links.yml
@@ -1,5 +1,7 @@
 name: Check for broken links in docs
 
+permissions: {}
+
 on:
   pull_request:
     branches: ["main"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed revision selection so the 64-revision cap prefers the newest matching branches and tags instead of pruning by ref-name order. [#1122](https://github.com/sourcebot-dev/sourcebot/pull/1122)
 - Fixed infinite pagination loop in Gitea/Forgejo when an API token can only see a subset of org repos (the `x-total-count` header reports org total while token returns fewer items). [#1130](https://github.com/sourcebot-dev/sourcebot/pull/1130)
+- Fixed missing workflow permissions in `docs-broken-links.yml` by adding explicit `permissions: {}` to follow least privilege principle. [#1131](https://github.com/sourcebot-dev/sourcebot/pull/1131)
 
 ## [4.16.11] - 2026-04-17
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses CodeQL security alert #1 (`actions/missing-workflow-permissions`) by adding explicit `permissions: {}` to the `docs-broken-links.yml` workflow.

## Problem

The workflow runs a broken-link check job using Mintlify without declaring explicit GitHub token permissions. Without explicit permissions, the job inherits default token permissions (potentially `contents: write` or `pull-requests: write` depending on repo settings).

Since this workflow:
- Checks out the repository
- Installs the Mintlify CLI via npm
- Runs `mintlify broken-links` in the docs directory

None of these steps require any GitHub token access, yet the ambient `GITHUB_TOKEN` could be exploited if the Mintlify package were compromised.

## Solution

Add `permissions: {}` at the workflow level to explicitly deny all GitHub token permissions, following the principle of least privilege.

## References

- [GitHub Alert #1](https://github.com/sourcebot-dev/sourcebot/security/code-scanning/1)
- [CodeQL rule: actions/missing-workflow-permissions](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/)
- [GitHub Docs: Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

Fixes #932
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-932](https://linear.app/sourcebot/issue/SOU-932/sourcebot-devsourcebot-codeqlactionsmissing-workflow-permissions1)

<div><a href="https://cursor.com/agents/bc-42424b4b-14b3-4b1c-8dfb-0d054284e99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-42424b4b-14b3-4b1c-8dfb-0d054284e99b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the documentation workflow's permissions to enforce least-privilege and prevent unintended token access.

* **Documentation**
  * Added a changelog entry noting the workflow permissions fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->