### PR TITLE
fix: add explicit empty permissions to deploy-railway.yml

### DIFF
--- a/.github/workflows/deploy-railway.yml
+++ b/.github/workflows/deploy-railway.yml
@@ -1,5 +1,7 @@
 name: Deploy to Railway
 
+permissions: {}
+
 on:
   workflow_run:
     workflows: ["Release Sourcebot (Development)"]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed revision selection so the 64-revision cap prefers the newest matching branches and tags instead of pruning by ref-name order. [#1122](https://github.com/sourcebot-dev/sourcebot/pull/1122)
 - Fixed infinite pagination loop in Gitea/Forgejo when an API token can only see a subset of org repos (the `x-total-count` header reports org total while token returns fewer items). [#1130](https://github.com/sourcebot-dev/sourcebot/pull/1130)
+- Fixed CodeQL missing-workflow-permissions alert by adding explicit empty permissions to `deploy-railway.yml`. [#1132](https://github.com/sourcebot-dev/sourcebot/pull/1132)
 
 ## [4.16.11] - 2026-04-17
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Add `permissions: {}` at the workflow level in `deploy-railway.yml` to explicitly deny all GitHub token permissions. This follows the principle of least privilege since the workflow only needs `RAILWAY_TOKEN` and has no use for GitHub token access.

## Problem

The `deploy-railway.yml` workflow was flagged by CodeQL (`actions/missing-workflow-permissions` - Alert #27) because it runs without declaring explicit GitHub token permissions. Without an explicit `permissions:` block, the job inherits the repository's or organization's default token permissions, which may include broad scopes like `contents: write` and `pull-requests: write`.

## Solution

Added `permissions: {}` at the workflow level to explicitly deny all GitHub token permissions, reducing the attack surface if the workflow were ever compromised.

## References

- [GitHub Alert #27](https://github.com/sourcebot-dev/sourcebot/security/code-scanning/27)
- [CodeQL rule: actions/missing-workflow-permissions](https://codeql.github.com/codeql-query-help/actions/actions-missing-workflow-permissions/)
- [GitHub Docs: Permissions for the GITHUB_TOKEN](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)

Fixes #929
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-929](https://linear.app/sourcebot/issue/SOU-929/sourcebot-devsourcebot-codeqlactionsmissing-workflow-permissions27)

<div><a href="https://cursor.com/agents/bc-702813b5-a755-4ad3-94ba-54558488ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-702813b5-a755-4ad3-94ba-54558488ee71"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow security by implementing explicit permission restrictions on the deployment workflow configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->