### PR TITLE
fix: validate reviewAgentLogPath to prevent path injection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed revision selection so the 64-revision cap prefers the newest matching branches and tags instead of pruning by ref-name order. [#1122](https://github.com/sourcebot-dev/sourcebot/pull/1122)
 - Fixed infinite pagination loop in Gitea/Forgejo when an API token can only see a subset of org repos (the `x-total-count` header reports org total while token returns fewer items). [#1130](https://github.com/sourcebot-dev/sourcebot/pull/1130)
+- Fixed CodeQL path injection vulnerability in review agent log file writing by validating paths stay within the expected log directory. [#1133](https://github.com/sourcebot-dev/sourcebot/pull/1133)
 
 ## [4.16.11] - 2026-04-17
 

--- a/packages/web/src/features/agents/review-agent/nodes/invokeDiffReviewLlm.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/invokeDiffReviewLlm.ts
@@ -2,9 +2,19 @@ import OpenAI from "openai";
 import { sourcebot_file_diff_review, sourcebot_file_diff_review_schema } from "@/features/agents/review-agent/types";
 import { env } from "@sourcebot/shared";
 import fs from "fs";
+import path from "path";
 import { createLogger } from "@sourcebot/shared";
 
 const logger = createLogger('invoke-diff-review-llm');
+
+const REVIEW_AGENT_LOG_BASE = path.join(env.DATA_CACHE_DIR, 'review-agent');
+
+const validateReviewAgentLogPath = (logPath: string): void => {
+    const resolved = path.resolve(logPath);
+    if (!resolved.startsWith(REVIEW_AGENT_LOG_BASE + path.sep)) {
+        throw new Error('reviewAgentLogPath escapes log directory');
+    }
+};
 
 export const invokeDiffReviewLlm = async (reviewAgentLogPath: string | undefined, prompt: string): Promise<sourcebot_file_diff_review> => {
     logger.debug("Executing invoke_diff_review_llm");
@@ -12,6 +22,10 @@ export const invokeDiffReviewLlm = async (reviewAgentLogPath: string | undefined
     if (!env.OPENAI_API_KEY) {
         logger.error("OPENAI_API_KEY is not set, skipping review agent");
         throw new Error("OPENAI_API_KEY is not set, skipping review agent");
+    }
+
+    if (reviewAgentLogPath) {
+        validateReviewAgentLogPath(reviewAgentLogPath);
     }
     
     const openai = new OpenAI({


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

This PR addresses CodeQL security alerts #18 and #19 for `js/path-injection` in the review agent log writing functionality.

## Changes

Added path validation in `invokeDiffReviewLlm` to ensure the `reviewAgentLogPath` parameter stays within the expected `review-agent` directory. The validation:

1. Resolves the provided path to an absolute path using `path.resolve()`
2. Verifies the resolved path starts with the expected base directory (`DATA_CACHE_DIR/review-agent/`)
3. Throws an error if the path escapes the log directory

This single guard covers both `fs.appendFileSync` calls in the function (lines 36 and 49), preventing potential path traversal attacks.

## Security Context

While the current risk is low (since `pullRequest.number` is an integer from the GitHub webhook payload), this validation provides defense-in-depth against future code changes that might introduce different data sources for path construction.

## Testing

- Lint passes
- All 391 existing tests pass

Fixes #931
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-931](https://linear.app/sourcebot/issue/SOU-931/sourcebot-devsourcebot-codeqljspath-injection18-codeqljspath)

<div><a href="https://cursor.com/agents/bc-0adfae3f-a031-4b76-bf1f-702afd87eb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-0adfae3f-a031-4b76-bf1f-702afd87eb42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

