### PR TITLE
chore: sync vendor/zoekt with upstream sourcegraph/zoekt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Synced `vendor/zoekt` with upstream `sourcegraph/zoekt`. [#1140](https://github.com/sourcebot-dev/sourcebot/pull/1140)
+
 ## [4.16.12] - 2026-04-20
 
 ### Fixed

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -23,7 +23,7 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, revisio
         `-branches "${revisions.join(',')}"`,
         `-tenant_id ${repo.orgId}`,
         `-repo_id ${repo.id}`,
-        `-shard_prefix ${shardPrefix}`,
+        `-shard_prefix_override ${shardPrefix}`,
         ...largeFileGlobPatterns.map((pattern) => `-large_file "${pattern}"`),
         repoPath
     ].join(' ');

--- a/packages/web/src/proto/query.ts
+++ b/packages/web/src/proto/query.ts
@@ -8,6 +8,7 @@ import type { BranchRepos as _zoekt_webserver_v1_BranchRepos, BranchRepos__Outpu
 import type { BranchesRepos as _zoekt_webserver_v1_BranchesRepos, BranchesRepos__Output as _zoekt_webserver_v1_BranchesRepos__Output } from './zoekt/webserver/v1/BranchesRepos';
 import type { FileNameSet as _zoekt_webserver_v1_FileNameSet, FileNameSet__Output as _zoekt_webserver_v1_FileNameSet__Output } from './zoekt/webserver/v1/FileNameSet';
 import type { Language as _zoekt_webserver_v1_Language, Language__Output as _zoekt_webserver_v1_Language__Output } from './zoekt/webserver/v1/Language';
+import type { Meta as _zoekt_webserver_v1_Meta, Meta__Output as _zoekt_webserver_v1_Meta__Output } from './zoekt/webserver/v1/Meta';
 import type { Not as _zoekt_webserver_v1_Not, Not__Output as _zoekt_webserver_v1_Not__Output } from './zoekt/webserver/v1/Not';
 import type { Or as _zoekt_webserver_v1_Or, Or__Output as _zoekt_webserver_v1_Or__Output } from './zoekt/webserver/v1/Or';
 import type { Q as _zoekt_webserver_v1_Q, Q__Output as _zoekt_webserver_v1_Q__Output } from './zoekt/webserver/v1/Q';
@@ -36,6 +37,7 @@ export interface ProtoGrpcType {
         BranchesRepos: MessageTypeDefinition<_zoekt_webserver_v1_BranchesRepos, _zoekt_webserver_v1_BranchesRepos__Output>
         FileNameSet: MessageTypeDefinition<_zoekt_webserver_v1_FileNameSet, _zoekt_webserver_v1_FileNameSet__Output>
         Language: MessageTypeDefinition<_zoekt_webserver_v1_Language, _zoekt_webserver_v1_Language__Output>
+        Meta: MessageTypeDefinition<_zoekt_webserver_v1_Meta, _zoekt_webserver_v1_Meta__Output>
         Not: MessageTypeDefinition<_zoekt_webserver_v1_Not, _zoekt_webserver_v1_Not__Output>
         Or: MessageTypeDefinition<_zoekt_webserver_v1_Or, _zoekt_webserver_v1_Or__Output>
         Q: MessageTypeDefinition<_zoekt_webserver_v1_Q, _zoekt_webserver_v1_Q__Output>

--- a/packages/web/src/proto/webserver.ts
+++ b/packages/web/src/proto/webserver.ts
@@ -19,6 +19,7 @@ import type { ListOptions as _zoekt_webserver_v1_ListOptions, ListOptions__Outpu
 import type { ListRequest as _zoekt_webserver_v1_ListRequest, ListRequest__Output as _zoekt_webserver_v1_ListRequest__Output } from './zoekt/webserver/v1/ListRequest';
 import type { ListResponse as _zoekt_webserver_v1_ListResponse, ListResponse__Output as _zoekt_webserver_v1_ListResponse__Output } from './zoekt/webserver/v1/ListResponse';
 import type { Location as _zoekt_webserver_v1_Location, Location__Output as _zoekt_webserver_v1_Location__Output } from './zoekt/webserver/v1/Location';
+import type { Meta as _zoekt_webserver_v1_Meta, Meta__Output as _zoekt_webserver_v1_Meta__Output } from './zoekt/webserver/v1/Meta';
 import type { MinimalRepoListEntry as _zoekt_webserver_v1_MinimalRepoListEntry, MinimalRepoListEntry__Output as _zoekt_webserver_v1_MinimalRepoListEntry__Output } from './zoekt/webserver/v1/MinimalRepoListEntry';
 import type { Not as _zoekt_webserver_v1_Not, Not__Output as _zoekt_webserver_v1_Not__Output } from './zoekt/webserver/v1/Not';
 import type { Or as _zoekt_webserver_v1_Or, Or__Output as _zoekt_webserver_v1_Or__Output } from './zoekt/webserver/v1/Or';
@@ -78,6 +79,7 @@ export interface ProtoGrpcType {
         ListRequest: MessageTypeDefinition<_zoekt_webserver_v1_ListRequest, _zoekt_webserver_v1_ListRequest__Output>
         ListResponse: MessageTypeDefinition<_zoekt_webserver_v1_ListResponse, _zoekt_webserver_v1_ListResponse__Output>
         Location: MessageTypeDefinition<_zoekt_webserver_v1_Location, _zoekt_webserver_v1_Location__Output>
+        Meta: MessageTypeDefinition<_zoekt_webserver_v1_Meta, _zoekt_webserver_v1_Meta__Output>
         MinimalRepoListEntry: MessageTypeDefinition<_zoekt_webserver_v1_MinimalRepoListEntry, _zoekt_webserver_v1_MinimalRepoListEntry__Output>
         Not: MessageTypeDefinition<_zoekt_webserver_v1_Not, _zoekt_webserver_v1_Not__Output>
         Or: MessageTypeDefinition<_zoekt_webserver_v1_Or, _zoekt_webserver_v1_Or__Output>

--- a/packages/web/src/proto/zoekt/webserver/v1/Meta.ts
+++ b/packages/web/src/proto/zoekt/webserver/v1/Meta.ts
@@ -1,0 +1,18 @@
+// Original file: ../../vendor/zoekt/grpc/protos/zoekt/webserver/v1/query.proto
+
+
+/**
+ * Meta allows filtering results by repo metadata.
+ */
+export interface Meta {
+  'key'?: (string);
+  'value'?: (string);
+}
+
+/**
+ * Meta allows filtering results by repo metadata.
+ */
+export interface Meta__Output {
+  'key': (string);
+  'value': (string);
+}

--- a/packages/web/src/proto/zoekt/webserver/v1/Q.ts
+++ b/packages/web/src/proto/zoekt/webserver/v1/Q.ts
@@ -17,6 +17,7 @@ import type { Or as _zoekt_webserver_v1_Or, Or__Output as _zoekt_webserver_v1_Or
 import type { Not as _zoekt_webserver_v1_Not, Not__Output as _zoekt_webserver_v1_Not__Output } from '../../../zoekt/webserver/v1/Not';
 import type { Branch as _zoekt_webserver_v1_Branch, Branch__Output as _zoekt_webserver_v1_Branch__Output } from '../../../zoekt/webserver/v1/Branch';
 import type { Boost as _zoekt_webserver_v1_Boost, Boost__Output as _zoekt_webserver_v1_Boost__Output } from '../../../zoekt/webserver/v1/Boost';
+import type { Meta as _zoekt_webserver_v1_Meta, Meta__Output as _zoekt_webserver_v1_Meta__Output } from '../../../zoekt/webserver/v1/Meta';
 
 export interface Q {
   'raw_config'?: (_zoekt_webserver_v1_RawConfig | null);
@@ -37,7 +38,8 @@ export interface Q {
   'not'?: (_zoekt_webserver_v1_Not | null);
   'branch'?: (_zoekt_webserver_v1_Branch | null);
   'boost'?: (_zoekt_webserver_v1_Boost | null);
-  'query'?: "raw_config"|"regexp"|"symbol"|"language"|"const"|"repo"|"repo_regexp"|"branches_repos"|"repo_ids"|"repo_set"|"file_name_set"|"type"|"substring"|"and"|"or"|"not"|"branch"|"boost";
+  'meta'?: (_zoekt_webserver_v1_Meta | null);
+  'query'?: "raw_config"|"regexp"|"symbol"|"language"|"const"|"repo"|"repo_regexp"|"branches_repos"|"repo_ids"|"repo_set"|"file_name_set"|"type"|"substring"|"and"|"or"|"not"|"branch"|"boost"|"meta";
 }
 
 export interface Q__Output {
@@ -59,5 +61,6 @@ export interface Q__Output {
   'not'?: (_zoekt_webserver_v1_Not__Output | null);
   'branch'?: (_zoekt_webserver_v1_Branch__Output | null);
   'boost'?: (_zoekt_webserver_v1_Boost__Output | null);
-  'query'?: "raw_config"|"regexp"|"symbol"|"language"|"const"|"repo"|"repo_regexp"|"branches_repos"|"repo_ids"|"repo_set"|"file_name_set"|"type"|"substring"|"and"|"or"|"not"|"branch"|"boost";
+  'meta'?: (_zoekt_webserver_v1_Meta__Output | null);
+  'query'?: "raw_config"|"regexp"|"symbol"|"language"|"const"|"repo"|"repo_regexp"|"branches_repos"|"repo_ids"|"repo_set"|"file_name_set"|"type"|"substring"|"and"|"or"|"not"|"branch"|"boost"|"meta";
 }

--- a/packages/web/src/proto/zoekt/webserver/v1/Repository.ts
+++ b/packages/web/src/proto/zoekt/webserver/v1/Repository.ts
@@ -92,6 +92,10 @@ export interface Repository {
    * tenant_id is the tenant ID of the repository.
    */
   'tenant_id'?: (number | string | Long);
+  /**
+   * Additional metadata about the repository.
+   */
+  'metadata'?: ({[key: string]: string});
 }
 
 export interface Repository__Output {
@@ -181,4 +185,8 @@ export interface Repository__Output {
    * tenant_id is the tenant ID of the repository.
    */
   'tenant_id': (number);
+  /**
+   * Additional metadata about the repository.
+   */
+  'metadata': ({[key: string]: string});
 }


### PR DESCRIPTION
## Summary

- Bumps the `vendor/zoekt` submodule to pull in 108 upstream commits from `sourcegraph/zoekt` (first upstream sync on the fork). See the companion PR: https://github.com/sourcebot-dev/zoekt/pull/10.
- Renames the `zoekt-git-index` flag `-shard_prefix` → `-shard_prefix_override` in `packages/backend/src/zoekt.ts` to match the upstream rename (sourcegraph/zoekt#1005).

> [!IMPORTANT]
> The zoekt reference in this PR currently points at the feature branch HEAD of sourcebot-dev/zoekt#10 (commit `8566836f`). Once that PR is merged into `sourcebot-dev/zoekt@main`, this submodule pointer must be re-pinned to the resulting merge commit before this PR lands.

## Test plan

- [x] `make zoekt` builds all zoekt binaries against the upgraded source.
- [x] `yarn workspace @sourcebot/backend build` and `yarn workspace @sourcebot/web build` compile cleanly.
- [x] Full worker indexing job completes: 1027 files indexed into `1_3_v16.00000.zoekt` with the new `-shard_prefix_override` flag.
- [x] Sourcebot web `/api/search` returns expected results end-to-end via gRPC against the upgraded `zoekt-webserver` (verified with a `lang:typescript` query and a plain text query; 3490 matches over 396 files for `sourcebot`).
- [x] Zoekt REST search path with `X-TENANT-ID` header still works.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added repo metadata support and a new "meta" query node to expose and filter repository metadata.
  * Updated API typings to include Meta message and metadata fields for metadata-aware search responses.

* **Chores**
  * Synced the vendored search-indexing library with upstream and updated indexing configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->