### PR TITLE
feat: improve diff tool display and token efficiency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Improved diff tool UI to truncate full commit SHAs to 7 characters, use RepoBadge component for repository display, and output diffs in git-diff format instead of JSON for better token efficiency. [#1146](https://github.com/sourcebot-dev/sourcebot/pull/1146)
+
 ## [4.16.14] - 2026-04-21
 
 ### Added

--- a/packages/web/src/features/chat/components/chatThread/tools/getDiffToolComponent.tsx
+++ b/packages/web/src/features/chat/components/chatThread/tools/getDiffToolComponent.tsx
@@ -2,6 +2,14 @@
 
 import { Separator } from '@/components/ui/separator';
 import { GetDiffMetadata, ToolResult } from '@/features/tools';
+import { RepoBadge } from './repoBadge';
+
+function truncateSha(ref: string): string {
+    if (/^[0-9a-f]{40}$/i.test(ref)) {
+        return ref.substring(0, 7);
+    }
+    return ref;
+}
 
 export const GetDiffToolComponent = ({ metadata }: ToolResult<GetDiffMetadata>) => {
     const fileCount = metadata.files.length;
@@ -10,16 +18,14 @@ export const GetDiffToolComponent = ({ metadata }: ToolResult<GetDiffMetadata>) 
         <div className="flex items-center gap-2 select-none cursor-default text-sm text-muted-foreground">
             <span className="flex-shrink-0">Compared</span>
             <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground">
-                {metadata.base}
+                {truncateSha(metadata.base)}
             </span>
             <span className="flex-shrink-0">to</span>
             <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground">
-                {metadata.head}
+                {truncateSha(metadata.head)}
             </span>
             <span className="flex-shrink-0">in</span>
-            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground truncate">
-                {metadata.repo}
-            </span>
+            <RepoBadge repo={metadata.repoInfo} />
             <span className="flex-1" />
             <span className="text-xs flex-shrink-0">
                 {fileCount} changed {fileCount === 1 ? 'file' : 'files'}

--- a/packages/web/src/features/chat/components/chatThread/tools/getDiffToolComponent.tsx
+++ b/packages/web/src/features/chat/components/chatThread/tools/getDiffToolComponent.tsx
@@ -2,11 +2,13 @@
 
 import { Separator } from '@/components/ui/separator';
 import { GetDiffMetadata, ToolResult } from '@/features/tools';
+import { GitCommitHorizontalIcon } from 'lucide-react';
 import { RepoBadge } from './repoBadge';
 
 function truncateSha(ref: string): string {
-    if (/^[0-9a-f]{40}$/i.test(ref)) {
-        return ref.substring(0, 7);
+    const match = ref.match(/^([0-9a-f]{40})(.*)$/i);
+    if (match) {
+        return match[1].substring(0, 7) + match[2];
     }
     return ref;
 }
@@ -17,11 +19,13 @@ export const GetDiffToolComponent = ({ metadata }: ToolResult<GetDiffMetadata>) 
     return (
         <div className="flex items-center gap-2 select-none cursor-default text-sm text-muted-foreground">
             <span className="flex-shrink-0">Compared</span>
-            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground">
+            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground inline-flex items-center gap-1">
+                <GitCommitHorizontalIcon className="h-3 w-3" />
                 {truncateSha(metadata.base)}
             </span>
             <span className="flex-shrink-0">to</span>
-            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground">
+            <span className="text-xs font-mono bg-muted px-1.5 py-0.5 rounded text-foreground inline-flex items-center gap-1">
+                <GitCommitHorizontalIcon className="h-3 w-3" />
                 {truncateSha(metadata.head)}
             </span>
             <span className="flex-shrink-0">in</span>

--- a/packages/web/src/features/tools/getDiff.test.ts
+++ b/packages/web/src/features/tools/getDiff.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from 'vitest';
+import { GetDiffResult } from '@/features/git';
+
+// Extract the formatting function for testing
+function formatDiffAsGitDiff(result: GetDiffResult): string {
+    let output = '';
+
+    for (const file of result.files) {
+        const oldPath = file.oldPath ?? '/dev/null';
+        const newPath = file.newPath ?? '/dev/null';
+
+        output += `--- a/${oldPath}\n`;
+        output += `+++ b/${newPath}\n`;
+
+        for (const hunk of file.hunks) {
+            const oldStart = hunk.oldRange.start;
+            const oldLines = hunk.oldRange.lines;
+            const newStart = hunk.newRange.start;
+            const newLines = hunk.newRange.lines;
+
+            output += `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`;
+            if (hunk.heading) {
+                output += ` ${hunk.heading}`;
+            }
+            output += '\n';
+
+            output += hunk.body;
+            if (!hunk.body.endsWith('\n')) {
+                output += '\n';
+            }
+        }
+    }
+
+    return output;
+}
+
+describe('formatDiffAsGitDiff', () => {
+    it('should format a simple file change correctly', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: 'file.txt',
+                    newPath: 'file.txt',
+                    hunks: [
+                        {
+                            oldRange: { start: 1, lines: 3 },
+                            newRange: { start: 1, lines: 4 },
+                            heading: undefined,
+                            body: ' context line\n-removed line\n+added line\n context line',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a/file.txt
++++ b/file.txt
+@@ -1,3 +1,4 @@
+ context line
+-removed line
++added line
+ context line
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+
+    it('should handle file deletion', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: 'deleted.txt',
+                    newPath: null,
+                    hunks: [
+                        {
+                            oldRange: { start: 1, lines: 2 },
+                            newRange: { start: 0, lines: 0 },
+                            heading: undefined,
+                            body: '-line 1\n-line 2',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a/deleted.txt
++++ b//dev/null
+@@ -1,2 +0,0 @@
+-line 1
+-line 2
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+
+    it('should handle file addition', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: null,
+                    newPath: 'new.txt',
+                    hunks: [
+                        {
+                            oldRange: { start: 0, lines: 0 },
+                            newRange: { start: 1, lines: 2 },
+                            heading: undefined,
+                            body: '+line 1\n+line 2',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a//dev/null
++++ b/new.txt
+@@ -0,0 +1,2 @@
++line 1
++line 2
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+
+    it('should include hunk heading when present', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: 'code.ts',
+                    newPath: 'code.ts',
+                    hunks: [
+                        {
+                            oldRange: { start: 10, lines: 5 },
+                            newRange: { start: 10, lines: 6 },
+                            heading: 'function myFunction()',
+                            body: ' function myFunction() {\n+  console.log("new line");\n   return true;\n }',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a/code.ts
++++ b/code.ts
+@@ -10,5 +10,6 @@ function myFunction()
+ function myFunction() {
++  console.log("new line");
+   return true;
+ }
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+
+    it('should handle multiple files', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: 'file1.txt',
+                    newPath: 'file1.txt',
+                    hunks: [
+                        {
+                            oldRange: { start: 1, lines: 1 },
+                            newRange: { start: 1, lines: 2 },
+                            heading: undefined,
+                            body: ' old\n+new',
+                        },
+                    ],
+                },
+                {
+                    oldPath: 'file2.txt',
+                    newPath: 'file2.txt',
+                    hunks: [
+                        {
+                            oldRange: { start: 1, lines: 1 },
+                            newRange: { start: 1, lines: 1 },
+                            heading: undefined,
+                            body: ' unchanged',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a/file1.txt
++++ b/file1.txt
+@@ -1,1 +1,2 @@
+ old
++new
+--- a/file2.txt
++++ b/file2.txt
+@@ -1,1 +1,1 @@
+ unchanged
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+
+    it('should handle multiple hunks in a single file', () => {
+        const input: GetDiffResult = {
+            files: [
+                {
+                    oldPath: 'file.txt',
+                    newPath: 'file.txt',
+                    hunks: [
+                        {
+                            oldRange: { start: 1, lines: 2 },
+                            newRange: { start: 1, lines: 2 },
+                            heading: undefined,
+                            body: ' line 1\n+line 2',
+                        },
+                        {
+                            oldRange: { start: 10, lines: 2 },
+                            newRange: { start: 11, lines: 2 },
+                            heading: undefined,
+                            body: '-line 10\n line 11',
+                        },
+                    ],
+                },
+            ],
+        };
+
+        const expected = `--- a/file.txt
++++ b/file.txt
+@@ -1,2 +1,2 @@
+ line 1
++line 2
+@@ -10,2 +11,2 @@
+-line 10
+ line 11
+`;
+
+        expect(formatDiffAsGitDiff(input)).toBe(expected);
+    });
+});

--- a/packages/web/src/features/tools/getDiff.ts
+++ b/packages/web/src/features/tools/getDiff.ts
@@ -2,6 +2,7 @@ import { getDiff, GetDiffResult } from '@/features/git';
 import { getDiffRequestSchema } from '@/features/git/schemas';
 import { isServiceError } from '@/lib/utils';
 import description from './getDiff.txt';
+import { formatDiffAsGitDiff } from './utils';
 import { logger } from './logger';
 import { ToolDefinition } from './types';
 import { CodeHostType } from '@sourcebot/db';
@@ -19,38 +20,6 @@ export type GetDiffMetadata = GetDiffResult & {
     base: string;
     head: string;
 };
-
-function formatDiffAsGitDiff(result: GetDiffResult): string {
-    let output = '';
-
-    for (const file of result.files) {
-        const oldPath = file.oldPath ?? '/dev/null';
-        const newPath = file.newPath ?? '/dev/null';
-
-        output += `--- a/${oldPath}\n`;
-        output += `+++ b/${newPath}\n`;
-
-        for (const hunk of file.hunks) {
-            const oldStart = hunk.oldRange.start;
-            const oldLines = hunk.oldRange.lines;
-            const newStart = hunk.newRange.start;
-            const newLines = hunk.newRange.lines;
-
-            output += `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`;
-            if (hunk.heading) {
-                output += ` ${hunk.heading}`;
-            }
-            output += '\n';
-
-            output += hunk.body;
-            if (!hunk.body.endsWith('\n')) {
-                output += '\n';
-            }
-        }
-    }
-
-    return output;
-}
 
 export const getDiffDefinition: ToolDefinition<'get_diff', typeof getDiffRequestSchema.shape, GetDiffMetadata> = {
     name: 'get_diff',

--- a/packages/web/src/features/tools/getDiff.ts
+++ b/packages/web/src/features/tools/getDiff.ts
@@ -4,12 +4,53 @@ import { isServiceError } from '@/lib/utils';
 import description from './getDiff.txt';
 import { logger } from './logger';
 import { ToolDefinition } from './types';
+import { CodeHostType } from '@sourcebot/db';
+import { getRepoInfoByName } from '@/actions';
+
+export type GetDiffRepoInfo = {
+    name: string;
+    displayName: string;
+    codeHostType: CodeHostType;
+};
 
 export type GetDiffMetadata = GetDiffResult & {
     repo: string;
+    repoInfo: GetDiffRepoInfo;
     base: string;
     head: string;
 };
+
+function formatDiffAsGitDiff(result: GetDiffResult): string {
+    let output = '';
+
+    for (const file of result.files) {
+        const oldPath = file.oldPath ?? '/dev/null';
+        const newPath = file.newPath ?? '/dev/null';
+
+        output += `--- a/${oldPath}\n`;
+        output += `+++ b/${newPath}\n`;
+
+        for (const hunk of file.hunks) {
+            const oldStart = hunk.oldRange.start;
+            const oldLines = hunk.oldRange.lines;
+            const newStart = hunk.newRange.start;
+            const newLines = hunk.newRange.lines;
+
+            output += `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`;
+            if (hunk.heading) {
+                output += ` ${hunk.heading}`;
+            }
+            output += '\n';
+
+            output += hunk.body;
+            if (!hunk.body.endsWith('\n')) {
+                output += '\n';
+            }
+        }
+    }
+
+    return output;
+}
 
 export const getDiffDefinition: ToolDefinition<'get_diff', typeof getDiffRequestSchema.shape, GetDiffMetadata> = {
     name: 'get_diff',
@@ -27,11 +68,24 @@ export const getDiffDefinition: ToolDefinition<'get_diff', typeof getDiffRequest
             throw new Error(response.message);
         }
 
+        const repoInfoResult = await getRepoInfoByName(repo);
+        if (isServiceError(repoInfoResult) || !repoInfoResult) {
+            throw new Error(`Repository "${repo}" not found.`);
+        }
+        const repoInfo: GetDiffRepoInfo = {
+            name: repoInfoResult.name,
+            displayName: repoInfoResult.displayName ?? repoInfoResult.name,
+            codeHostType: repoInfoResult.codeHostType,
+        };
+
+        const gitDiffOutput = formatDiffAsGitDiff(response);
+
         return {
-            output: JSON.stringify(response),
+            output: gitDiffOutput,
             metadata: {
                 ...response,
                 repo,
+                repoInfo,
                 base,
                 head,
             },

--- a/packages/web/src/features/tools/utils.test.ts
+++ b/packages/web/src/features/tools/utils.test.ts
@@ -1,38 +1,9 @@
 import { describe, it, expect } from 'vitest';
-import { GetDiffResult } from '@/features/git';
+import type { z } from 'zod';
+import type { getDiffResponseSchema } from '@/features/git/schemas';
+import { formatDiffAsGitDiff } from './utils';
 
-// Extract the formatting function for testing
-function formatDiffAsGitDiff(result: GetDiffResult): string {
-    let output = '';
-
-    for (const file of result.files) {
-        const oldPath = file.oldPath ?? '/dev/null';
-        const newPath = file.newPath ?? '/dev/null';
-
-        output += `--- a/${oldPath}\n`;
-        output += `+++ b/${newPath}\n`;
-
-        for (const hunk of file.hunks) {
-            const oldStart = hunk.oldRange.start;
-            const oldLines = hunk.oldRange.lines;
-            const newStart = hunk.newRange.start;
-            const newLines = hunk.newRange.lines;
-
-            output += `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`;
-            if (hunk.heading) {
-                output += ` ${hunk.heading}`;
-            }
-            output += '\n';
-
-            output += hunk.body;
-            if (!hunk.body.endsWith('\n')) {
-                output += '\n';
-            }
-        }
-    }
-
-    return output;
-}
+type GetDiffResult = z.infer<typeof getDiffResponseSchema>;
 
 describe('formatDiffAsGitDiff', () => {
     it('should format a simple file change correctly', () => {
@@ -84,7 +55,7 @@ describe('formatDiffAsGitDiff', () => {
         };
 
         const expected = `--- a/deleted.txt
-+++ b//dev/null
++++ /dev/null
 @@ -1,2 +0,0 @@
 -line 1
 -line 2
@@ -111,7 +82,7 @@ describe('formatDiffAsGitDiff', () => {
             ],
         };
 
-        const expected = `--- a//dev/null
+        const expected = `--- /dev/null
 +++ b/new.txt
 @@ -0,0 +1,2 @@
 +line 1

--- a/packages/web/src/features/tools/utils.ts
+++ b/packages/web/src/features/tools/utils.ts
@@ -1,0 +1,33 @@
+import type { z } from 'zod';
+import type { getDiffResponseSchema } from '@/features/git/schemas';
+
+type DiffResult = z.infer<typeof getDiffResponseSchema>;
+
+export function formatDiffAsGitDiff(result: DiffResult): string {
+    let output = '';
+
+    for (const file of result.files) {
+        output += file.oldPath ? `--- a/${file.oldPath}\n` : `--- /dev/null\n`;
+        output += file.newPath ? `+++ b/${file.newPath}\n` : `+++ /dev/null\n`;
+
+        for (const hunk of file.hunks) {
+            const oldStart = hunk.oldRange.start;
+            const oldLines = hunk.oldRange.lines;
+            const newStart = hunk.newRange.start;
+            const newLines = hunk.newRange.lines;
+
+            output += `@@ -${oldStart},${oldLines} +${newStart},${newLines} @@`;
+            if (hunk.heading) {
+                output += ` ${hunk.heading}`;
+            }
+            output += '\n';
+
+            output += hunk.body;
+            if (!hunk.body.endsWith('\n')) {
+                output += '\n';
+            }
+        }
+    }
+
+    return output;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
This PR implements the feedback from the Slack thread on the diff tool:

1. **Truncate SHAs to 7 characters**: Full commit SHAs (40-character hashes) are now displayed as 7-character truncated versions for a more compact display
2. **Use RepoBadge component**: Repository references now consistently use the RepoBadge component instead of a plain monospace span, matching the pattern used by other tools like `read_file`, `list_commits`, etc.
3. **Git-diff format output**: The tool now outputs diffs in standard git-diff format instead of JSON, which is more token-efficient and better suited for LLM reasoning (as this format appears heavily in training data)

<img width="1189" height="33" alt="image" src="https://github.com/user-attachments/assets/4d607d80-980a-43aa-a761-edfa2a8ac6e1" />


## Changes

- Modified `getDiff.ts` to format the API response into git-diff format and fetch repo info
- Updated `getDiffToolComponent.tsx` to truncate SHAs and use RepoBadge
- Added `GetDiffRepoInfo` type to metadata for repository information
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sourcebot-dev.slack.com/archives/C05AX425LDA/p1776966033235379?thread_ts=1776966033.235379&cid=C05AX425LDA)

<div><a href="https://cursor.com/agents/bc-ac460f9f-18f9-51b2-a774-f2a668350aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ac460f9f-18f9-51b2-a774-f2a668350aad"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Diff output now formatted as git-unified diffs instead of JSON
  * Repository metadata resolution and display added to diff tool

* **Improvements**
  * Commit SHA references shortened to 7 characters
  * Repository display updated with an enhanced badge component

* **Tests**
  * Added tests validating Git-diff formatting and multi-hunk/file cases
<!-- end of auto-generated comment: release notes by coderabbit.ai -->