### PR TITLE
fix(web): preserve selected language model

### DIFF
--- a/packages/web/src/features/chat/components/chatBox/chatBoxToolbar.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBoxToolbar.tsx
@@ -27,7 +27,7 @@ export const ChatBoxToolbar = ({
     isContextSelectorOpen,
     onContextSelectorOpenChanged,
 }: ChatBoxToolbarProps) => {
-    const { selectedLanguageModel, setSelectedLanguageModel } = useSelectedLanguageModel({
+    const { resolvedSelectedLanguageModel, setSelectedLanguageModel } = useSelectedLanguageModel({
         languageModels,
     });
 
@@ -48,7 +48,7 @@ export const ChatBoxToolbar = ({
             <LanguageModelSelector
                 languageModels={languageModels}
                 onSelectedModelChange={setSelectedLanguageModel}
-                selectedModel={selectedLanguageModel}
+                selectedModel={resolvedSelectedLanguageModel}
             />
         </>
     )

--- a/packages/web/src/features/chat/components/chatBox/languageModelSelector.tsx
+++ b/packages/web/src/features/chat/components/chatBox/languageModelSelector.tsx
@@ -126,6 +126,12 @@ export const LanguageModelSelector = ({
                                         return (
                                             <CommandItem
                                                 key={getLanguageModelKey(model)}
+                                                value={getLanguageModelKey(model)}
+                                                keywords={[
+                                                    model.displayName ?? "",
+                                                    model.model,
+                                                    model.provider,
+                                                ]}
                                                 onSelect={() => {
                                                     selectModel(model)
                                                 }}

--- a/packages/web/src/features/chat/useSelectedLanguageModel.ts
+++ b/packages/web/src/features/chat/useSelectedLanguageModel.ts
@@ -16,7 +16,18 @@ const getStoredSelectedLanguageModel = (): LanguageModelInfo | undefined => {
             return undefined;
         }
 
-        return JSON.parse(storedValue) as LanguageModelInfo;
+        const parsedValue = JSON.parse(storedValue);
+        if (
+            typeof parsedValue === "object" &&
+            parsedValue !== null &&
+            typeof parsedValue.provider === "string" &&
+            typeof parsedValue.model === "string" &&
+            typeof parsedValue.displayName === "string"
+        ) {
+            return parsedValue as LanguageModelInfo;
+        }
+
+        return undefined;
     } catch {
         return undefined;
     }
@@ -48,7 +59,7 @@ export const useSelectedLanguageModel = ({
         }
 
         if (selectedLanguageModel && !availableSelectedLanguageModel) {
-            setSelectedLanguageModel((currentSelectedLanguageModel) => {
+            setSelectedLanguageModel(() => {
                 const storedSelectedLanguageModel = getStoredSelectedLanguageModel();
                 const availableStoredSelectedLanguageModel = storedSelectedLanguageModel && languageModels.find(
                     (model) => getLanguageModelKey(model) === getLanguageModelKey(storedSelectedLanguageModel)
@@ -56,12 +67,6 @@ export const useSelectedLanguageModel = ({
 
                 if (availableStoredSelectedLanguageModel) {
                     return availableStoredSelectedLanguageModel;
-                }
-
-                if (currentSelectedLanguageModel && languageModels.find(
-                    (model) => getLanguageModelKey(model) === getLanguageModelKey(currentSelectedLanguageModel)
-                )) {
-                    return currentSelectedLanguageModel;
                 }
 
                 return fallbackLanguageModel;

--- a/packages/web/src/features/chat/useSelectedLanguageModel.ts
+++ b/packages/web/src/features/chat/useSelectedLanguageModel.ts
@@ -76,7 +76,8 @@ export const useSelectedLanguageModel = ({
     ]);
 
     return {
-        selectedLanguageModel: resolvedSelectedLanguageModel,
+        selectedLanguageModel,
+        resolvedSelectedLanguageModel,
         setSelectedLanguageModel,
     };
 }

--- a/packages/web/src/features/chat/useSelectedLanguageModel.ts
+++ b/packages/web/src/features/chat/useSelectedLanguageModel.ts
@@ -9,27 +9,66 @@ type Props = {
     languageModels: LanguageModelInfo[];
 }
 
+const getStoredSelectedLanguageModel = (): LanguageModelInfo | undefined => {
+    try {
+        const storedValue = window.localStorage.getItem("selectedLanguageModel");
+        if (!storedValue) {
+            return undefined;
+        }
+
+        return JSON.parse(storedValue) as LanguageModelInfo;
+    } catch {
+        return undefined;
+    }
+};
+
 export const useSelectedLanguageModel = ({
     languageModels,
 }: Props) => {
     const fallbackLanguageModel = languageModels.length > 0 ? languageModels[0] : undefined;
     const [selectedLanguageModel, setSelectedLanguageModel] = useLocalStorage<LanguageModelInfo | undefined>(
         "selectedLanguageModel",
-        fallbackLanguageModel,
+        undefined,
         {
             initializeWithValue: false,
         }
     );
 
+    const availableSelectedLanguageModel = selectedLanguageModel && languageModels.find(
+        (model) => getLanguageModelKey(model) === getLanguageModelKey(selectedLanguageModel)
+    );
+
+    const resolvedSelectedLanguageModel = availableSelectedLanguageModel ?? fallbackLanguageModel;
+
     // Handle the case where the selected language model is no longer
     // available. Reset to the fallback language model in this case.
     useEffect(() => {
-        if (!selectedLanguageModel || !languageModels.find(
-            (model) => getLanguageModelKey(model) === getLanguageModelKey(selectedLanguageModel)
-        )) {
-            setSelectedLanguageModel(fallbackLanguageModel);
+        if (languageModels.length === 0) {
+            return;
+        }
+
+        if (selectedLanguageModel && !availableSelectedLanguageModel) {
+            setSelectedLanguageModel((currentSelectedLanguageModel) => {
+                const storedSelectedLanguageModel = getStoredSelectedLanguageModel();
+                const availableStoredSelectedLanguageModel = storedSelectedLanguageModel && languageModels.find(
+                    (model) => getLanguageModelKey(model) === getLanguageModelKey(storedSelectedLanguageModel)
+                );
+
+                if (availableStoredSelectedLanguageModel) {
+                    return availableStoredSelectedLanguageModel;
+                }
+
+                if (currentSelectedLanguageModel && languageModels.find(
+                    (model) => getLanguageModelKey(model) === getLanguageModelKey(currentSelectedLanguageModel)
+                )) {
+                    return currentSelectedLanguageModel;
+                }
+
+                return fallbackLanguageModel;
+            });
         }
     }, [
+        availableSelectedLanguageModel,
         fallbackLanguageModel,
         languageModels,
         selectedLanguageModel,
@@ -37,7 +76,7 @@ export const useSelectedLanguageModel = ({
     ]);
 
     return {
-        selectedLanguageModel,
+        selectedLanguageModel: resolvedSelectedLanguageModel,
         setSelectedLanguageModel,
     };
 }


### PR DESCRIPTION
## Summary
- Fix chat language model selection when configured model names or model IDs are similar.
- Prevent broken fallback logic from alternating between models in a React hook loop, which caused repeated re-renders and made it impossible to change the selected model in some cases.
- Make language model command items match by stable key plus display name, model, and provider.

## Tests
- Not run (not requested).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved model selector search: models are now matched with clearer keywords (name, identifier, provider) for easier discovery.
  * Selector now uses a resolved current model across the UI for more consistent display.

* **Bug Fixes**
  * More robust selection persistence and fallback handling when available models change, reducing incorrect or missing selections.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->