### PR TITLE
fix(mcp): match language model by provider+model, fall back when displayName absent

### DIFF
--- a/packages/web/src/features/mcp/askCodebase.ts
+++ b/packages/web/src/features/mcp/askCodebase.ts
@@ -1,7 +1,7 @@
 import { sew } from "@/middleware/sew";
 import { getConfiguredLanguageModels, getAISDKLanguageModelAndOptions, generateChatNameFromMessage, updateChatMessages } from "@/features/chat/utils.server";
 import { LanguageModelInfo, SBChatMessage, SearchScope } from "@/features/chat/types";
-import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage, getLanguageModelKey } from "@/features/chat/utils";
+import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage } from "@/features/chat/utils";
 import { ErrorCode } from "@/lib/errorCodes";
 import { ServiceError, ServiceErrorException } from "@/lib/serviceError";
 import { withOptionalAuth } from "@/middleware/withAuth";
@@ -57,14 +57,34 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
 
             let languageModelConfig = configuredModels[0];
             if (requestedLanguageModel) {
-                const matchingModel = configuredModels.find(
-                    (m) => getLanguageModelKey(m) === getLanguageModelKey(requestedLanguageModel)
+                const candidates = configuredModels.filter(
+                    (m) => m.provider === requestedLanguageModel.provider &&
+                           m.model === requestedLanguageModel.model
                 );
+                const displayNameProvided = requestedLanguageModel.displayName !== undefined;
+                const matchingModel = displayNameProvided
+                    ? candidates.find((m) => m.displayName === requestedLanguageModel.displayName)
+                    : candidates.length === 1 ? candidates[0] : undefined;
                 if (!matchingModel) {
+                    const available = candidates
+                        .map((m) => m.displayName)
+                        .filter((n): n is string => n !== undefined)
+                        .map((n) => `"${n}"`)
+                        .join(', ');
+                    let message: string;
+                    if (candidates.length === 0) {
+                        message = `Language model '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' is not configured.`;
+                    } else if (displayNameProvided) {
+                        message = `Language model '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' is configured but displayName '${requestedLanguageModel.displayName}' was not found.`
+                            + (available ? ` Available: ${available}.` : '');
+                    } else {
+                        message = `Multiple configurations found for '${requestedLanguageModel.provider}/${requestedLanguageModel.model}'. Provide a displayName to disambiguate.`
+                            + (available ? ` Available: ${available}.` : '');
+                    }
                     return {
                         statusCode: StatusCodes.BAD_REQUEST,
                         errorCode: ErrorCode.INVALID_REQUEST_BODY,
-                        message: `Language model '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' is not configured.`,
+                        message,
                     } satisfies ServiceError;
                 }
                 languageModelConfig = matchingModel;

--- a/packages/web/src/features/mcp/askCodebase.ts
+++ b/packages/web/src/features/mcp/askCodebase.ts
@@ -78,8 +78,9 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
                         message = `Language model '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' is configured but displayName '${requestedLanguageModel.displayName}' was not found.`
                             + (available ? ` Available: ${available}.` : '');
                     } else {
-                        message = `Multiple configurations found for '${requestedLanguageModel.provider}/${requestedLanguageModel.model}'. Provide a displayName to disambiguate.`
-                            + (available ? ` Available: ${available}.` : '');
+                        message = available
+                            ? `Multiple configurations found for '${requestedLanguageModel.provider}/${requestedLanguageModel.model}'. Provide a displayName to disambiguate. Available: ${available}.`
+                            : `Multiple configurations found for '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' but none define a displayName. Add a unique displayName to each configuration entry to enable disambiguation.`;
                     }
                     return {
                         statusCode: StatusCodes.BAD_REQUEST,


### PR DESCRIPTION
## Problem

`ask_codebase` rejects any explicit `languageModel` with a 400, even when `list_language_models` returns the exact model. Reported in #1137.

Root cause: `askCodebase.ts` uses `getLanguageModelKey` to match the requested model against configured ones. That key includes `displayName`:

```ts
// chat/utils.ts
export const getLanguageModelKey = (model: LanguageModelInfo) =>
    `${model.provider}-${model.model}-${model.displayName}`;
```

But the MCP package (`@sourcebot/mcp`) explicitly omits `displayName` from the `ask_codebase` request schema:

```ts
// @sourcebot/mcp dist/schemas.js
export const askCodebaseRequestSchema = z.object({
    languageModel: languageModelInfoSchema.omit({ displayName: true })
```

So an LLM agent can only pass `{provider, model}` — `displayName` is always `undefined` on the caller's side. Match always fails:

- configured key: `anthropic-claude-opus-4-7-Claude Opus 4.7 (slow, highest quality)`
- requested key:  `anthropic-claude-opus-4-7-undefined`

## Fix

Replace the `getLanguageModelKey`-based match with a two-step approach:

1. Filter configured models by `provider + model` → `candidates`.
2. `displayName !== undefined` (strict, not truthiness — so `""` is treated as an explicit value).
3. If `displayName` provided → exact match within candidates. Preserves disambiguation between same-model entries differing in `displayName` (e.g. two `opus-4-7` with different `reasoningEffort`).
4. If `displayName` absent and exactly one candidate → use it.
5. If `displayName` absent and multiple candidates → 400 with one of two distinct messages:
   - some candidates have `displayName` → list them and ask caller to disambiguate
   - no candidate has `displayName` → tell the operator to add `displayName` to the config

Three distinct 400 messages:

| Scenario | Message |
|---|---|
| `provider+model` not found | `Language model 'X/Y' is not configured.` |
| `provider+model` found, wrong `displayName` | `… is configured but displayName 'Z' was not found. Available: "A", "B".` |
| Multiple candidates, caller sent no `displayName`, some have `displayName` | `Multiple configurations found for 'X/Y'. Provide a displayName to disambiguate. Available: "A", "B".` |
| Multiple candidates, none have `displayName` | `Multiple configurations found for 'X/Y' but none define a displayName. Add a unique displayName to each configuration entry to enable disambiguation.` |

Also removes the now-unused `getLanguageModelKey` import.

## Test plan

- `{provider, model}`, one matching config, no `displayName` → succeeds
- `{provider, model, displayName: ""}` → treated as explicit empty-string match
- `{provider, model, displayName}` → exact match on all three fields
- `{provider, model, displayName}` wrong name → 400 listing available displayNames
- Two configs same `provider+model`, different `displayName`, no `displayName` sent → 400 with hint listing available names
- Two configs same `provider+model`, different `displayName`, correct `displayName` sent → correct model selected
- Two configs same `provider+model`, neither has `displayName` → 400 telling operator to add `displayName` to config
- `provider+model` not configured at all → plain "not configured" message
- No `languageModel` param → falls back to first configured model (unchanged)