### PR TITLE
chore(web): bump postcss to 8.5.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added commit history viewer to code browser. [#1150](https://github.com/sourcebot-dev/sourcebot/pull/1150)
 - Added `/api/commits/authors` to the public API to allow fetching a list of authors for a given path and revision. [#1150](https://github.com/sourcebot-dev/sourcebot/pull/1150)
 
+### Fixed
+- Bumped `postcss` to `8.5.10`. [#1155](https://github.com/sourcebot-dev/sourcebot/pull/1155)
+
 ## [4.16.15] - 2026-04-23
 
 ### Changed

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -219,7 +219,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "jsdom": "^25.0.1",
     "npm-run-all": "^4.1.5",
-    "postcss": "^8",
+    "postcss": "^8.5.10",
     "raw-loader": "^4.0.2",
     "react-email": "^5.2.10",
     "react-grab": "^0.1.23",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8812,7 +8812,7 @@ __metadata:
     octokit: "npm:^4.1.3"
     openai: "npm:^4.98.0"
     parse-diff: "npm:^0.11.1"
-    postcss: "npm:^8"
+    postcss: "npm:^8.5.10"
     posthog-js: "npm:^1.369.0"
     posthog-node: "npm:^5.24.15"
     pretty-bytes: "npm:^6.1.1"
@@ -17085,7 +17085,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6, nanoid@npm:^3.3.8":
+"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -18300,25 +18300,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"postcss@npm:^8, postcss@npm:^8.4.47":
-  version: 8.5.3
-  resolution: "postcss@npm:8.5.3"
-  dependencies:
-    nanoid: "npm:^3.3.8"
-    picocolors: "npm:^1.1.1"
-    source-map-js: "npm:^1.2.1"
-  checksum: 10c0/b75510d7b28c3ab728c8733dd01538314a18c52af426f199a3c9177e63eb08602a3938bfb66b62dc01350b9aed62087eabbf229af97a1659eb8d3513cec823b3
-  languageName: node
-  linkType: hard
-
-"postcss@npm:^8.5.8":
-  version: 8.5.9
-  resolution: "postcss@npm:8.5.9"
+"postcss@npm:^8.4.47, postcss@npm:^8.5.10, postcss@npm:^8.5.8":
+  version: 8.5.12
+  resolution: "postcss@npm:8.5.12"
   dependencies:
     nanoid: "npm:^3.3.11"
     picocolors: "npm:^1.1.1"
     source-map-js: "npm:^1.2.1"
-  checksum: 10c0/7cb2b32202ea1ead03f15cfbb2756a64a0f98942378e99b3dfce33678fe5eaf93e31d675a46e3a0dfb417d7b49b82d8999d0dd42a33c3b128e71ade0f978719a
+  checksum: 10c0/5baebaf574c567bc1b3d61197f38af4ce5920b8f611c887fb6bc3dcc14af00253c169dbf19897bc889cce0b0d9818ab5eb4ea0caedf02b0bab10da8a43ce8c12
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-995

## Summary
- Bumped `postcss` direct devDependency in `packages/web` from `^8` to `^8.5.10`.
- Ran `yarn dedupe postcss` to consolidate transitive copies (vite, tailwindcss) onto the same resolution.


🤖 Generated with [Claude Code](https://claude.com/claude-code)