### PR TITLE
chore(web): harden post-auth redirects and legacy URL rewrite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Added `/api/avatar` to resolve user profile pictures. [#1159](https://github.com/sourcebot-dev/sourcebot/pull/1159)
+- Hardened post-auth redirects with an explicit same-origin `redirect` callback in the NextAuth config, and switched the legacy `/~/...` URL rewrite from a 308 to a 301. [#1161](https://github.com/sourcebot-dev/sourcebot/pull/1161)
 
 ### Fixed
 - Bumped `postcss` to `8.5.10`. [#1155](https://github.com/sourcebot-dev/sourcebot/pull/1155)

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -220,6 +220,26 @@ export const { handlers, signIn, signOut, auth } = NextAuth({
         }
     },
     callbacks: {
+        // Restrict post-auth redirects (sign-in / sign-out, `callbackUrl`,
+        // `redirectTo`) to the same origin as the application. This mirrors
+        // Auth.js's documented default; we set it explicitly so the protection
+        // is visible in code and not dependent on upstream defaults.
+        // @see https://authjs.dev/reference/core#redirect
+        async redirect({ url, baseUrl }) {
+            if (url.startsWith("/")) {
+                return `${baseUrl}${url}`;
+            }
+
+            try {
+                if (new URL(url).origin === baseUrl) {
+                    return url;
+                }
+            } catch {
+                // Malformed URL — fall through to baseUrl.
+            }
+
+            return baseUrl;
+        },
         async jwt({ token, user: _user }) {
             const user = _user as User | undefined;
             // @note: `user` will be available on signUp or signIn triggers.

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -1,3 +1,4 @@
+import { StatusCodes } from 'http-status-codes';
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
@@ -27,12 +28,12 @@ export async function proxy(request: NextRequest) {
 
     if (url.pathname.startsWith('/~/')) {
         url.pathname = url.pathname.replace(/^\/~/, '');
-        return NextResponse.redirect(url, 308);
+        return NextResponse.redirect(url, StatusCodes.MOVED_PERMANENTLY);
     }
 
     if (url.pathname === '/~') {
         url.pathname = '/';
-        return NextResponse.redirect(url, 308);
+        return NextResponse.redirect(url, StatusCodes.MOVED_PERMANENTLY);
     }
 
     return NextResponse.next();


### PR DESCRIPTION
Fixes SOU-945

## Summary
- Add an explicit `redirect` callback to the NextAuth config in `packages/web/src/auth.ts`. It restricts post-auth redirects (sign-in / sign-out, `callbackUrl`, `redirectTo`) to the same origin as the application. This mirrors the documented Auth.js default ([reference](https://authjs.dev/reference/core#redirect)), but makes the protection visible in code rather than relying on upstream defaults staying stable across major versions.
- Switch the legacy `/~/...` rewrite in `packages/web/src/proxy.ts` from **308** to **301**. The rewrite is a backwards-compat shim for v3.0.0–v4.16.8 page URLs, which are virtually all GETs. 301 has matching cache/permanence semantics but downgrades any stray POST to GET and drops the body, which is the right behavior for a path-rewrite shim.


🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced post-authentication security by restricting login redirects to same-origin URLs only, with fallback handling for invalid targets.
  * Updated redirect HTTP status codes to align with standard behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->