### PR TITLE
feat(web): add audit log entries for org membership changes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [EE] Added three new audit actions covering the full org membership lifecycle: `org.member_added` (fires from all five `UserToOrg`-creation paths, including two that were previously silent), `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)
+
 ## [4.17.0] - 2026-04-30
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- [EE] Added three new audit actions covering the full org membership lifecycle: `org.member_added` (fires from all five `UserToOrg`-creation paths, including two that were previously silent), `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)
+- [EE] Added three new audit actions covering the full org membership lifecycle: `org.member_added`, `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)
 
 ## [4.17.0] - 2026-04-30
 

--- a/docs/docs/configuration/audit-logs.mdx
+++ b/docs/docs/configuration/audit-logs.mdx
@@ -145,6 +145,9 @@ curl --request GET '$SOURCEBOT_URL/api/ee/audit' \
 | `user.signed_out`                     | `user` | `user` |
 | `org.member_promoted_to_owner`        | `user` | `user` |
 | `org.owner_demoted_to_member`         | `user` | `user` |
+| `org.member_added`                    | `user` | `user` |
+| `org.member_removed`                  | `user` | `user` |
+| `org.member_left`                     | `user` | `user` |
 
 
 ## Response schema

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -1047,6 +1047,16 @@ export const approveAccountRequest = async (requestId: string) => sew(async () =
                     type: "account_join_request"
                 }
             });
+
+            await auditService.createAudit({
+                action: "org.member_added",
+                actor: { id: user.id, type: "user" },
+                target: { id: request.requestedById, type: "user" },
+                orgId: org.id,
+                metadata: {
+                    message: `${user.id} approved join request ${requestId} for ${request.requestedById}`,
+                },
+            });
             return {
                 success: true,
             }

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -1005,36 +1005,6 @@ export const approveAccountRequest = async (requestId: string) => sew(async () =
                 return addUserToOrgRes;
             }
 
-            // Send approval email to the user
-            const smtpConnectionUrl = getSMTPConnectionURL();
-            if (smtpConnectionUrl && env.EMAIL_FROM_ADDRESS) {
-                const html = await render(JoinRequestApprovedEmail({
-                    baseUrl: env.AUTH_URL,
-                    user: {
-                        name: request.requestedBy.name ?? undefined,
-                        email: request.requestedBy.email!,
-                        avatarUrl: request.requestedBy.image ?? undefined,
-                    },
-                    orgName: org.name,
-                }));
-
-                const transport = createTransport(smtpConnectionUrl);
-                const result = await transport.sendMail({
-                    to: request.requestedBy.email!,
-                    from: env.EMAIL_FROM_ADDRESS,
-                    subject: `Your request to join ${org.name} has been approved`,
-                    html,
-                    text: `Your request to join ${org.name} on Sourcebot has been approved. You can now access the organization at ${env.AUTH_URL}`,
-                });
-
-                const failed = result.rejected.concat(result.pending).filter(Boolean);
-                if (failed.length > 0) {
-                    logger.error(`Failed to send approval email to ${request.requestedBy.email}: ${failed}`);
-                }
-            } else {
-                logger.warn(`SMTP_CONNECTION_URL or EMAIL_FROM_ADDRESS not set. Skipping approval email to ${request.requestedBy.email}`);
-            }
-
             await auditService.createAudit({
                 action: "user.join_request_approved",
                 actor: {
@@ -1057,6 +1027,40 @@ export const approveAccountRequest = async (requestId: string) => sew(async () =
                     message: `${user.id} approved join request ${requestId} for ${request.requestedById}`,
                 },
             });
+
+            // Send approval email to the user
+            const smtpConnectionUrl = getSMTPConnectionURL();
+            if (smtpConnectionUrl && env.EMAIL_FROM_ADDRESS) {
+                try {
+                    const html = await render(JoinRequestApprovedEmail({
+                        baseUrl: env.AUTH_URL,
+                        user: {
+                            name: request.requestedBy.name ?? undefined,
+                            email: request.requestedBy.email!,
+                            avatarUrl: request.requestedBy.image ?? undefined,
+                        },
+                        orgName: org.name,
+                    }));
+
+                    const transport = createTransport(smtpConnectionUrl);
+                    const result = await transport.sendMail({
+                        to: request.requestedBy.email!,
+                        from: env.EMAIL_FROM_ADDRESS,
+                        subject: `Your request to join ${org.name} has been approved`,
+                        html,
+                        text: `Your request to join ${org.name} on Sourcebot has been approved. You can now access the organization at ${env.AUTH_URL}`,
+                    });
+
+                    const failed = result.rejected.concat(result.pending).filter(Boolean);
+                    if (failed.length > 0) {
+                        logger.error(`Failed to send approval email to ${request.requestedBy.email}: ${failed}`);
+                    }
+                } catch (e) {
+                    logger.error(`Failed to send approval email to ${request.requestedBy.email}: ${e}`);
+                }
+            } else {
+                logger.warn(`SMTP_CONNECTION_URL or EMAIL_FROM_ADDRESS not set. Skipping approval email to ${request.requestedBy.email}`);
+            }
             return {
                 success: true,
             }

--- a/packages/web/src/app/invite/actions.ts
+++ b/packages/web/src/app/invite/actions.ts
@@ -56,6 +56,16 @@ export const joinOrganization = async (inviteLinkId?: string) => sew(async () =>
         return addUserToOrgRes;
     }
 
+    await auditService.createAudit({
+        action: "org.member_added",
+        actor: { id: user.id, type: "user" },
+        target: { id: user.id, type: "user" },
+        orgId: org.id,
+        metadata: {
+            message: `${user.id} joined the organization via invite link`,
+        },
+    });
+
     return {
         success: true,
     }
@@ -133,6 +143,16 @@ export const redeemInvite = async (inviteId: string): Promise<{ success: boolean
             id: inviteId,
             type: "invite"
         }
+    });
+
+    await auditService.createAudit({
+        action: "org.member_added",
+        actor: { id: user.id, type: "user" },
+        target: { id: user.id, type: "user" },
+        orgId: invite.org.id,
+        metadata: {
+            message: `${user.id} joined the organization by accepting invite ${inviteId}`,
+        },
     });
 
     return {

--- a/packages/web/src/features/userManagement/actions.ts
+++ b/packages/web/src/features/userManagement/actions.ts
@@ -5,11 +5,14 @@ import { ErrorCode } from "@/lib/errorCodes";
 import { notFound, ServiceError } from "@/lib/serviceError";
 import { withAuth } from "@/middleware/withAuth";
 import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
+import { getAuditService } from "@/ee/features/audit/factory";
 import { OrgRole, Prisma } from "@sourcebot/db";
 import { StatusCodes } from "http-status-codes";
 
+const auditService = getAuditService();
+
 export const removeMemberFromOrg = async (memberId: string): Promise<{ success: boolean } | ServiceError> => sew(() =>
-    withAuth(async ({ org, role, prisma }) =>
+    withAuth(async ({ user, org, role, prisma }) =>
         withMinimumOrgRole(role, OrgRole.OWNER, async () => {
             const guardError = await prisma.$transaction(async (tx) => {
                 const targetMember = await tx.userToOrg.findUnique({
@@ -58,6 +61,16 @@ export const removeMemberFromOrg = async (memberId: string): Promise<{ success: 
                 return guardError;
             }
 
+            await auditService.createAudit({
+                action: "org.member_removed",
+                actor: { id: user.id, type: "user" },
+                target: { id: memberId, type: "user" },
+                orgId: org.id,
+                metadata: {
+                    message: `${user.id} removed ${memberId} from the organization`,
+                },
+            });
+
             return { success: true };
         }))
 );
@@ -97,6 +110,16 @@ export const leaveOrg = async (): Promise<{ success: boolean } | ServiceError> =
         if (guardError) {
             return guardError;
         }
+
+        await auditService.createAudit({
+            action: "org.member_left",
+            actor: { id: user.id, type: "user" },
+            target: { id: user.id, type: "user" },
+            orgId: org.id,
+            metadata: {
+                message: `${user.id} left the organization`,
+            },
+        });
 
         return {
             success: true,

--- a/packages/web/src/lib/authUtils.ts
+++ b/packages/web/src/lib/authUtils.ts
@@ -104,6 +104,16 @@ export const onCreateUser = async ({ user }: { user: AuthJsUser }) => {
                 type: "org"
             }
         });
+
+        await auditService.createAudit({
+            action: "org.member_added",
+            actor: { id: user.id, type: "user" },
+            target: { id: user.id, type: "user" },
+            orgId: SINGLE_TENANT_ORG_ID,
+            metadata: {
+                message: `${user.id} joined the organization as the initial owner`,
+            },
+        });
     } else if (!defaultOrg.memberApprovalRequired) {
         const hasAvailability = await orgHasAvailability();
         if (!hasAvailability) {
@@ -117,6 +127,16 @@ export const onCreateUser = async ({ user }: { user: AuthJsUser }) => {
                 orgId: SINGLE_TENANT_ORG_ID,
                 role: OrgRole.MEMBER,
             }
+        });
+
+        await auditService.createAudit({
+            action: "org.member_added",
+            actor: { id: user.id, type: "user" },
+            target: { id: user.id, type: "user" },
+            orgId: SINGLE_TENANT_ORG_ID,
+            metadata: {
+                message: `${user.id} joined the organization (member approval not required)`,
+            },
         });
     }
 


### PR DESCRIPTION
## Summary

Adds three new audit actions so the membership lifecycle is fully captured in the audit log:

- **`org.member_added`** — fires from all five `UserToOrg`-creation paths:
  - Initial owner on first signup (`onCreateUser`, alongside the existing `user.owner_created`)
  - Auto-add on signup when `memberApprovalRequired = false` (previously silent)
  - Magic invite-link join via `joinOrganization` (previously silent)
  - Email invite redemption (alongside the existing `user.invite_accepted`)
  - Join-request approval (alongside the existing `user.join_request_approved`)
- **`org.member_removed`** — fires when an admin removes a member via Settings → Members.
- **`org.member_left`** — fires when a user leaves the org themselves.

All three use a consistent `(actor=user, target=user)` shape so the full membership history can be reconstructed with one filter per state transition (`org.member_added` / `org.member_removed` / `org.member_left`). The existing per-path audits (`user.invite_accepted`, `user.join_request_approved`, `user.owner_created`) are preserved as semantic detail — they describe *how* a user joined, while `org.member_added` records *that* they joined.

The `metadata.message` on each event records the specific path (initial owner, no-approval signup, invite link, invite ID, approving admin) so detail isn't lost.

`createGuestUser` is intentionally not audited — it upserts the singleton system Guest user, not a real membership grant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three audit action types for organization member lifecycle: org.member_added, org.member_removed, org.member_left. These events are now recorded across member approval, invite acceptance, removals, voluntary departures, and single-tenant provisioning flows.

* **Documentation**
  * Updated audit logs docs to include the new membership action types with actor/target details.

* **Chores**
  * Added entry to CHANGELOG for the new audit actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->