### PR TITLE
fix(schemas): allow spaces in Azure DevOps project and repo names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [EE] Added three new audit actions covering the full org membership lifecycle: `org.member_added`, `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)
 
+### Fixed
+- Fixed Azure DevOps connection schema to allow spaces in project and repository names. [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170)
+
 ## [4.17.0] - 2026-04-30
 
 ### Added

--- a/docs/snippets/schemas/v3/azuredevops.schema.mdx
+++ b/docs/snippets/schemas/v3/azuredevops.schema.mdx
@@ -82,7 +82,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+        "pattern": "^[\\w.-]+\\/[\\w. -]+$"
       },
       "default": [],
       "examples": [
@@ -97,7 +97,7 @@
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+        "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
       },
       "default": [],
       "examples": [

--- a/packages/schemas/src/v3/azuredevops.schema.ts
+++ b/packages/schemas/src/v3/azuredevops.schema.ts
@@ -81,7 +81,7 @@ const schema = {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+        "pattern": "^[\\w.-]+\\/[\\w. -]+$"
       },
       "default": [],
       "examples": [
@@ -96,7 +96,7 @@ const schema = {
       "type": "array",
       "items": {
         "type": "string",
-        "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+        "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
       },
       "default": [],
       "examples": [

--- a/schemas/v3/azuredevops.json
+++ b/schemas/v3/azuredevops.json
@@ -53,7 +53,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+                "pattern": "^[\\w.-]+\\/[\\w. -]+$"
             },
             "default": [],
             "examples": [
@@ -68,7 +68,7 @@
             "type": "array",
             "items": {
                 "type": "string",
-                "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+                "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
             },
             "default": [],
             "examples": [


### PR DESCRIPTION
Update the regex patterns for `projects` and `repos` in the Azure DevOps connection schema to accept names containing spaces. Azure DevOps natively supports spaces in project and repository names, but the previous pattern `[\w.-]+` excluded them.

Fixes #1166

Generated with [Claude Code](https://claude.ai/code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Azure DevOps project and repository names with spaces are now accepted in configurations.
  * Added three audit events for organization membership lifecycle: member added, member removed, member left.
  * Per-user JWT session versioning: removed users’ JWT cookies, personal API keys, and OAuth tokens are invalidated on next request.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->