### PR TITLE
feat(web): acknowledge review command comments with a reaction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [Experimental] Review agent now acknowledges receipt of the `review` command by adding a reaction to the triggering comment. The reaction is configurable via `REVIEW_AGENT_ACK_REACTION` (default: `eyes`). [#1174](https://github.com/sourcebot-dev/sourcebot/pull/1174)
+
 ### Fixed
 - Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [EE] Added prompt caching for Ask Sourcebot. For Anthropic models, the static prompt prefix (tool definitions, system prompt, and conversation history) is marked with a cache breakpoint so it is billed at the provider's discounted cache-read rate on subsequent agent steps and follow-up turns. Toggle with `SOURCEBOT_CHAT_PROMPT_CACHING_ENABLED` (default `true`). [#1278](https://github.com/sourcebot-dev/sourcebot/pull/1278)
 - [EE] Added a cached-token breakdown to the Ask Sourcebot message details, showing what share of the input tokens were served from the model provider's prompt cache. [#1278](https://github.com/sourcebot-dev/sourcebot/pull/1278)
+- [Experimental] Review agent now acknowledges receipt of the `review` command by adding a reaction to the triggering comment. The reaction is configurable via `REVIEW_AGENT_ACK_REACTION` (default: `eyes`). [#1174](https://github.com/sourcebot-dev/sourcebot/pull/1174)
 
 ### Fixed
 - Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)

--- a/docs/docs/configuration/environment-variables.mdx
+++ b/docs/docs/configuration/environment-variables.mdx
@@ -70,6 +70,7 @@ The following environment variables allow you to configure your Sourcebot deploy
 | `GITHUB_REVIEW_AGENT_APP_PRIVATE_KEY_PATH` | `-` | <p>The container relative path to the private key file for the GitHub App used by the review agent.</p> |
 | `GITHUB_REVIEW_AGENT_APP_WEBHOOK_SECRET` | `-` | <p>The webhook secret for the GitHub App used by the review agent.</p> |
 | `OPENAI_API_KEY` | `-` | <p>The OpenAI API key used by the review agent.</p> |
+| `REVIEW_AGENT_ACK_REACTION` | `eyes` | <p>The reaction/emoji added to a comment when the review agent acknowledges receipt of the review command.</p> |
 | `REVIEW_AGENT_API_KEY` | `-` | <p>The Sourcebot API key used by the review agent.</p> |
 | `REVIEW_AGENT_AUTO_REVIEW_ENABLED` | `false` | <p>Enables/disables automatic code reviews by the review agent.</p> |
 | `REVIEW_AGENT_LOGGING_ENABLED` | `true` | <p>Enables/disables logging for the review agent. Logs are saved in `DATA_CACHE_DIR/review-agent`</p> |

--- a/docs/docs/configuration/environment-variables.mdx
+++ b/docs/docs/configuration/environment-variables.mdx
@@ -12,7 +12,7 @@ The following environment variables allow you to configure your Sourcebot deploy
 | :------- | :------ | :---------- |
 | `AUTH_CREDENTIALS_LOGIN_ENABLED` | `true` | <p>Enables/disables authentication with basic credentials. Username and passwords are stored encrypted at rest within the postgres database. Checkout the [auth docs](/docs/configuration/auth/authentication) for more info</p> |
 | `AUTH_EMAIL_CODE_LOGIN_ENABLED` | `false` | <p>Enables/disables authentication with a login code that's sent to a users email. `SMTP_CONNECTION_URL` and `EMAIL_FROM_ADDRESS` must also be set. Checkout the [auth docs](/docs/configuration/auth/authentication) for more info </p> |
-| `AUTH_SECRET` **(required)** | - | <p>Used to validate login session cookies. Genearte one with `openssl rand -base64 33`.</p> |
+| `AUTH_SECRET` **(required)** | - | <p>Used to validate login session cookies. Generate one with `openssl rand -base64 33`.</p> |
 | `AUTH_SESSION_MAX_AGE_SECONDS` | `2592000` (30 days) | <p>Relative time from now in seconds when to expire the session.</p> |
 | `AUTH_SESSION_UPDATE_AGE_SECONDS` | `86400` (1 day) | <p>How often the session should be updated in seconds. If set to `0`, session is updated every time.</p> |
 | `OAUTH_AUTHORIZATION_CODE_TTL_SECONDS` | `600` (10 minutes) | <p>Lifetime of an OAuth authorization code, in seconds.</p> |

--- a/docs/docs/configuration/environment-variables.mdx
+++ b/docs/docs/configuration/environment-variables.mdx
@@ -68,6 +68,7 @@ The following environment variables allow you to configure your Sourcebot deploy
 | `GITHUB_REVIEW_AGENT_APP_PRIVATE_KEY_PATH` | `-` | <p>The container relative path to the private key file for the GitHub App used by the review agent.</p> |
 | `GITHUB_REVIEW_AGENT_APP_WEBHOOK_SECRET` | `-` | <p>The webhook secret for the GitHub App used by the review agent.</p> |
 | `OPENAI_API_KEY` | `-` | <p>The OpenAI API key used by the review agent.</p> |
+| `REVIEW_AGENT_ACK_REACTION` | `eyes` | <p>The reaction/emoji added to a comment when the review agent acknowledges receipt of the review command.</p> |
 | `REVIEW_AGENT_API_KEY` | `-` | <p>The Sourcebot API key used by the review agent.</p> |
 | `REVIEW_AGENT_AUTO_REVIEW_ENABLED` | `false` | <p>Enables/disables automatic code reviews by the review agent.</p> |
 | `REVIEW_AGENT_LOGGING_ENABLED` | `true` | <p>Enables/disables logging for the review agent. Logs are saved in `DATA_CACHE_DIR/review-agent`</p> |

--- a/docs/docs/features/agents/review-agent.mdx
+++ b/docs/docs/features/agents/review-agent.mdx
@@ -141,7 +141,8 @@ You can also trigger a review manually by commenting `/review` on any PR or MR. 
 
 | Variable | Default | Description |
 |---|---|---|
+| `REVIEW_AGENT_ACK_REACTION` | `eyes` | Reaction/emoji added to acknowledge receipt of the review command |
 | `REVIEW_AGENT_AUTO_REVIEW_ENABLED` | `false` | Automatically review new and updated PRs/MRs |
-| `REVIEW_AGENT_REVIEW_COMMAND` | `review` | Comment command that triggers a manual review (without the `/`) |
-| `REVIEW_AGENT_MODEL` | first configured model | `displayName` of the language model to use for reviews |
 | `REVIEW_AGENT_LOGGING_ENABLED` | unset | Write prompt and response logs to disk for debugging |
+| `REVIEW_AGENT_MODEL` | first configured model | `displayName` of the language model to use for reviews |
+| `REVIEW_AGENT_REVIEW_COMMAND` | `review` | Comment command that triggers a manual review (without the `/`) |

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -235,10 +235,11 @@ const options = {
         GITLAB_REVIEW_AGENT_TOKEN: z.string().optional(),
         GITLAB_REVIEW_AGENT_HOST: z.string().default('gitlab.com').transform(s => s.replace(/^https?:\/\//, '').replace(/\/+$/, '')).refine(s => /^[a-z0-9.-]+$/i.test(s), { message: 'invalid hostname' }),
         // Review agent config
-        REVIEW_AGENT_MODEL: z.string().optional(),
+        REVIEW_AGENT_ACK_REACTION: z.string().default('eyes'),
         REVIEW_AGENT_API_KEY: z.string().optional(),
-        REVIEW_AGENT_LOGGING_ENABLED: booleanSchema.default('true'),
         REVIEW_AGENT_AUTO_REVIEW_ENABLED: booleanSchema.default('false'),
+        REVIEW_AGENT_LOGGING_ENABLED: booleanSchema.default('true'),
+        REVIEW_AGENT_MODEL: z.string().optional(),
         REVIEW_AGENT_REVIEW_COMMAND: z.string().default('review'),
 
         ANTHROPIC_API_KEY: z.string().optional(),

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -240,10 +240,11 @@ const options = {
         GITLAB_REVIEW_AGENT_TOKEN: z.string().optional(),
         GITLAB_REVIEW_AGENT_HOST: z.string().default('gitlab.com').transform(s => s.replace(/^https?:\/\//, '').replace(/\/+$/, '')).refine(s => /^[a-z0-9.-]+$/i.test(s), { message: 'invalid hostname' }),
         // Review agent config
-        REVIEW_AGENT_MODEL: z.string().optional(),
+        REVIEW_AGENT_ACK_REACTION: z.string().default('eyes'),
         REVIEW_AGENT_API_KEY: z.string().optional(),
-        REVIEW_AGENT_LOGGING_ENABLED: booleanSchema.default('true'),
         REVIEW_AGENT_AUTO_REVIEW_ENABLED: booleanSchema.default('false'),
+        REVIEW_AGENT_LOGGING_ENABLED: booleanSchema.default('true'),
+        REVIEW_AGENT_MODEL: z.string().optional(),
         REVIEW_AGENT_REVIEW_COMMAND: z.string().default('review'),
 
         ANTHROPIC_API_KEY: z.string().optional(),

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -130,6 +130,16 @@ if (env.GITLAB_REVIEW_AGENT_TOKEN) {
     }
 }
 
+const ACK_TIMEOUT_MS = 1500;
+
+const ackWithTimeout = (promise: Promise<unknown>, label: string): Promise<void> => {
+    const timeout = new Promise<void>(resolve => setTimeout(resolve, ACK_TIMEOUT_MS));
+    return Promise.race([promise, timeout]).then(
+        () => { /* success or timeout — proceed */ },
+        (error) => { logger.warn(`${label}: ${error}`); },
+    );
+};
+
 export const POST = async (request: NextRequest) => {
     const body = await request.json();
     const headers = Object.fromEntries(Array.from(request.headers.entries(), ([key, value]) => [key.toLowerCase(), value]));
@@ -186,16 +196,15 @@ export const POST = async (request: NextRequest) => {
 
                 const octokit = await githubApp.getInstallationOctokit(body.installation.id);
 
-                try {
-                    await octokit.rest.reactions.createForIssueComment({
+                await ackWithTimeout(
+                    octokit.rest.reactions.createForIssueComment({
                         owner,
                         repo: repositoryName,
                         comment_id: body.comment.id,
                         content: env.REVIEW_AGENT_ACK_REACTION as "-1" | "+1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes",
-                    });
-                } catch (error) {
-                    logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);
-                }
+                    }),
+                    'Failed to add acknowledgment reaction to GitHub comment',
+                );
 
                 const { data: pullRequest } = await octokit.rest.pulls.get({
                     owner,
@@ -258,16 +267,15 @@ export const POST = async (request: NextRequest) => {
             if (noteBody === `/${env.REVIEW_AGENT_REVIEW_COMMAND}`) {
                 logger.info('Review agent review command received on GitLab MR, processing');
 
-                try {
-                    await gitlabClient.MergeRequestNoteAwardEmojis.award(
+                await ackWithTimeout(
+                    gitlabClient.MergeRequestNoteAwardEmojis.award(
                         parsed.data.project.id,
                         parsed.data.merge_request.iid,
                         parsed.data.object_attributes.id,
                         env.REVIEW_AGENT_ACK_REACTION,
-                    );
-                } catch (error) {
-                    logger.warn(`Failed to add acknowledgment emoji to GitLab note: ${error}`);
-                }
+                    ),
+                    'Failed to add acknowledgment emoji to GitLab note',
+                );
 
                 const mrPayload: GitLabMergeRequestPayload = {
                     object_kind: "merge_request",

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -185,6 +185,18 @@ export const POST = async (request: NextRequest) => {
                 const owner = body.repository.owner.login;
 
                 const octokit = await githubApp.getInstallationOctokit(body.installation.id);
+
+                try {
+                    await octokit.rest.reactions.createForIssueComment({
+                        owner,
+                        repo: repositoryName,
+                        comment_id: body.comment.id,
+                        content: env.REVIEW_AGENT_ACK_REACTION as Parameters<typeof octokit.rest.reactions.createForIssueComment>[0]['content'],
+                    });
+                } catch (error) {
+                    logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);
+                }
+
                 const { data: pullRequest } = await octokit.rest.pulls.get({
                     owner,
                     repo: repositoryName,
@@ -245,6 +257,17 @@ export const POST = async (request: NextRequest) => {
             const noteBody = parsed.data.object_attributes.note;
             if (noteBody === `/${env.REVIEW_AGENT_REVIEW_COMMAND}`) {
                 logger.info('Review agent review command received on GitLab MR, processing');
+
+                try {
+                    await gitlabClient.MergeRequestNoteAwardEmojis.award(
+                        parsed.data.project.id,
+                        parsed.data.merge_request.iid,
+                        parsed.data.object_attributes.id,
+                        env.REVIEW_AGENT_ACK_REACTION,
+                    );
+                } catch (error) {
+                    logger.warn(`Failed to add acknowledgment emoji to GitLab note: ${error}`);
+                }
 
                 const mrPayload: GitLabMergeRequestPayload = {
                     object_kind: "merge_request",

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -191,7 +191,7 @@ export const POST = async (request: NextRequest) => {
                         owner,
                         repo: repositoryName,
                         comment_id: body.comment.id,
-                        content: env.REVIEW_AGENT_ACK_REACTION as Parameters<typeof octokit.rest.reactions.createForIssueComment>[0]['content'],
+                        content: env.REVIEW_AGENT_ACK_REACTION as "-1" | "+1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes",
                     });
                 } catch (error) {
                     logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -192,7 +192,7 @@ export const POST = async (request: NextRequest) => {
                         owner,
                         repo: repositoryName,
                         comment_id: body.comment.id,
-                        content: env.REVIEW_AGENT_ACK_REACTION as Parameters<typeof octokit.rest.reactions.createForIssueComment>[0]['content'],
+                        content: env.REVIEW_AGENT_ACK_REACTION as "-1" | "+1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes",
                     });
                 } catch (error) {
                     logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -186,6 +186,18 @@ export const POST = async (request: NextRequest) => {
                 const owner = body.repository.owner.login;
 
                 const octokit = await githubApp.getInstallationOctokit(body.installation.id);
+
+                try {
+                    await octokit.rest.reactions.createForIssueComment({
+                        owner,
+                        repo: repositoryName,
+                        comment_id: body.comment.id,
+                        content: env.REVIEW_AGENT_ACK_REACTION as Parameters<typeof octokit.rest.reactions.createForIssueComment>[0]['content'],
+                    });
+                } catch (error) {
+                    logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);
+                }
+
                 const { data: pullRequest } = await octokit.rest.pulls.get({
                     owner,
                     repo: repositoryName,
@@ -246,6 +258,17 @@ export const POST = async (request: NextRequest) => {
             const noteBody = parsed.data.object_attributes.note;
             if (noteBody === `/${env.REVIEW_AGENT_REVIEW_COMMAND}`) {
                 logger.info('Review agent review command received on GitLab MR, processing');
+
+                try {
+                    await gitlabClient.MergeRequestNoteAwardEmojis.award(
+                        parsed.data.project.id,
+                        parsed.data.merge_request.iid,
+                        parsed.data.object_attributes.id,
+                        env.REVIEW_AGENT_ACK_REACTION,
+                    );
+                } catch (error) {
+                    logger.warn(`Failed to add acknowledgment emoji to GitLab note: ${error}`);
+                }
 
                 const mrPayload: GitLabMergeRequestPayload = {
                     object_kind: "merge_request",

--- a/packages/web/src/app/api/(server)/webhook/route.ts
+++ b/packages/web/src/app/api/(server)/webhook/route.ts
@@ -130,6 +130,16 @@ if (env.GITLAB_REVIEW_AGENT_TOKEN) {
     }
 }
 
+const ACK_TIMEOUT_MS = 1500;
+
+const ackWithTimeout = (promise: Promise<unknown>, label: string): Promise<void> => {
+    const timeout = new Promise<void>(resolve => setTimeout(resolve, ACK_TIMEOUT_MS));
+    return Promise.race([promise, timeout]).then(
+        () => { /* success or timeout — proceed */ },
+        (error) => { logger.warn(`${label}: ${error}`); },
+    );
+};
+
 // eslint-disable-next-line authz/require-auth-wrapper -- authenticated via GitHub App / GitLab webhook secrets, not user session
 export const POST = async (request: NextRequest) => {
     const body = await request.json();
@@ -187,16 +197,15 @@ export const POST = async (request: NextRequest) => {
 
                 const octokit = await githubApp.getInstallationOctokit(body.installation.id);
 
-                try {
-                    await octokit.rest.reactions.createForIssueComment({
+                await ackWithTimeout(
+                    octokit.rest.reactions.createForIssueComment({
                         owner,
                         repo: repositoryName,
                         comment_id: body.comment.id,
                         content: env.REVIEW_AGENT_ACK_REACTION as "-1" | "+1" | "laugh" | "confused" | "heart" | "hooray" | "rocket" | "eyes",
-                    });
-                } catch (error) {
-                    logger.warn(`Failed to add acknowledgment reaction to GitHub comment: ${error}`);
-                }
+                    }),
+                    'Failed to add acknowledgment reaction to GitHub comment',
+                );
 
                 const { data: pullRequest } = await octokit.rest.pulls.get({
                     owner,
@@ -259,16 +268,15 @@ export const POST = async (request: NextRequest) => {
             if (noteBody === `/${env.REVIEW_AGENT_REVIEW_COMMAND}`) {
                 logger.info('Review agent review command received on GitLab MR, processing');
 
-                try {
-                    await gitlabClient.MergeRequestNoteAwardEmojis.award(
+                await ackWithTimeout(
+                    gitlabClient.MergeRequestNoteAwardEmojis.award(
                         parsed.data.project.id,
                         parsed.data.merge_request.iid,
                         parsed.data.object_attributes.id,
                         env.REVIEW_AGENT_ACK_REACTION,
-                    );
-                } catch (error) {
-                    logger.warn(`Failed to add acknowledgment emoji to GitLab note: ${error}`);
-                }
+                    ),
+                    'Failed to add acknowledgment emoji to GitLab note',
+                );
 
                 const mrPayload: GitLabMergeRequestPayload = {
                     object_kind: "merge_request",

--- a/packages/web/src/features/agents/review-agent/types.ts
+++ b/packages/web/src/features/agents/review-agent/types.ts
@@ -87,6 +87,7 @@ export type GitLabMergeRequestPayload = z.infer<typeof gitLabMergeRequestPayload
 export const gitLabNotePayloadSchema = z.object({
     object_kind: z.literal('note'),
     object_attributes: z.object({
+        id: z.number(),
         note: z.string(),
         noteable_type: z.literal('MergeRequest'),
     }),


### PR DESCRIPTION
Adds a configurable acknowledgment reaction/emoji to the triggering
comment when the review agent receives a `review` command, so users
get immediate feedback that the request was received.

- `github`: reacts to the issue comment via the reactions API (default: `eyes`)
- `gitlab`: awards an emoji on the MR note via `MergeRequestNoteAwardEmojis`
- New `REVIEW_AGENT_ACK_REACTION` env var (default: `eyes`) controls the reaction
- Acknowledgment failures are logged as warnings and do not block the review

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Review Agent now adds an acknowledgement reaction to review-command comments on GitHub and GitLab (best-effort).

* **Behavior**
  * Acknowledgement is non-blocking; failures or timeouts are logged and do not prevent processing.

* **Configuration**
  * New REVIEW_AGENT_ACK_REACTION environment variable (default: "eyes") to configure the acknowledgement emoji.

* **Documentation**
  * Environment variable reference and changelog updated to document the new reaction setting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->