### PR TITLE
fix: Add missing changes from #1170

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [4.17.1] - 2026-05-04
 
+### Fixed
+- Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
+
 ### Added
 - Added three new audit actions covering the full org membership lifecycle: `org.member_added`, `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)
 - Added per-user JWT session versioning so admin-driven member removals (and voluntary leaves) invalidate the removed user's active JWT cookies, personal API keys, and OAuth tokens atomically on their next request. [#1168](https://github.com/sourcebot-dev/sourcebot/pull/1168)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [4.17.1] - 2026-05-04
-
 ### Fixed
 - Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
+
+## [4.17.1] - 2026-05-04
 
 ### Added
 - Added three new audit actions covering the full org membership lifecycle: `org.member_added`, `org.member_removed`, and `org.member_left`. [#1165](https://github.com/sourcebot-dev/sourcebot/pull/1165)

--- a/docs/snippets/schemas/v3/connection.schema.mdx
+++ b/docs/snippets/schemas/v3/connection.schema.mdx
@@ -985,7 +985,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+            "pattern": "^[\\w.-]+\\/[\\w. -]+$"
           },
           "default": [],
           "examples": [
@@ -1000,7 +1000,7 @@
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+            "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
           },
           "default": [],
           "examples": [

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -1476,7 +1476,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+                    "pattern": "^[\\w.-]+\\/[\\w. -]+$"
                   },
                   "default": [],
                   "examples": [
@@ -1491,7 +1491,7 @@
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+                    "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
                   },
                   "default": [],
                   "examples": [

--- a/packages/schemas/src/v3/connection.schema.ts
+++ b/packages/schemas/src/v3/connection.schema.ts
@@ -984,7 +984,7 @@ const schema = {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+            "pattern": "^[\\w.-]+\\/[\\w. -]+$"
           },
           "default": [],
           "examples": [
@@ -999,7 +999,7 @@ const schema = {
           "type": "array",
           "items": {
             "type": "string",
-            "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+            "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
           },
           "default": [],
           "examples": [

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -1475,7 +1475,7 @@ const schema = {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^[\\w.-]+\\/[\\w.-]+$"
+                    "pattern": "^[\\w.-]+\\/[\\w. -]+$"
                   },
                   "default": [],
                   "examples": [
@@ -1490,7 +1490,7 @@ const schema = {
                   "type": "array",
                   "items": {
                     "type": "string",
-                    "pattern": "^[\\w.-]+\\/[\\w.-]+\\/[\\w.-]+$"
+                    "pattern": "^[\\w.-]+\\/[\\w. -]+\\/[\\w. -]+$"
                   },
                   "default": [],
                   "examples": [


### PR DESCRIPTION
Forgot to re-generate the schema for changes introduced in #1170 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Azure DevOps connection validation relaxed to allow spaces in project/repository path segments and to accept three-segment repository identifiers.

* **Documentation**
  * Updated schema documentation to reflect the relaxed Azure DevOps connection validation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->