### PR TITLE
fix: upgrade simple-git to 3.36.0 to address CVE-2026-6951

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
+- Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951 (RCE via `--config` bypass). [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
-- Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951 (RCE via `--config` bypass). [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/packages/backend/package.json
+++ b/packages/backend/package.json
@@ -53,7 +53,7 @@
         "posthog-node": "^5.24.15",
         "prom-client": "^15.1.3",
         "redlock": "5.0.0-beta.2",
-        "simple-git": "^3.33.0",
+        "simple-git": "^3.36.0",
         "zod": "^3.25.74"
     }
 }

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -183,7 +183,7 @@
     "scroll-into-view-if-needed": "^3.1.0",
     "server-only": "^0.0.1",
     "sharp": "^0.33.5",
-    "simple-git": "^3.33.0",
+    "simple-git": "^3.36.0",
     "slate": "^0.117.0",
     "slate-dom": "^0.116.0",
     "slate-history": "^0.113.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8047,6 +8047,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@simple-git/args-pathspec@npm:^1.0.3":
+  version: 1.0.3
+  resolution: "@simple-git/args-pathspec@npm:1.0.3"
+  checksum: 10c0/91bfc99daa956df28e4efd683cd799f60c6d169fce6adf71a9efa80a6b5938fed4b03e55fa929cfd51aed64f3ada5c1e4edad45a3872dbd94d11924b3258b5bc
+  languageName: node
+  linkType: hard
+
+"@simple-git/argv-parser@npm:^1.1.0":
+  version: 1.1.1
+  resolution: "@simple-git/argv-parser@npm:1.1.1"
+  dependencies:
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+  checksum: 10c0/2c21166f1bb7c4373e7b4e52bd0c7f333e58ea0ff5ac0b6c2d305835f4a2bcad1ef4bcce3cff63312ac55655ea7be3aba4c7c0c41e3ebcb8bee343f65bb92f5e
+  languageName: node
+  linkType: hard
+
 "@smithy/config-resolver@npm:^4.4.17":
   version: 4.4.17
   resolution: "@smithy/config-resolver@npm:4.4.17"
@@ -8633,7 +8649,7 @@ __metadata:
     posthog-node: "npm:^5.24.15"
     prom-client: "npm:^15.1.3"
     redlock: "npm:5.0.0-beta.2"
-    simple-git: "npm:^3.33.0"
+    simple-git: "npm:^3.36.0"
     tsc-watch: "npm:^6.2.0"
     tsx: "npm:^4.21.0"
     typescript: "npm:^5.6.2"
@@ -8924,7 +8940,7 @@ __metadata:
     scroll-into-view-if-needed: "npm:^3.1.0"
     server-only: "npm:^0.0.1"
     sharp: "npm:^0.33.5"
-    simple-git: "npm:^3.33.0"
+    simple-git: "npm:^3.36.0"
     slate: "npm:^0.117.0"
     slate-dom: "npm:^0.116.0"
     slate-history: "npm:^0.113.1"
@@ -20394,14 +20410,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"simple-git@npm:^3.33.0":
-  version: 3.33.0
-  resolution: "simple-git@npm:3.33.0"
+"simple-git@npm:^3.36.0":
+  version: 3.36.0
+  resolution: "simple-git@npm:3.36.0"
   dependencies:
     "@kwsites/file-exists": "npm:^1.1.1"
     "@kwsites/promise-deferred": "npm:^1.1.1"
+    "@simple-git/args-pathspec": "npm:^1.0.3"
+    "@simple-git/argv-parser": "npm:^1.1.0"
     debug: "npm:^4.4.0"
-  checksum: 10c0/463e91f3ee04b7fc445284c64502a4ee3d607f626f18c8bcc036815a30fe178d2216976e683c6368edd7b3093801d6e534deeb8e700a4863a76ef23f881a0712
+  checksum: 10c0/4c22e57107535168f354e5abbbf6e618a7b39d76491ca225c70588520fbe86891f3b9a5c4f8a3fc0137e669aad2f0e11f6c6e677bfec07169cd18f29bf23cb77
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-1032

## Summary

This PR upgrades `simple-git` from `3.33.0` to `3.36.0` in both the `@sourcebot/backend` and `@sourcebot/web` packages to address **CVE-2026-6951**, a high-severity Remote Code Execution vulnerability.

## Vulnerability Details

The vulnerability allows attackers to bypass the previous fix for CVE-2022-25912 by using the `--config` long-form flag instead of the `-c` short-form flag (which was already blocked). An attacker who can supply untrusted input to simple-git's options argument could:

1. Enable `protocol.ext.allow=always` via `--config`
2. Use an `ext::` clone source to execute arbitrary shell commands via git's external protocol handler

This results in full remote code execution on the server.

## Changes

- Updated `simple-git` dependency from `^3.33.0` to `^3.36.0` in `packages/backend/package.json`
- Updated `simple-git` dependency from `^3.33.0` to `^3.36.0` in `packages/web/package.json`
- Updated `yarn.lock` to reflect the new version

## Security Review

I reviewed all usages of `simple-git` in the codebase and confirmed that:

1. **User-controlled data is handled safely**: Repository URLs, refs, and paths are passed as string arguments to git commands, not as part of the options object where this vulnerability could be exploited
2. **Input validation is already in place**:
   - Git refs starting with `-` are rejected to prevent flag injection
   - File paths are validated to prevent directory traversal and null byte attacks
3. **Config usage is controlled**: The `-c` flag is only used with hardcoded, safe configuration values (e.g., `core.quotePath=false`, `http.extraHeader`)

This upgrade provides defense-in-depth by closing the `--config` bypass vector, even though our existing code patterns were not directly vulnerable.

## References

- [CVE-2026-6951](https://nvd.nist.gov/vuln/detail/CVE-2026-6951)
- [Snyk Advisory](https://security.snyk.io/vuln/SNYK-JS-SIMPLEGIT-15456078)
- [Fix Commit](https://github.com/steveukx/git-js/commit/89a2294febed5dfe737c4c735d936bb6018746a8)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-1032](https://linear.app/sourcebot/issue/SOU-1032/sourcebot-devsourcebot-cve-2026-6951-simple-git-rce-via-config-bypass)

<div><a href="https://cursor.com/agents/bc-9e730173-9972-4bdf-83c1-a211c43d6700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9e730173-9972-4bdf-83c1-a211c43d6700"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded a critical dependency across backend and web to address a remote code execution security vulnerability (CVE-2026-6951) and updated the changelog to reflect the fix.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1183)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->