### PR TITLE
fix: refresh yarn.lock to upgrade fast-xml-builder to ^1.2.0 (CVE-2026-44664, CVE-2026-44665)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `fast-xml-builder` to `^1.1.7` to address CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
-- Upgraded `fast-xml-builder` to `^1.1.7` to address CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
+- Upgraded `fast-xml-builder` to `^1.2.0` to address CVE-2026-44664, CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "smol-toml@npm:^1.6.0": "^1.6.1",
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
-        "fast-uri@npm:^3.0.1": "^3.1.2"
+        "fast-uri@npm:^3.0.1": "^3.1.2",
+        "fast-xml-builder": "^1.1.7"
     }
 }

--- a/package.json
+++ b/package.json
@@ -59,7 +59,6 @@
         "smol-toml@npm:^1.6.0": "^1.6.1",
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
-        "fast-uri@npm:^3.0.1": "^3.1.2",
-        "fast-xml-builder": "^1.1.7"
+        "fast-uri@npm:^3.0.1": "^3.1.2"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13677,12 +13677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "fast-xml-builder@npm:1.1.5"
+"fast-xml-builder@npm:^1.1.7":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:
-    path-expression-matcher: "npm:^1.1.3"
-  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10c0/84bb105cd04e91d6dcb746c4dbaeb12903b510e7ab9a06ffde55b5a582e005559a87d84467f18a655c6c4baf098f696fd74cee3cbe1aea9d01385907768ba32d
   languageName: node
   linkType: hard
 
@@ -18050,13 +18051,6 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
-  languageName: node
-  linkType: hard
-
-"path-expression-matcher@npm:^1.1.3":
-  version: 1.2.0
-  resolution: "path-expression-matcher@npm:1.2.0"
-  checksum: 10c0/86c661dfb265ed5dd1ddd9188f0dfbecf4ec4dc3ea6cabab081d3a2ba285054d9767a641a233bd6fd694fd89f7d0ef94913032feddf5365252700b02db4bf4e1
   languageName: node
   linkType: hard
 
@@ -22614,6 +22608,13 @@ __metadata:
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
   checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13677,7 +13677,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.7":
+"fast-xml-builder@npm:^1.1.5":
   version: 1.2.0
   resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:


### PR DESCRIPTION
Fixes SOU-1073
Fixes SOU-1074

## Summary

Addresses two sibling `fast-xml-builder` CVEs in one upstream release:

- CVE-2026-44664 (SOU-1073) — regex bypass via triple-dash sequences
- CVE-2026-44665 (SOU-1074) — attribute injection via unescaped quotes

## Approach

The existing `fast-xml-builder: ^1.1.5` range (from `fast-xml-parser`) already admits the patched `1.2.0`. The lockfile was just stale, so the fix is a lockfile refresh — no `package.json` change, no `resolutions` override (per the CVE flow in `CLAUDE.md`).

## Verification

```
$ yarn why fast-xml-builder
└─ fast-xml-parser@npm:5.7.1
   └─ fast-xml-builder@npm:1.2.0 (via npm:^1.1.5)
```

Consolidated from #1185 (CVE-2026-44664), which was the same fix for the sibling CVE.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved issues related to XML building functionality. Improvements to XML processing capabilities enhance system reliability and data handling accuracy.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1184)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->