### PR TITLE
fix: upgrade fast-xml-builder to address CVE-2026-44664

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `fast-xml-builder` to `^1.1.7` to address CVE-2026-44664. [#1185](https://github.com/sourcebot-dev/sourcebot/pull/1185)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "smol-toml@npm:^1.6.0": "^1.6.1",
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
-        "fast-uri@npm:^3.0.1": "^3.1.2"
+        "fast-uri@npm:^3.0.1": "^3.1.2",
+        "fast-xml-builder": "^1.1.7"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -13677,12 +13677,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fast-xml-builder@npm:^1.1.5":
-  version: 1.1.5
-  resolution: "fast-xml-builder@npm:1.1.5"
+"fast-xml-builder@npm:^1.1.7":
+  version: 1.2.0
+  resolution: "fast-xml-builder@npm:1.2.0"
   dependencies:
-    path-expression-matcher: "npm:^1.1.3"
-  checksum: 10c0/b814ba5559cb3140de46d2846045607ab4d4c0bfc312a49d22c91efb9f7cd7004971314841e5823eeb467a5bf403e3ade8371b7912200e111df027d42ae51715
+    path-expression-matcher: "npm:^1.5.0"
+    xml-naming: "npm:^0.1.0"
+  checksum: 10c0/84bb105cd04e91d6dcb746c4dbaeb12903b510e7ab9a06ffde55b5a582e005559a87d84467f18a655c6c4baf098f696fd74cee3cbe1aea9d01385907768ba32d
   languageName: node
   linkType: hard
 
@@ -18050,13 +18051,6 @@ __metadata:
   version: 4.0.0
   resolution: "path-exists@npm:4.0.0"
   checksum: 10c0/8c0bd3f5238188197dc78dced15207a4716c51cc4e3624c44fc97acf69558f5ebb9a2afff486fe1b4ee148e0c133e96c5e11a9aa5c48a3006e3467da070e5e1b
-  languageName: node
-  linkType: hard
-
-"path-expression-matcher@npm:^1.1.3":
-  version: 1.2.0
-  resolution: "path-expression-matcher@npm:1.2.0"
-  checksum: 10c0/86c661dfb265ed5dd1ddd9188f0dfbecf4ec4dc3ea6cabab081d3a2ba285054d9767a641a233bd6fd694fd89f7d0ef94913032feddf5365252700b02db4bf4e1
   languageName: node
   linkType: hard
 
@@ -22614,6 +22608,13 @@ __metadata:
   version: 5.0.0
   resolution: "xml-name-validator@npm:5.0.0"
   checksum: 10c0/3fcf44e7b73fb18be917fdd4ccffff3639373c7cb83f8fc35df6001fecba7942f1dbead29d91ebb8315e2f2ff786b508f0c9dc0215b6353f9983c6b7d62cb1f5
+  languageName: node
+  linkType: hard
+
+"xml-naming@npm:^0.1.0":
+  version: 0.1.0
+  resolution: "xml-naming@npm:0.1.0"
+  checksum: 10c0/8c7614865361bcb7e53e3e091dac21c567e2b92d447919b2f072775aa9dcfc94a5255bd52fbaa0fd53c93513e53a23a6a835218ad2af512451dbc678392f85fe
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-1073

## Summary

This PR addresses CVE-2026-44664, a regex bypass vulnerability in `fast-xml-builder` v1.1.5 that allows XML/HTML injection through triple-dash sequences.

## Changes

- Added a yarn resolution to force `fast-xml-builder` to `^1.1.7`
- This upgrades the package from v1.1.5 to v1.2.0, which includes fixes for both CVE-2026-44664 and CVE-2026-44665

## Dependency Chain

The vulnerability was introduced transitively through:
- `@aws-sdk/credential-providers` → `@aws-sdk/client-cognito-identity` → `@aws-sdk/core` → `@aws-sdk/xml-builder` → `fast-xml-parser@5.7.1` → `fast-xml-builder@1.1.5`

## Verification

Confirmed via `yarn why fast-xml-builder` that the package is now resolved to v1.2.0.

## References

- [Dependabot alert](https://github.com/sourcebot-dev/sourcebot/security/dependabot/189)
- [GHSA-45c6-75p6-83cc](https://github.com/advisories/GHSA-45c6-75p6-83cc)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-1073](https://linear.app/sourcebot/issue/SOU-1073/sourcebot-devsourcebot-cve-2026-44664-fast-xml-builder-comment-value)

<div><a href="https://cursor.com/agents/bc-2aa295f6-a86d-449e-b7a3-12c4a2983d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-2aa295f6-a86d-449e-b7a3-12c4a2983d87"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

