### PR TITLE
fix: upgrade hono to ^4.12.18 to address CVE-2026-44455, CVE-2026-44456, CVE-2026-44457, CVE-2026-44458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
-- Upgraded `hono` to `^4.12.18` to address CVE-2026-44455. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
-- Upgraded `hono` to `^4.12.18` to address CVE-2026-44456. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
-- Upgraded `hono` to `^4.12.18` to address CVE-2026-44457. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
-- Upgraded `hono` to `^4.12.18` to address CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44455, CVE-2026-44456, CVE-2026-44457, CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44457. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44455. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44456. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 - Upgraded `hono` to `^4.12.18` to address CVE-2026-44457. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "brace-expansion@npm:^5.0.2": "^5.0.5",
         "brace-expansion@npm:^1.1.7": "^1.1.13",
         "@react-email/preview-server/next": "^16.2.3",
-        "@modelcontextprotocol/sdk/hono": "^4.12.14",
+        "@modelcontextprotocol/sdk/hono": "^4.12.18",
         "@modelcontextprotocol/sdk/@hono/node-server": "^1.19.13",
         "langsmith@npm:>=0.5.0 <1.0.0": "^0.5.19",
         "markdown-it@npm:^14.1.0": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14608,10 +14608,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.14":
-  version: 4.12.14
-  resolution: "hono@npm:4.12.14"
-  checksum: 10c0/78de4c98a9a3da0f067e38dcc4bd27f0d82b45d146ac39f5ca688515ee482c0a2e704d2ac6c1ee91ad17596b7c52b3e4b9483acd9c238d42f6ebcb43414a71b6
+"hono@npm:^4.12.18":
+  version: 4.12.18
+  resolution: "hono@npm:4.12.18"
+  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1068
Fixes SOU-1069
Fixes SOU-1070
Fixes SOU-1071

## Summary

Upgrades `hono` from 4.12.14 to 4.12.18 to address four related CVEs:

- CVE-2026-44455
- CVE-2026-44456
- CVE-2026-44457
- CVE-2026-44458

## Changes

- Bumped the yarn resolution for `@modelcontextprotocol/sdk/hono` from `^4.12.14` to `^4.12.18`.
- Added one CHANGELOG entry per CVE under `[Unreleased] → Fixed`.

Consolidated from #1187, #1188, #1190 — all four PRs were the same package bump for sibling CVEs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded `hono` to address multiple security vulnerabilities.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1186)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->