### PR TITLE
fix: upgrade hono to ^4.12.18 to address CVE-2026-44456

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44456. [#1187](https://github.com/sourcebot-dev/sourcebot/pull/1187)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "brace-expansion@npm:^5.0.2": "^5.0.5",
         "brace-expansion@npm:^1.1.7": "^1.1.13",
         "@react-email/preview-server/next": "^16.2.3",
-        "@modelcontextprotocol/sdk/hono": "^4.12.14",
+        "@modelcontextprotocol/sdk/hono": "^4.12.18",
         "@modelcontextprotocol/sdk/@hono/node-server": "^1.19.13",
         "langsmith@npm:>=0.5.0 <1.0.0": "^0.5.19",
         "markdown-it@npm:^14.1.0": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14608,10 +14608,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.14":
-  version: 4.12.14
-  resolution: "hono@npm:4.12.14"
-  checksum: 10c0/78de4c98a9a3da0f067e38dcc4bd27f0d82b45d146ac39f5ca688515ee482c0a2e704d2ac6c1ee91ad17596b7c52b3e4b9483acd9c238d42f6ebcb43414a71b6
+"hono@npm:^4.12.18":
+  version: 4.12.18
+  resolution: "hono@npm:4.12.18"
+  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-1069

## Summary

Updated the `hono` package resolution from `^4.12.14` to `^4.12.18` to address CVE-2026-44456, a bodyLimit() bypass vulnerability for chunked/unknown-length requests.

## Details

- **CVE**: CVE-2026-44456
- **Affected package**: `hono` v4.12.14 (transitive dependency via `@modelcontextprotocol/sdk`)
- **Fixed in**: `hono` v4.12.18
- **Vulnerability**: `bodyLimit()` does not reliably enforce `maxSize` for requests without a usable `Content-Length` header (e.g., `Transfer-Encoding: chunked`), allowing oversized requests to bypass the limit and reach handler logic

## Changes

- Updated `@modelcontextprotocol/sdk/hono` resolution in `package.json` from `^4.12.14` to `^4.12.18`
- Regenerated `yarn.lock` to apply the resolution

## Testing

- All existing tests pass (789 tests across all packages)
- Verified the upgraded version with `yarn why hono --recursive`
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-1069](https://linear.app/sourcebot/issue/SOU-1069/sourcebot-devsourcebot-cve-2026-44456-hono-bodylimit-bypass-for)

<div><a href="https://cursor.com/agents/bc-87308287-3e2a-4ff7-9765-092c40af36d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-87308287-3e2a-4ff7-9765-092c40af36d3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

