### PR TITLE
fix: upgrade hono to ^4.12.18 to address CVE-2026-44458

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Upgraded `hono` to `^4.12.18` to address CVE-2026-44458. [#1190](https://github.com/sourcebot-dev/sourcebot/pull/1190)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
         "brace-expansion@npm:^5.0.2": "^5.0.5",
         "brace-expansion@npm:^1.1.7": "^1.1.13",
         "@react-email/preview-server/next": "^16.2.3",
-        "@modelcontextprotocol/sdk/hono": "^4.12.14",
+        "@modelcontextprotocol/sdk/hono": "^4.12.18",
         "@modelcontextprotocol/sdk/@hono/node-server": "^1.19.13",
         "langsmith@npm:>=0.5.0 <1.0.0": "^0.5.19",
         "markdown-it@npm:^14.1.0": "^14.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -14608,10 +14608,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.14":
-  version: 4.12.14
-  resolution: "hono@npm:4.12.14"
-  checksum: 10c0/78de4c98a9a3da0f067e38dcc4bd27f0d82b45d146ac39f5ca688515ee482c0a2e704d2ac6c1ee91ad17596b7c52b3e4b9483acd9c238d42f6ebcb43414a71b6
+"hono@npm:^4.12.18":
+  version: 4.12.18
+  resolution: "hono@npm:4.12.18"
+  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-1071

## Summary

Upgraded `hono` from v4.12.14 to v4.12.18 via yarn resolution to address CVE-2026-44458.

## CVE Details

**CVE-2026-44458**: Hono JSX SSR CSS declaration injection via style object values

The JSX renderer in hono v4.12.14 and earlier escapes `style` attribute object values for HTML context but not for CSS context. This allows characters that act as CSS declaration boundaries (`;`, comment markers, block delimiters) to extend a value beyond its assigned property, potentially injecting additional CSS declarations into the rendered `style` attribute.

## Impact

An attacker who can control a `style` object value or property name during server-side JSX rendering may inject arbitrary CSS declarations, potentially enabling:
- Full-viewport overlays for phishing
- Outbound requests to attacker-controlled hosts via `url(...)`
- Layout/visibility manipulation

## Remediation

Updated the existing yarn resolution for `@modelcontextprotocol/sdk/hono` from `^4.12.14` to `^4.12.18`.

## Dependencies Affected

`hono` is pulled in transitively via:
- `@sourcebot/web` → `@modelcontextprotocol/sdk@1.29.0` → `hono@4.12.14`
- `@sourcebot/web` → `@react-grab/mcp@0.1.29` → `@modelcontextprotocol/sdk@1.27.1` → `hono@4.12.14`

After resolution, both paths now use `hono@4.12.18`.

## References

- [Dependabot alert](https://github.com/sourcebot-dev/sourcebot/security/dependabot/195)
- [GHSA-qp7p-654g-cw7p](https://github.com/advisories/GHSA-qp7p-654g-cw7p)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-1071](https://linear.app/sourcebot/issue/SOU-1071/sourcebot-devsourcebot-cve-2026-44458-hono-jsx-ssr-css-declaration)

<div><a href="https://cursor.com/agents/bc-4c42cf37-079b-49bb-896e-03005da80227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4c42cf37-079b-49bb-896e-03005da80227"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

