### PR TITLE
fix: add postcss resolutions override to address CVE-2026-41305

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
 - Bumped transitive `fast-uri` dependency to `^3.1.2`. [#1181](https://github.com/sourcebot-dev/sourcebot/pull/1181)
 - Upgraded `simple-git` to `3.36.0` to address CVE-2026-6951. [#1183](https://github.com/sourcebot-dev/sourcebot/pull/1183)
+- Added `postcss` resolutions override to force all instances to `^8.5.10` to address CVE-2026-41305. [#1191](https://github.com/sourcebot-dev/sourcebot/pull/1191)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "smol-toml@npm:^1.6.0": "^1.6.1",
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
-        "fast-uri@npm:^3.0.1": "^3.1.2"
+        "fast-uri@npm:^3.0.1": "^3.1.2",
+        "postcss@npm:8.4.31": "^8.5.10"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -17188,7 +17188,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nanoid@npm:^3.3.11, nanoid@npm:^3.3.6":
+"nanoid@npm:^3.3.11":
   version: 3.3.11
   resolution: "nanoid@npm:3.3.11"
   bin:
@@ -18389,17 +18389,6 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
-  languageName: node
-  linkType: hard
-
-"postcss@npm:8.4.31":
-  version: 8.4.31
-  resolution: "postcss@npm:8.4.31"
-  dependencies:
-    nanoid: "npm:^3.3.6"
-    picocolors: "npm:^1.0.0"
-    source-map-js: "npm:^1.0.2"
-  checksum: 10c0/748b82e6e5fc34034dcf2ae88ea3d11fd09f69b6c50ecdd3b4a875cfc7cdca435c958b211e2cb52355422ab6fccb7d8f2f2923161d7a1b281029e4a913d59acf
   languageName: node
   linkType: hard
 
@@ -20595,7 +20584,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"source-map-js@npm:^1.0.2, source-map-js@npm:^1.2.1":
+"source-map-js@npm:^1.2.1":
   version: 1.2.1
   resolution: "source-map-js@npm:1.2.1"
   checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-995

## Summary

This PR adds a Yarn resolutions override to force all PostCSS instances (including the transitive dependency from Next.js) to use version ^8.5.10, which addresses CVE-2026-41305.

## Background

CVE-2026-41305 is an XSS vulnerability in PostCSS versions prior to 8.5.10. The vulnerability allows unescaped `</style>` sequences in CSS AST stringification, which can break out of style contexts and enable XSS attacks.

PR #1155 previously upgraded the direct PostCSS devDependency in `packages/web/package.json` from `^8` to `^8.5.10`. However, Next.js 16.2.3 has a pinned dependency on PostCSS 8.4.31 (vulnerable), which was not addressed by the direct dependency upgrade.

## Changes

- Added `"postcss@npm:8.4.31": "^8.5.10"` to the `resolutions` section in the root `package.json`
- Updated `yarn.lock` to reflect the new resolution (all PostCSS instances now resolve to 8.5.12)

## Verification

Before fix:
```bash
$ yarn why postcss --recursive | grep "8.4.31"
   │     └─ postcss@npm:8.4.31 (via npm:8.4.31)
   │  └─ postcss@npm:8.4.31 (via npm:8.4.31)
```

After fix:
```bash
$ yarn why postcss --recursive | grep "next@npm:16.2.3" -A1
   │  └─ next@npm:16.2.3 [02298] (via npm:^16.2.3 [02298])
   │     └─ postcss@npm:8.5.12 (via npm:^8.5.10)
   ├─ next@npm:16.2.3 [7c8a9] (via npm:^16.2.3 [7c8a9])
   │  └─ postcss@npm:8.5.12 (via npm:^8.5.10)
```

All PostCSS instances now use 8.5.12 (>= 8.5.10, the patched version).

## References

- [CVE-2026-41305](https://nvd.nist.gov/vuln/detail/CVE-2026-41305)
- [GitHub Advisory GHSA-qx2v-qp2m-jg93](https://github.com/postcss/postcss/security/advisories/GHSA-qx2v-qp2m-jg93)
- [PostCSS 8.5.10 Release](https://github.com/postcss/postcss/releases/tag/8.5.10)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-995](https://linear.app/sourcebot/issue/SOU-995/sourcebot-devsourcebot-cve-2026-41305-postcss-xss-via-unescaped-style)

<div><a href="https://cursor.com/agents/bc-4fabcf50-1a84-4dc8-b1c3-f8f23708d3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4fabcf50-1a84-4dc8-b1c3-f8f23708d3b3"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * PostCSS dependency updated to version 8.5.10.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1191)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->