### PR TITLE
fix(backend): opt in to simple-git unsafe categories present in env

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added warning message that fires on startup when host environment contains env vars that simple-git flags as unsafe. [#1193](https://github.com/sourcebot-dev/sourcebot/pull/1193)
+
 ### Fixed
 - Add missing schema changes introduced in [#1170](https://github.com/sourcebot-dev/sourcebot/pull/1170). [#1176](https://github.com/sourcebot-dev/sourcebot/pull/1176)
 - Fixed blame gutter commit navigation to use the file path as it existed at the attributing commit, so clicking a blame line whose commit predates a rename resolves to the correct historical path. [#1178](https://github.com/sourcebot-dev/sourcebot/pull/1178)
@@ -18,9 +21,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)
-
-### Added
-- Added warning message that fires on startup when host environment contains env vars that simple-git flags unsafe. [#1193](https://github.com/sourcebot-dev/sourcebot/pull/1193)
 
 ## [4.17.1] - 2026-05-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `hono` to `^4.12.18` to address CVE-2026-44455, CVE-2026-44456, CVE-2026-44457, CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 - Upgraded `ip-address` to `^10.2.0` to address CVE-2026-42338. [#1189](https://github.com/sourcebot-dev/sourcebot/pull/1189)
 - Upgraded `fast-xml-builder` to `^1.2.0` to address CVE-2026-44664, CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
+- Fixed git operations failing when the host environment contains values that `simple-git`'s new safety checks flag (e.g., `PAGER`, `EDITOR`, `GIT_SSH_COMMAND`). [#1193](https://github.com/sourcebot-dev/sourcebot/pull/1193)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,10 +15,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `hono` to `^4.12.18` to address CVE-2026-44455, CVE-2026-44456, CVE-2026-44457, CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 - Upgraded `ip-address` to `^10.2.0` to address CVE-2026-42338. [#1189](https://github.com/sourcebot-dev/sourcebot/pull/1189)
 - Upgraded `fast-xml-builder` to `^1.2.0` to address CVE-2026-44664, CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
-- Fixed git operations failing when the host environment contains values that `simple-git`'s new safety checks flag (e.g., `PAGER`, `EDITOR`, `GIT_SSH_COMMAND`). [#1193](https://github.com/sourcebot-dev/sourcebot/pull/1193)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)
+
+### Added
+- Added warning message that fires on startup when host environment contains env vars that simple-git flags unsafe. [#1193](https://github.com/sourcebot-dev/sourcebot/pull/1193)
 
 ## [4.17.1] - 2026-05-04
 

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -14,6 +14,8 @@ const logger = createLogger('git-utils');
  * by default to prevent common git vulnerabilities by throwing a exception. To
  * maintain backwards compatibility, we opt to permit these env vars but raise a
  * warning message s.t., system admins are aware.
+ * 
+ * @see https://github.com/steveukx/git-js/blob/main/docs/PLUGIN-UNSAFE-ACTIONS.md
  */
 const { vulnerabilities: envVulnerabilities } = parseEnv(process.env);
 const unsafe = Object.fromEntries(

--- a/packages/backend/src/git.ts
+++ b/packages/backend/src/git.ts
@@ -3,10 +3,30 @@ import { existsSync } from 'node:fs';
 import { mkdir } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { CheckRepoActions, GitConfigScope, simpleGit, SimpleGitProgressEvent } from 'simple-git';
+import { parseEnv } from '@simple-git/argv-parser';
 
 type onProgressFn = (event: SimpleGitProgressEvent) => void;
 
 const logger = createLogger('git-utils');
+
+/**
+ * simple-git blocks certain env vars (e.g., GIT_SSH_COMMAND, GIT_ASKPASS, etc.)
+ * by default to prevent common git vulnerabilities by throwing a exception. To
+ * maintain backwards compatibility, we opt to permit these env vars but raise a
+ * warning message s.t., system admins are aware.
+ */
+const { vulnerabilities: envVulnerabilities } = parseEnv(process.env);
+const unsafe = Object.fromEntries(
+    envVulnerabilities.map(v => [v.category, true] as const)
+);
+
+if (envVulnerabilities.length > 0) {
+    const details = envVulnerabilities.map(v => `  - ${v.category}: ${v.message}`).join('\n');
+    logger.warn(
+        `Opting in to unsafe simple-git categories based on inherited environment:\n${details}\n` +
+        `See https://github.com/steveukx/git-js/blob/main/docs/PLUGIN-UNSAFE-ACTIONS.md`
+    );
+}
 
 /**
  * Creates a simple-git client that has it's working directory
@@ -22,6 +42,7 @@ const createGitClientForPath = (path: string, onProgress?: onProgressFn, signal?
     const git = simpleGit({
         progress: onProgress,
         abort: signal,
+        unsafe,
     })
         .env({
             ...process.env,


### PR DESCRIPTION
## Summary

- simple-git `3.36.0` (the [CVE-2026-6951 upgrade](https://github.com/sourcebot-dev/sourcebot/pull/1183)) introduced a hardening layer via `@simple-git/argv-parser` that throws when the parent process environment contains values it deems unsafe. This includes very common shell vars like `PAGER` and `EDITOR`, as well as legitimate operator-set values like `GIT_SSH_COMMAND` (deploy-key setups), `GIT_SSL_NO_VERIFY` (referenced in [#766](https://github.com/sourcebot-dev/sourcebot/issues/766)), etc. The result was `git clone`/`fetch` failing with `Use of "PAGER" is not permitted without enabling allowUnsafePager` (and similar) on any host with these set.
- This PR parses `process.env` once at module load using `parseEnv` from `@simple-git/argv-parser` and reflects the resulting categories back into simple-git's `unsafe` option, so whatever the operator's environment contains is trusted by default. When any unsafe values are detected, a `logger.warn` lists the categories and messages, with a link to [simple-git's unsafe-actions doc](https://github.com/steveukx/git-js/blob/main/docs/PLUGIN-UNSAFE-ACTIONS.md), so the trust isn't silent.
- Arg-channel risks (alias injection, custom hooks paths, fsmonitor, credential helpers, etc.) remain blocked — only env-driven categories present at startup are opted in.

## Test plan

- [x] On a host with `PAGER=less` set, run a clone and confirm it succeeds (was failing pre-fix).
- [x] Confirm the startup warn log fires and lists the expected categories + messages when `PAGER` / `EDITOR` are set.
- [x] Confirm no warn log fires when the environment is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * App now emits a startup warning when git-related environment variables are detected as unsafe, helping users spot configuration issues that might affect git operations and repository handling.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1193)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->