### PR TITLE
fix: inconsistent left padding in preview file path truncation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `hono` to `^4.12.18` to address CVE-2026-44455, CVE-2026-44456, CVE-2026-44457, CVE-2026-44458. [#1186](https://github.com/sourcebot-dev/sourcebot/pull/1186)
 - Upgraded `ip-address` to `^10.2.0` to address CVE-2026-42338. [#1189](https://github.com/sourcebot-dev/sourcebot/pull/1189)
 - Upgraded `fast-xml-builder` to `^1.2.0` to address CVE-2026-44664, CVE-2026-44665. [#1184](https://github.com/sourcebot-dev/sourcebot/pull/1184)
+- Fixed inconsistent left padding in preview window file path truncation. [#1196](https://github.com/sourcebot-dev/sourcebot/issues/1196)
 
 ### Changed
 - Reduced the log verbosity of the worker by changing various log messages from info to debug. [#1179](https://github.com/sourcebot-dev/sourcebot/pull/1179)

--- a/packages/web/src/app/globals.css
+++ b/packages/web/src/app/globals.css
@@ -307,7 +307,7 @@
 
 .truncate-start {
   direction: rtl;
-  text-align: left;
+  text-align: right;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;


### PR DESCRIPTION
## Summary
- Changed `.truncate-start` CSS `text-align` from `left` to `right` to fix inconsistent ~30% left padding when displaying long file paths in the code preview panel
- The `direction: rtl` combined with `text-align: left` caused flex layout rendering inconsistencies across browsers

Fixes #103



## Test plan
- [ ] Open a search result with a long file path in the preview panel
- [ ] Verify the file path is flush-right with the start truncated (ellipsis on the left)
- [ ] Test across Chrome, Firefox, and Safari to confirm consistent rendering

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed inconsistent left padding in the preview window so truncated file paths align correctly.
  * Adjusted truncation behavior so ellipsized paths display with correct alignment in RTL contexts.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1197)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->