### PR TITLE
chore: add lint workflow for PRs

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,27 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: ["main"]
+
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          submodules: "true"
+      - name: Use Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.x'
+
+      - name: Install
+        run: yarn install --frozen-lockfile
+
+      - name: Lint
+        run: yarn lint

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -19,6 +19,8 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: '20.x'
+          cache: 'yarn'
+          cache-dependency-path: '**/yarn.lock'
 
       - name: Install
         run: yarn install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "scripts": {
         "build": "cross-env SKIP_ENV_VALIDATION=1 yarn workspaces foreach --all --topological run build",
         "test": "yarn workspaces foreach --all --topological run test",
+        "lint": "yarn workspaces foreach --all --topological run lint",
         "dev": "concurrently --kill-others --names \"zoekt,worker,web,schemas\" 'yarn dev:zoekt' 'yarn dev:backend' 'yarn dev:web' 'yarn watch:schemas'",
         "with-env": "cross-env PATH=\"$PWD/bin:$PATH\" dotenv -e .env.development -c --",
         "dev:zoekt": "yarn with-env zoekt-webserver -index .sourcebot/index -rpc",

--- a/packages/web/src/features/agents/review-agent/nodes/githubPrParser.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/githubPrParser.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi, describe } from 'vitest';
+import { Octokit } from 'octokit';
 import { githubPrParser } from './githubPrParser';
 import { GitHubPullRequest } from '../types';
 
@@ -50,7 +51,7 @@ function makePullRequest(overrides: Partial<{
 function makeMockOctokit(diffText: string) {
     return {
         request: vi.fn().mockResolvedValue({ data: diffText }),
-    } as any;
+    } as unknown as Octokit;
 }
 
 describe('githubPrParser', () => {
@@ -80,7 +81,7 @@ describe('githubPrParser', () => {
 
     test('fetches diff using the pull request diff_url', async () => {
         const mockRequest = vi.fn().mockResolvedValue({ data: '' });
-        const octokit = { request: mockRequest } as any;
+        const octokit = { request: mockRequest } as unknown as Octokit;
         const pr = makePullRequest({ diff_url: 'https://github.com/my-org/my-repo/pull/7.diff' });
 
         await githubPrParser(octokit, pr);
@@ -184,7 +185,7 @@ describe('githubPrParser', () => {
     test('throws when the diff request fails', async () => {
         const octokit = {
             request: vi.fn().mockRejectedValue(new Error('Network error')),
-        } as any;
+        } as unknown as Octokit;
         const pr = makePullRequest();
 
         await expect(githubPrParser(octokit, pr)).rejects.toThrow('Network error');

--- a/packages/web/src/features/agents/review-agent/nodes/githubPushPrReviews.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/githubPushPrReviews.test.ts
@@ -1,4 +1,5 @@
 import { expect, test, vi, describe } from 'vitest';
+import { Octokit } from 'octokit';
 import { githubPushPrReviews } from './githubPushPrReviews';
 import { sourcebot_pr_payload, sourcebot_file_diff_review } from '../types';
 
@@ -38,7 +39,7 @@ function makeMockOctokit(createReviewCommentResult: 'resolve' | 'reject' = 'reso
                     : vi.fn().mockRejectedValue(new Error('Unprocessable Entity')),
             },
         },
-    } as any;
+    } as unknown as Octokit;
 }
 
 describe('githubPushPrReviews', () => {
@@ -123,7 +124,7 @@ describe('githubPushPrReviews', () => {
         const mockCreate = vi.fn()
             .mockRejectedValueOnce(new Error('422'))
             .mockResolvedValueOnce({});
-        const octokit = { rest: { pulls: { createReviewComment: mockCreate } } } as any;
+        const octokit = { rest: { pulls: { createReviewComment: mockCreate } } } as unknown as Octokit;
 
         await githubPushPrReviews(octokit, MOCK_PAYLOAD, twoReviews);
 

--- a/packages/web/src/features/agents/review-agent/nodes/gitlabMrParser.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/gitlabMrParser.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, vi, describe } from 'vitest';
+import { Gitlab } from '@gitbeaker/rest';
 import { gitlabMrParser } from './gitlabMrParser';
 import { GitLabMergeRequestPayload } from '../types';
+
+type GitlabClient = InstanceType<typeof Gitlab>;
 
 vi.mock('@sourcebot/shared', () => ({
     createLogger: () => ({
@@ -51,7 +54,7 @@ function makeMockGitlabClient(allDiffsResult: unknown, mrOverrides: Partial<type
             show: vi.fn().mockResolvedValue({ ...MOCK_MR_API_RESPONSE, ...mrOverrides }),
             allDiffs: vi.fn().mockResolvedValue(allDiffsResult),
         },
-    } as any;
+    } as unknown as GitlabClient;
 }
 
 describe('gitlabMrParser', () => {
@@ -100,7 +103,7 @@ describe('gitlabMrParser', () => {
     test('calls show and allDiffs with the correct project id and MR iid', async () => {
         const mockShow = vi.fn().mockResolvedValue(MOCK_MR_API_RESPONSE);
         const mockAllDiffs = vi.fn().mockResolvedValue([]);
-        const client = { MergeRequests: { show: mockShow, allDiffs: mockAllDiffs } } as any;
+        const client = { MergeRequests: { show: mockShow, allDiffs: mockAllDiffs } } as unknown as GitlabClient;
 
         await gitlabMrParser(client, MOCK_MR_PAYLOAD, 'gitlab.com');
 
@@ -244,7 +247,7 @@ describe('gitlabMrParser', () => {
                 show: vi.fn().mockResolvedValue(MOCK_MR_API_RESPONSE),
                 allDiffs: vi.fn().mockRejectedValue(new Error('Network error')),
             },
-        } as any;
+        } as unknown as GitlabClient;
 
         await expect(gitlabMrParser(client, MOCK_MR_PAYLOAD, 'gitlab.com')).rejects.toThrow('Network error');
     });

--- a/packages/web/src/features/agents/review-agent/nodes/gitlabPushMrReviews.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/gitlabPushMrReviews.test.ts
@@ -1,6 +1,9 @@
 import { expect, test, vi, describe } from 'vitest';
+import { Gitlab } from '@gitbeaker/rest';
 import { gitlabPushMrReviews } from './gitlabPushMrReviews';
 import { sourcebot_pr_payload, sourcebot_file_diff_review } from '../types';
+
+type GitlabClient = InstanceType<typeof Gitlab>;
 
 vi.mock('@sourcebot/shared', () => ({
     createLogger: () => ({
@@ -44,7 +47,7 @@ function makeMockClient(discussionResult: 'resolve' | 'reject' = 'resolve') {
         MergeRequestNotes: {
             create: vi.fn().mockResolvedValue({}),
         },
-    } as any;
+    } as unknown as GitlabClient;
 }
 
 describe('gitlabPushMrReviews', () => {
@@ -165,7 +168,7 @@ describe('gitlabPushMrReviews', () => {
         const client = {
             MergeRequestDiscussions: { create: mockCreate },
             MergeRequestNotes: { create: vi.fn().mockResolvedValue({}) },
-        } as any;
+        } as unknown as GitlabClient;
 
         await gitlabPushMrReviews(client, 101, MOCK_PAYLOAD, twoReviews);
 
@@ -178,7 +181,7 @@ describe('gitlabPushMrReviews', () => {
         const client = {
             MergeRequestDiscussions: { create: vi.fn().mockRejectedValue(new Error('500')) },
             MergeRequestNotes: { create: vi.fn().mockRejectedValue(new Error('500')) },
-        } as any;
+        } as unknown as GitlabClient;
 
         await expect(
             gitlabPushMrReviews(client, 101, MOCK_PAYLOAD, SINGLE_REVIEW),


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/lint.yml` that runs on PRs to `main` and executes `yarn lint`.
- Adds a root `lint` script (`yarn workspaces foreach --all --topological run lint`) mirroring the existing `test` script — only `@sourcebot/web` defines a `lint` script today, but new packages with a `lint` script will be picked up automatically.
- Fixes the 11 pre-existing `@typescript-eslint/no-explicit-any` errors in `review-agent` test files so the new workflow lands green. Replaces `as any` casts on mock Octokit / Gitlab clients with `as unknown as Octokit` / `as unknown as GitlabClient`.

## Test plan
- [x] `yarn lint` exits 0 locally (0 errors, 7 pre-existing warnings remain)
- [x] The new `Lint` check appears and passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Set up automated linting workflow to run on pull requests
  * Added a root workspace lint script to run lint across all packages
  * Improved type safety in test infrastructure by replacing loose casts with concrete client typings

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1200)

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1200)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->