### PR TITLE
fix: pin @protobufjs/inquire to 1.1.0 to fix Turbopack incompatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     },
     "packageManager": "yarn@4.7.0",
     "resolutions": {
+        "@protobufjs/inquire": "1.1.0",
         "prettier": "3.5.3",
         "@lezer/common": "1.3.0",
         "qs": "^6.14.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5154,17 +5154,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/inquire@npm:^1.1.0":
+"@protobufjs/inquire@npm:1.1.0":
   version: 1.1.0
   resolution: "@protobufjs/inquire@npm:1.1.0"
   checksum: 10c0/64372482efcba1fb4d166a2664a6395fa978b557803857c9c03500e0ac1013eb4b1aacc9ed851dd5fc22f81583670b4f4431bae186f3373fedcfde863ef5921a
-  languageName: node
-  linkType: hard
-
-"@protobufjs/inquire@npm:^1.1.1":
-  version: 1.1.1
-  resolution: "@protobufjs/inquire@npm:1.1.1"
-  checksum: 10c0/a638d981adabdbdd61fba04e5045e0d2f98fa557eb0e705482a6dc25e84318bc736b0cd4aaee5d6b9941f121b488ece872c203af2a665b6dfefa95c903bb0cc8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- `@protobufjs/inquire@1.1.1` replaced its `eval`-based dynamic require with a plain `require(moduleName)` call. Turbopack rewrites that into a throwing IIFE, so `inquire("fs")` returns `null` and `protobufjs`'s `loadSync` crashes with `Cannot read properties of null (reading 'readFileSync')` when loading `.proto` files (e.g. the zoekt webserver proto used by search).
- Pins `@protobufjs/inquire` to `1.1.0` via a root `resolutions` override until upstream ships a real fix (tracked in [protobufjs/protobuf.js#2214](https://github.com/protobufjs/protobuf.js/issues/2214); maintainer is planning to backport #2237 to 7.x).
- Regression was introduced by 8c51974d (`chore: update protobufjs deps`), which bumped `protobufjs` to 7.5.8 and pulled in the new `inquire` transitively.

## Test plan

- [x] `yarn install` runs cleanly
- [x] Verify only `@protobufjs/inquire@1.1.0` is installed (no nested 1.1.1 under `protobufjs/node_modules`)
- [x] Run the web app in dev mode and execute a search — `/api/stream_search` should return 200 instead of crashing on `null.readFileSync`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency resolution configuration to ensure consistent package versions across installations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1208?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->