### PR TITLE
fix(worker): clean up orphaned zoekt .tmp shard files after every index attempt

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Cleaned up orphaned zoekt `.tmp` shard files on every indexing attempt, not just on failure, so leftovers from previously interrupted runs are removed. [#1214](https://github.com/sourcebot-dev/sourcebot/pull/1214)
+
 ## [4.17.2] - 2026-05-16
 
 ### Added

--- a/packages/backend/src/repoIndexManager.test.ts
+++ b/packages/backend/src/repoIndexManager.test.ts
@@ -56,6 +56,7 @@ vi.mock('./git.js', () => ({
 
 vi.mock('./zoekt.js', () => ({
     indexGitRepository: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+    cleanupTempShards: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock('./posthog.js', () => ({

--- a/packages/backend/src/repoIndexManager.ts
+++ b/packages/backend/src/repoIndexManager.ts
@@ -516,11 +516,15 @@ export class RepoIndexManager {
             const indexDuration_s = durationMs / 1000;
             logger.debug(`Indexed ${repo.name} (id: ${repo.id}) in ${indexDuration_s}s`);
         } catch (error) {
-            // Clean up any temporary shard files left behind by the failed indexing operation.
-            // Zoekt creates .tmp files during indexing which can accumulate if indexing fails repeatedly.
-            logger.warn(`Indexing failed for ${repo.name} (id: ${repo.id}), cleaning up temp shard files...`);
-            await cleanupTempShards(repo);
+            logger.warn(`Indexing failed for ${repo.name} (id: ${repo.id}).`);
             throw error;
+        } finally {
+            // Zoekt writes shards to a .tmp file first, then atomically renames them to their final
+            // name. If the process is killed or interrupted during the rename loop, some .tmp files
+            // may be left behind that zoekt won't clean up on the next run (it only tracks temp
+            // files from the current build). Running cleanup here ensures orphans from previous
+            // interrupted runs are removed.
+            await cleanupTempShards(repo);
         }
 
         return revisions;


### PR DESCRIPTION
## Summary
- Moved `cleanupTempShards` from the `catch` block into a `finally` block in `repoIndexManager.ts` so leftover `.tmp` shard files are cleaned up on every indexing attempt, not just on failure.
- Previously, if a previous run was killed mid-rename (zoekt writes shards to `.tmp` first and atomically renames them), the orphaned `.tmp` files would persist indefinitely — zoekt itself only tracks temp files from the current build, so a subsequent successful run would not remove them.

## Investigation
- https://chat.betterstack.com/team/t306397/chats/48168

## Test plan
- [ ] Verify that successful indexing runs no longer leave behind `.tmp` shard files when orphans exist from a prior interrupted run.
- [ ] Verify that failed indexing runs still trigger cleanup and propagate the original error (the `cleanupTempShards` call is best-effort and does not throw, so it cannot mask the error from `catch`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Temporary shard files are now consistently cleaned up after every indexing attempt, eliminating leftover files from interrupted runs.

* **Documentation**
  * Changelog updated with an "Unreleased" entry noting the cleanup fix.

* **Tests**
  * Test suite updated to cover and validate the new cleanup behavior during indexing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1214?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->