### PR TITLE
fix(worker): extend permission-sync fail-closed to HTTP 410

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where repo permissions could go stale when authentication or token refresh related errors occured. [#1215](https://github.com/sourcebot-dev/sourcebot/pull/1215)
-- [EE] Account-driven permission syncer now also cleans up an account's permission rows when an upstream endpoint returns HTTP 410 Gone, so permissions don't get stuck after an API is removed (e.g. Bitbucket Cloud's CHANGE-2770).
+- [EE] Account-driven permission syncer now also cleans up an account's permission rows when an upstream endpoint returns HTTP 410 Gone, so permissions don't get stuck after an API is removed (e.g. Bitbucket Cloud's CHANGE-2770). [#1216](https://github.com/sourcebot-dev/sourcebot/pull/1216)
 
 ## [4.17.2] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where repo permissions could go stale when authentication or token refresh related errors occured. [#1215](https://github.com/sourcebot-dev/sourcebot/pull/1215)
-- [EE] Account-driven permission syncer now also cleans up an account's permission rows when an upstream endpoint returns HTTP 410 Gone, so permissions don't get stuck after an API is removed (e.g. Bitbucket Cloud's CHANGE-2770). [#1216](https://github.com/sourcebot-dev/sourcebot/pull/1216)
+- [EE] Fixed issue where repo permissions could go stale when an upstream endpoint returned HTTP 410 Gone (e.g. Bitbucket Cloud's CHANGE-2770). [#1216](https://github.com/sourcebot-dev/sourcebot/pull/1216)
 
 ## [4.17.2] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where repo permissions could go stale when authentication or token refresh related errors occured. [#1215](https://github.com/sourcebot-dev/sourcebot/pull/1215)
+- [EE] Account-driven permission syncer now also cleans up an account's permission rows when an upstream endpoint returns HTTP 410 Gone, so permissions don't get stuck after an API is removed (e.g. Bitbucket Cloud's CHANGE-2770).
 
 ## [4.17.2] - 2026-05-16
 

--- a/packages/backend/src/ee/accountPermissionSyncer.ts
+++ b/packages/backend/src/ee/accountPermissionSyncer.ts
@@ -17,7 +17,7 @@ import {
 import { createBitbucketCloudClient, createBitbucketServerClient, getReposForAuthenticatedBitbucketCloudUser, getReposForAuthenticatedBitbucketServerUser } from "../bitbucket.js";
 import { Settings } from "../types.js";
 import { setIntervalAsync } from "../utils.js";
-import { isUnauthorized, isForbidden } from "../errors.js";
+import { isUnauthorized, isForbidden, isGone } from "../errors.js";
 
 const LOG_TAG = 'user-permission-syncer';
 const logger = createLogger(LOG_TAG);
@@ -191,12 +191,14 @@ export class AccountPermissionSyncer {
         } catch (error) {
             // Fail-closed: when the code-host layer signals that the upstream
             // account is permanently unauthorized (token revoked, user
-            // deprovisioned, OAuth grant dead), clear the account's existing
-            // permission rows so the read-side filter stops matching through
-            // them.
+            // deprovisioned, OAuth grant dead) or that the endpoint we depend
+            // on is gone (e.g. Bitbucket Cloud's CHANGE-2770), clear the
+            // account's existing permission rows so the read-side filter stops
+            // matching through them.
             if (
                 isUnauthorized(error) ||
                 isForbidden(error) ||
+                isGone(error) ||
                 error instanceof RefreshTokenError
             ) {
                 await this.db.account.update({

--- a/packages/backend/src/ee/accountPermissionSyncer.ts
+++ b/packages/backend/src/ee/accountPermissionSyncer.ts
@@ -195,20 +195,19 @@ export class AccountPermissionSyncer {
             // on is gone (e.g. Bitbucket Cloud's CHANGE-2770), clear the
             // account's existing permission rows so the read-side filter stops
             // matching through them.
-            if (
-                isUnauthorized(error) ||
-                isForbidden(error) ||
-                isGone(error) ||
-                error instanceof RefreshTokenError
-            ) {
-                await this.db.account.update({
-                    where: { id: account.id },
-                    data: {
-                        accessibleRepos: {
-                            deleteMany: {},
-                        },
-                    },
+            const reason =
+                error instanceof RefreshTokenError ? 'token refresh failure' :
+                isUnauthorized(error) ? 'HTTP 401 Unauthorized' :
+                isForbidden(error) ? 'HTTP 403 Forbidden' :
+                isGone(error) ? 'HTTP 410 Gone' :
+                null;
+
+            if (reason !== null) {
+                const { count } = await this.db.accountToRepoPermission.deleteMany({
+                    where: { accountId: account.id },
                 });
+                const message = error instanceof Error ? error.message : String(error);
+                logger.warn(`Cleared ${count} permission row(s) for account ${account.id} (user ${account.user.email ?? 'unknown'}) — fail-closed cleanup triggered by ${reason}: ${message}`);
             }
             throw error;
         }

--- a/packages/backend/src/errors.test.ts
+++ b/packages/backend/src/errors.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, test } from 'vitest';
 import { RequestError } from '@octokit/request-error';
 import { GitbeakerRequestError } from '@gitbeaker/requester-utils';
-import { isForbidden, isUnauthorized } from './errors';
+import { isForbidden, isGone, isUnauthorized } from './errors';
 import { throwOnHttpError } from './bitbucket';
 
 // Helper: invoke the openapi-fetch middleware against a synthetic Response and
@@ -145,6 +145,56 @@ describe('isForbidden', () => {
             request: { method: 'GET', url: 'https://api.github.com/user/repos', headers: {} },
         });
         expect(isForbidden(err)).toBe(false);
+    });
+});
+
+describe('isGone', () => {
+    test('Octokit RequestError with status 410', () => {
+        const err = new RequestError('Gone', 410, {
+            request: { method: 'GET', url: 'https://api.github.com/user/repos', headers: {} },
+        });
+        expect(isGone(err)).toBe(true);
+    });
+
+    test('Octokit RequestError with status 401 is NOT gone', () => {
+        const err = new RequestError('Unauthorized', 401, {
+            request: { method: 'GET', url: 'https://api.github.com/user/repos', headers: {} },
+        });
+        expect(isGone(err)).toBe(false);
+    });
+
+    test('Bitbucket middleware throws an isGone error on 410 Response', async () => {
+        // Real-world case: Bitbucket Cloud's CHANGE-2770 removed
+        // /2.0/user/permissions/repositories and now returns 410 Gone.
+        const err = await invokeMiddleware(new Response('CHANGE-2770 - Functionality has been deprecated', { status: 410 }));
+        expect(err).toBeInstanceOf(Error);
+        expect(isGone(err)).toBe(true);
+    });
+
+    test('real GitbeakerRequestError with response status 410', () => {
+        const err = new GitbeakerRequestError('Gone', {
+            cause: {
+                description: 'Gone',
+                request: new Request('https://gitlab.com/api/v4/projects'),
+                response: new Response(null, { status: 410 }),
+            },
+        });
+        expect(isGone(err)).toBe(true);
+    });
+
+    test('plain Error without status is NOT gone', () => {
+        expect(isGone(new Error('Missing required scope'))).toBe(false);
+    });
+
+    test('null is NOT gone', () => {
+        expect(isGone(null)).toBe(false);
+    });
+
+    test('Octokit RequestError with status 500 is NOT gone', () => {
+        const err = new RequestError('Internal Server Error', 500, {
+            request: { method: 'GET', url: 'https://api.github.com/user/repos', headers: {} },
+        });
+        expect(isGone(err)).toBe(false);
     });
 });
 

--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -27,3 +27,4 @@ const getStatus = (err: unknown): number | null => {
 
 export const isUnauthorized = (err: unknown): boolean => getStatus(err) === 401;
 export const isForbidden = (err: unknown): boolean => getStatus(err) === 403;
+export const isGone = (err: unknown): boolean => getStatus(err) === 410;


### PR DESCRIPTION
PR #1215 added a fail-closed branch in the account-driven permission syncer (`accountPermissionSyncer.runJob`) that clears an account's `AccountToRepoPermission` rows when the upstream call throws **401**, **403**, or a token-refresh error. The predicate set is too narrow for endpoint deprecations:

Bitbucket Cloud's [CHANGE-2770](https://developer.atlassian.com/cloud/bitbucket/changelog#CHANGE-2770) removed `GET /2.0/user/permissions/repositories` and the endpoint now returns HTTP 410 Gone for every caller. With the existing predicate, the syncer aborts without clearing the account's rows, so stale permissions persist indefinitely. This PR makes 410 errors trigger that clean up logic

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Account permissions are now reliably removed when an upstream API returns HTTP 410 Gone, preventing stale access after an external resource is removed.
  * Improved upstream error classification to ensure consistent permission cleanup for permanently gone endpoints.

* **Tests**
  * Added coverage validating detection of upstream "gone" (410) responses across different client behaviors.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1216?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->