### PR TITLE
fix(worker): replace Bitbucket Cloud user-repos endpoint removed by CHANGE-2770

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where repo permissions could go stale when authentication or token refresh related errors occured. [#1215](https://github.com/sourcebot-dev/sourcebot/pull/1215)
-- [EE] Fixed Bitbucket Cloud account-driven permission sync after Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`.
+- [EE] Fixed Bitbucket Cloud account-driven permission sync after Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`. [#1217](https://github.com/sourcebot-dev/sourcebot/pull/1217)
 
 ## [4.17.2] - 2026-05-16
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed issue where repo permissions could go stale when authentication or token refresh related errors occured. [#1215](https://github.com/sourcebot-dev/sourcebot/pull/1215)
+- [EE] Fixed Bitbucket Cloud account-driven permission sync after Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`.
 
 ## [4.17.2] - 2026-05-16
 

--- a/packages/backend/src/bitbucket.ts
+++ b/packages/backend/src/bitbucket.ts
@@ -9,7 +9,6 @@ import micromatch from "micromatch";
 import {
     SchemaRepository as CloudRepository,
     SchemaRepositoryUserPermission as CloudRepositoryUserPermission,
-    SchemaRepositoryPermission as CloudRepositoryPermission,
 } from "@coderabbitai/bitbucket/cloud/openapi";
 import { SchemaRestRepository as ServerRepository } from "@coderabbitai/bitbucket/server/openapi";
 import { processPromiseResults } from "./connectionUtils.js";
@@ -658,26 +657,82 @@ export const getExplicitUserPermissionsForCloudRepo = async (
 };
 
 /**
- * Returns the UUIDs of all private repositories accessible to the authenticated Bitbucket Cloud user.
+ * Returns the UUIDs of all repositories accessible to the authenticated Bitbucket Cloud user.
  * Used for account-driven permission syncing.
- * 
- * @see https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-user-permissions-repositories-get
+ *
+ * @note Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`
+ * (the previous single-call cross-workspace endpoint) and has stated there is no
+ * direct replacement. The recommended path is two-step: enumerate the workspaces
+ * the user is a member of, then enumerate the repositories the user can see
+ * within each workspace.
+ *
+ * `?role=member` returns repositories where the user has at least explicit read
+ * access (including access inherited from workspace admin, project membership,
+ * or group membership). Bitbucket treats workspace admins as having implicit
+ * read on every repo in the workspace, so this query naturally returns the
+ * admin's full set without needing a special case. Conversely, a user with no
+ * grant on a given repo gets nothing back for it, even if the workspace is
+ * shared — Bitbucket enforces the access filter server-side.
+ *
+ * Visibility (public vs. private) is intentionally not filtered server-side.
+ * Sourcebot's read-side prisma extension already short-circuits public repos to
+ * org-wide access, so an ACCOUNT_DRIVEN row on a public repo is harmless; but
+ * not filtering means that during a public↔private visibility flip, the user
+ * never has a window where they're missing an ACCOUNT_DRIVEN row for a repo
+ * they can see upstream.
+ *
+ * @see https://developer.atlassian.com/cloud/bitbucket/changelog/#CHANGE-2770
+ * @see https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get
+ * @see https://developer.atlassian.com/cloud/bitbucket/rest/api-group-repositories/#api-repositories-workspace-get
  */
 export const getReposForAuthenticatedBitbucketCloudUser = async (
     client: BitbucketClient,
 ): Promise<Array<{ uuid: string }>> => {
-    const path = `/user/permissions/repositories` as CloudGetRequestPath;
+    // The `/user/workspaces` path is not in the openapi-fetch typed surface
+    // (the package's bundled types still describe the deprecated paths under
+    // /user/permissions/*), so we cast to CloudGetRequestPath and narrow the
+    // response shape locally to just the fields we use.
+    interface CloudUserWorkspaceAccess {
+        readonly workspace?: { readonly slug?: string };
+    }
 
-    const permissions = await fetchWithRetry(() => getPaginatedCloud<CloudRepositoryPermission>(path, async (p, query) => {
-        const { data } = await client.apiClient.GET(p, {
-            params: { query },
-        });
-        return data;
-    }), 'user repository permissions', logger);
+    const memberships = await fetchWithRetry(
+        () => getPaginatedCloud<CloudUserWorkspaceAccess>(
+            `/user/workspaces` as CloudGetRequestPath,
+            async (path, query) => {
+                const { data } = await client.apiClient.GET(path, { params: { query } });
+                return data;
+            },
+        ),
+        'user workspace memberships',
+        logger,
+    );
 
-    return permissions
-        .filter(p => p.repository?.uuid != null)
-        .map(p => ({ uuid: p.repository!.uuid as string }));
+    const slugs = memberships
+        .map(m => m.workspace?.slug)
+        .filter((slug): slug is string => typeof slug === 'string');
+
+    const reposByWorkspace = await Promise.all(slugs.map(workspace => fetchWithRetry(
+        () => getPaginatedCloud<CloudRepository>(
+            `/repositories/${workspace}` as CloudGetRequestPath,
+            async (path, query) => {
+                const { data } = await client.apiClient.GET(path, {
+                    params: {
+                        path: { workspace },
+                        query: { role: 'member', ...query },
+                    },
+                });
+                return data;
+            },
+        ),
+        `repos for workspace ${workspace}`,
+        logger,
+    )));
+
+    return reposByWorkspace
+        .flat()
+        .filter(repo => repo.uuid != null)
+        .map(repo => ({ uuid: repo.uuid as string }));
 };
 
 /**

--- a/packages/backend/src/bitbucket.ts
+++ b/packages/backend/src/bitbucket.ts
@@ -657,7 +657,7 @@ export const getExplicitUserPermissionsForCloudRepo = async (
 };
 
 /**
- * Returns the UUIDs of all repositories accessible to the authenticated Bitbucket Cloud user.
+ * Returns the UUIDs of all private repositories accessible to the authenticated Bitbucket Cloud user.
  * Used for account-driven permission syncing.
  *
  * @see https://developer.atlassian.com/cloud/bitbucket/rest/api-group-workspaces/#api-user-workspaces-get
@@ -693,7 +693,7 @@ export const getReposForAuthenticatedBitbucketCloudUser = async (
                 const { data } = await client.apiClient.GET(path, {
                     params: {
                         path: { workspace },
-                        query: { role: 'member', ...query },
+                        query: { role: 'member', q: 'is_private=true', ...query },
                     },
                 });
                 return data;


### PR DESCRIPTION
Fixes SOU-1179

## Summary

`GET /2.0/user/permissions/repositories` was removed by Atlassian's CHANGE-2770 and now returns 410 Gone, breaking Bitbucket Cloud account-driven permission sync.

There is no direct replacement. This PR rewrites `getReposForAuthenticatedBitbucketCloudUser` to the two-step pattern Atlassian recommends:

1. `GET /2.0/user/workspaces` — list the workspaces the user belongs to.
2. `GET /2.0/repositories/{workspace}?role=member&q=is_private=true` — list the private repos the user can see in each workspace.

## Test plan

Verified against a live Bitbucket Cloud stack:

- [x] Account-driven sync completes successfully for workspace admins, members, and external collaborators with per-repo grants.
- [x] No over-granting: each user only gets `AccountToRepoPermission` rows for repos they actually have access to in Bitbucket.
- [x] Revoking a grant in Bitbucket propagates to a 404 in Sourcebot on the next sync tick; re-granting restores access.
- [x] Public-repo handling: visibility flips (public↔private) converge correctly once connection sync catches up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)