### PR TITLE
fix(web): reject OAuth account-linking without a signed-in session

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Fixed issue where repo permissions could go stale when an upstream endpoint returned HTTP 410 Gone (e.g. Bitbucket Cloud's CHANGE-2770). [#1216](https://github.com/sourcebot-dev/sourcebot/pull/1216)
 - [EE] Fixed Bitbucket Cloud account-driven permission sync after Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`. [#1217](https://github.com/sourcebot-dev/sourcebot/pull/1217)
 - Fixed issue where session invalidation (signout, user deletion, removal from org) was not reflected by `/api/auth/session`. [#1219](https://github.com/sourcebot-dev/sourcebot/pull/1219)
-- Fixed issue where an OAuth account-linking attempt without a valid signed-in session would silently create an orphan User row instead of rejecting the request.
+- [EE] Fixed issue where an OAuth account-linking attempt without a valid signed-in session would silently create an orphan User row instead of rejecting the request. [#1221](https://github.com/sourcebot-dev/sourcebot/pull/1221)
 ## [4.17.2] - 2026-05-16
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Fixed issue where repo permissions could go stale when an upstream endpoint returned HTTP 410 Gone (e.g. Bitbucket Cloud's CHANGE-2770). [#1216](https://github.com/sourcebot-dev/sourcebot/pull/1216)
 - [EE] Fixed Bitbucket Cloud account-driven permission sync after Atlassian's CHANGE-2770 removed `GET /2.0/user/permissions/repositories`. [#1217](https://github.com/sourcebot-dev/sourcebot/pull/1217)
 - Fixed issue where session invalidation (signout, user deletion, removal from org) was not reflected by `/api/auth/session`. [#1219](https://github.com/sourcebot-dev/sourcebot/pull/1219)
+- Fixed issue where an OAuth account-linking attempt without a valid signed-in session would silently create an orphan User row instead of rejecting the request.
 ## [4.17.2] - 2026-05-16
 
 ### Added

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -242,13 +242,24 @@ const nextAuthResult = NextAuth({
         async signIn({ account }) {
             const matchingProvider = account
                 ? getProviders().find((p) => {
-                    const providerId = typeof p.provider === 'function'
-                        ? p.provider().id
-                        : p.provider.id;
+                    // NextAuth/Auth.js provider factories (e.g. Bitbucket,
+                    // GitHub, GitLab) hardcode a default `id` at the top of
+                    // the returned object and nest the caller's options
+                    // (including any `id` override) under `.options`. At
+                    // runtime the framework merges options over the
+                    // top-level defaults, so the effective provider id can
+                    // live under either field depending on whether the
+                    // caller passed an override. Read `.options.id` first
+                    // and fall back to the top-level `id`.
+                    const config = (
+                        typeof p.provider === 'function'
+                            ? (p.provider as unknown as () => unknown)()
+                            : p.provider
+                    ) as { id?: string; options?: { id?: string } };
+                    const providerId = config.options?.id ?? config.id;
                     return providerId === account.provider;
                 })
                 : undefined;
-
 
             // Refuse OAuth signin for providers configured purely for account
             // linking when no authenticated user is present on the request.
@@ -271,6 +282,7 @@ const nextAuthResult = NextAuth({
             // new orphan identity with no UserToOrg row.
             const isAccountLinkingAttempt = matchingProvider?.purpose === 'account_linking';
             const session = await auth();
+
             if (isAccountLinkingAttempt && session === null) {
                 return false;
             }

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -129,7 +129,7 @@ export const getProviders = () => {
                     } else {
                         if (!user.hashedPassword) {
                             return null;
-                        }
+                    }
 
                         if (!bcrypt.compareSync(password, user.hashedPassword)) {
                             return null;
@@ -241,24 +241,7 @@ const nextAuthResult = NextAuth({
     callbacks: {
         async signIn({ account }) {
             const matchingProvider = account
-                ? getProviders().find((p) => {
-                    // NextAuth/Auth.js provider factories (e.g. Bitbucket,
-                    // GitHub, GitLab) hardcode a default `id` at the top of
-                    // the returned object and nest the caller's options
-                    // (including any `id` override) under `.options`. At
-                    // runtime the framework merges options over the
-                    // top-level defaults, so the effective provider id can
-                    // live under either field depending on whether the
-                    // caller passed an override. Read `.options.id` first
-                    // and fall back to the top-level `id`.
-                    const config = (
-                        typeof p.provider === 'function'
-                            ? (p.provider as unknown as () => unknown)()
-                            : p.provider
-                    ) as { id?: string; options?: { id?: string } };
-                    const providerId = config.options?.id ?? config.id;
-                    return providerId === account.provider;
-                })
+                ? getProviders().find((p) => getEffectiveProviderId(p.provider) === account.provider)
                 : undefined;
 
             // Refuse OAuth signin for providers configured purely for account
@@ -282,7 +265,6 @@ const nextAuthResult = NextAuth({
             // new orphan identity with no UserToOrg row.
             const isAccountLinkingAttempt = matchingProvider?.purpose === 'account_linking';
             const session = await auth();
-
             if (isAccountLinkingAttempt && session === null) {
                 return false;
             }
@@ -417,18 +399,29 @@ export const auth = cache(async (): Promise<Session | null> => {
     return nextAuthResult.auth();
 });
 
+// NextAuth/Auth.js provider factories (e.g. Bitbucket, GitHub, GitLab) hardcode
+// a default `id` at the top of the returned object and nest the caller's
+// options (including any `id` override) under `.options`. At runtime the
+// framework merges options over the top-level defaults, so the effective
+// provider id can live under either field depending on whether the caller
+// passed an override. Read `.options.id` first and fall back to the top-level
+// `id`. The function form of `Provider` is part of the NextAuth type union but
+// unused in this codebase; we handle it for type completeness.
+const getEffectiveProviderId = (provider: Provider): string | undefined => {
+    const config = (
+        typeof provider === 'function'
+            ? (provider as unknown as () => unknown)()
+            : provider
+    ) as { id?: string; options?: { id?: string } };
+    return config.options?.id ?? config.id;
+}
+
 /**
  * Returns the issuer URL for a given auth.js account
  */
 const getIssuerUrlForAccount = async (account: { provider: string; }) => {
-    const providers = getProviders();
-    const matchingProvider = providers.find((provider) => {
-        if (typeof provider.provider === "function") {
-            const providerInfo = provider.provider();
-            return providerInfo.id === account.provider;
-        } else {
-            return provider.provider.id === account.provider;
-        }
-    });
+    const matchingProvider = getProviders().find(
+        (p) => getEffectiveProviderId(p.provider) === account.provider
+    );
     return matchingProvider?.issuerUrl;
 }

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -239,6 +239,44 @@ const nextAuthResult = NextAuth({
         }
     },
     callbacks: {
+        // Refuse OAuth signin for providers configured purely for account
+        // linking when no authenticated user is present on the request.
+        //
+        // Background: @auth/core's handleLoginOrRegister (callback/handle-login.js)
+        // reads the session token from the request and, if it can't decode it
+        // (e.g., the session cookie expired browser-side while the user was
+        // mid-OAuth-dance, or it never made it across the cross-site redirect),
+        // falls through to `createUser({ ...profile })` — silently spawning a
+        // new orphan User row from the OAuth profile. That's correct behavior
+        // for `purpose: "sso"` providers (an unauthenticated user logging in
+        // via SSO should become a new Sourcebot user). It's wrong for
+        // `purpose: "account_linking"` providers: by definition, those should
+        // only ever attach an upstream identity to an *existing* signed-in
+        // user, never mint a new Sourcebot user.
+        //
+        // Returning `false` here short-circuits the callback action with an
+        // `AccessDenied` before handleLoginOrRegister can run, redirecting
+        // the user to the error page instead of leaving them stranded as a
+        // new orphan identity with no UserToOrg row.
+        async signIn({ account }) {
+            if (!account || (account.type !== 'oauth' && account.type !== 'oidc')) {
+                return true;
+            }
+
+            const matchingProvider = getProviders().find((p) => {
+                const providerId = typeof p.provider === 'function'
+                    ? p.provider().id
+                    : p.provider.id;
+                return providerId === account.provider;
+            });
+
+            if (matchingProvider?.purpose !== 'account_linking') {
+                return true;
+            }
+
+            const session = await auth();
+            return session !== null;
+        },
         // Restrict post-auth redirects (sign-in / sign-out, `callbackUrl`,
         // `redirectTo`) to the same origin as the application. This mirrors
         // Auth.js's documented default; we set it explicitly so the protection

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -239,43 +239,45 @@ const nextAuthResult = NextAuth({
         }
     },
     callbacks: {
-        // Refuse OAuth signin for providers configured purely for account
-        // linking when no authenticated user is present on the request.
-        //
-        // Background: @auth/core's handleLoginOrRegister (callback/handle-login.js)
-        // reads the session token from the request and, if it can't decode it
-        // (e.g., the session cookie expired browser-side mid auth flow, or it
-        // never made it across the cross-site redirect),
-        // falls through to `createUser({ ...profile })`, silently spawning a
-        // new orphan User row from the OAuth profile. That's correct behavior
-        // for `purpose: "sso"` providers (an unauthenticated user logging in
-        // via SSO should become a new Sourcebot user). It's wrong for
-        // `purpose: "account_linking"` providers: by definition, those should
-        // only ever attach an upstream identity to an *existing* signed-in
-        // user, never mint a new Sourcebot user.
-        //
-        // Returning `false` here short-circuits the callback action with an
-        // `AccessDenied` before handleLoginOrRegister can run, redirecting
-        // the user to the error page instead of leaving them stranded as a
-        // new orphan identity with no UserToOrg row.
         async signIn({ account }) {
-            if (!account || (account.type !== 'oauth' && account.type !== 'oidc')) {
-                return true;
-            }
-
-            const matchingProvider = getProviders().find((p) => {
+            const matchingProvider = account
+            ? getProviders().find((p) => {
                 const providerId = typeof p.provider === 'function'
-                    ? p.provider().id
-                    : p.provider.id;
+                ? p.provider().id
+                : p.provider.id;
                 return providerId === account.provider;
-            });
-
-            if (matchingProvider?.purpose !== 'account_linking') {
-                return true;
+            })
+            : undefined;
+            
+            const isAccountLinkingAttempt =
+            (account?.type === 'oauth' || account?.type === 'oidc') &&
+            matchingProvider?.purpose === 'account_linking';
+            
+            // Refuse OAuth signin for providers configured purely for account
+            // linking when no authenticated user is present on the request.
+            //
+            // Background: @auth/core's handleLoginOrRegister (callback/handle-login.js)
+            // reads the session token from the request and, if it can't decode it
+            // (e.g., the session cookie expired browser-side mid auth flow, or it
+            // never made it across the cross-site redirect),
+            // falls through to `createUser({ ...profile })`, silently spawning a
+            // new orphan User row from the OAuth profile. That's correct behavior
+            // for `purpose: "sso"` providers (an unauthenticated user logging in
+            // via SSO should become a new Sourcebot user). It's wrong for
+            // `purpose: "account_linking"` providers: by definition, those should
+            // only ever attach an upstream identity to an *existing* signed-in
+            // user, never mint a new Sourcebot user.
+            //
+            // Returning `false` here short-circuits the callback action with an
+            // `AccessDenied` before handleLoginOrRegister can run, redirecting
+            // the user to the error page instead of leaving them stranded as a
+            // new orphan identity with no UserToOrg row.
+            const session = await auth();
+            if (isAccountLinkingAttempt && session === null) {
+                return false;
             }
 
-            const session = await auth();
-            return session !== null;
+            return true;
         },
         // Restrict post-auth redirects (sign-in / sign-out, `callbackUrl`,
         // `redirectTo`) to the same origin as the application. This mirrors

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -244,9 +244,9 @@ const nextAuthResult = NextAuth({
         //
         // Background: @auth/core's handleLoginOrRegister (callback/handle-login.js)
         // reads the session token from the request and, if it can't decode it
-        // (e.g., the session cookie expired browser-side while the user was
-        // mid-OAuth-dance, or it never made it across the cross-site redirect),
-        // falls through to `createUser({ ...profile })` — silently spawning a
+        // (e.g., the session cookie expired browser-side mid auth flow, or it
+        // never made it across the cross-site redirect),
+        // falls through to `createUser({ ...profile })`, silently spawning a
         // new orphan User row from the OAuth profile. That's correct behavior
         // for `purpose: "sso"` providers (an unauthenticated user logging in
         // via SSO should become a new Sourcebot user). It's wrong for

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -241,18 +241,15 @@ const nextAuthResult = NextAuth({
     callbacks: {
         async signIn({ account }) {
             const matchingProvider = account
-            ? getProviders().find((p) => {
-                const providerId = typeof p.provider === 'function'
-                ? p.provider().id
-                : p.provider.id;
-                return providerId === account.provider;
-            })
-            : undefined;
-            
-            const isAccountLinkingAttempt =
-            (account?.type === 'oauth' || account?.type === 'oidc') &&
-            matchingProvider?.purpose === 'account_linking';
-            
+                ? getProviders().find((p) => {
+                    const providerId = typeof p.provider === 'function'
+                        ? p.provider().id
+                        : p.provider.id;
+                    return providerId === account.provider;
+                })
+                : undefined;
+
+
             // Refuse OAuth signin for providers configured purely for account
             // linking when no authenticated user is present on the request.
             //
@@ -272,6 +269,7 @@ const nextAuthResult = NextAuth({
             // `AccessDenied` before handleLoginOrRegister can run, redirecting
             // the user to the error page instead of leaving them stranded as a
             // new orphan identity with no UserToOrg row.
+            const isAccountLinkingAttempt = matchingProvider?.purpose === 'account_linking';
             const session = await auth();
             if (isAccountLinkingAttempt && session === null) {
                 return false;


### PR DESCRIPTION
## Summary

OAuth providers configured with \`purpose: \"account_linking\"\` should only ever attach an identity to an existing signed-in user, never mint a new Sourcebot user. \`@auth/core\` does not know about this distinction and falls back to \`createUser\` when its session lookup returns null, which can happen when the user's session cookie expires while they are on the upstream consent screen. The result is a silent orphan \`User\` row and a confused user.

Add a \`signIn\` callback that refuses the request in that case.

## Test plan

- [x] TypeScript build clean (\`yarn workspace @sourcebot/web build\`).
- [x] Docker image builds and boots cleanly.
- [x] **Live negative path**: sign in as Bob, click Disconnect, click Connect, wait past \`AUTH_SESSION_MAX_AGE_SECONDS\` on the BB consent screen, approve. Expect Sourcebot to land on the error page with no orphan User or Account row created.
- [x] **Live positive path**: sign in as Bob, click Connect, approve on BB within the session lifetime. Expect Pan Owner to link cleanly to Bob.
- [x] **Live regression check**: credentials login still works (no OAuth account on the request, signIn returns true early).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * OAuth account-linking now rejects sign-in attempts without an active authenticated session, preventing orphaned user accounts.
  * Credential sign-in now fails safely when an existing account lacks a stored password, avoiding invalid password checks.

* **Documentation**
  * Changelog updated under Unreleased → Fixed to record these account-linking and credential behavior changes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1221?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->