### PR TITLE
fix(web): match MCP language models by provider and model

### DIFF
--- a/packages/web/src/features/chat/utils.test.ts
+++ b/packages/web/src/features/chat/utils.test.ts
@@ -1,5 +1,5 @@
 import { expect, test, vi } from 'vitest'
-import { fileReferenceToString, getAnswerPartFromAssistantMessage, groupMessageIntoSteps, repairReferences } from './utils'
+import { fileReferenceToString, getAnswerPartFromAssistantMessage, groupMessageIntoSteps, isSameLanguageModelIdentity, repairReferences } from './utils'
 import { FILE_REFERENCE_REGEX, ANSWER_TAG } from './constants';
 import { SBChatMessage, SBChatMessagePart } from './types';
 
@@ -42,6 +42,31 @@ test('fileReferenceToString matches FILE_REFERENCE_REGEX', () => {
             endLine: 60,
         }
     }))).toBe(true);
+});
+
+test('isSameLanguageModelIdentity ignores displayName', () => {
+    expect(isSameLanguageModelIdentity(
+        {
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+            displayName: 'Claude Opus 4.7 (slow, highest quality)',
+        },
+        {
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+        },
+    )).toBe(true);
+
+    expect(isSameLanguageModelIdentity(
+        {
+            provider: 'anthropic',
+            model: 'claude-opus-4-7',
+        },
+        {
+            provider: 'anthropic',
+            model: 'claude-sonnet-4-6',
+        },
+    )).toBe(false);
 });
 
 test('groupMessageIntoSteps returns an empty array when there are no parts', () => {

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -372,6 +372,17 @@ export const getLanguageModelKey = (model: LanguageModelInfo) => {
 }
 
 /**
+ * Checks whether two language model infos refer to the same configured model.
+ *
+ * Unlike getLanguageModelKey, this intentionally ignores displayName because
+ * MCP clients can select models using only the externally visible provider and
+ * model fields.
+ */
+export const isSameLanguageModelIdentity = (a: LanguageModelInfo, b: LanguageModelInfo) => {
+    return a.provider === b.provider && a.model === b.model;
+}
+
+/**
  * Given a file reference and a list of file sources, attempts to resolve the file source that the reference points to.
  */
 export const tryResolveFileReference = (reference: FileReference, sources: FileSource[]): FileSource | undefined => {

--- a/packages/web/src/features/mcp/askCodebase.ts
+++ b/packages/web/src/features/mcp/askCodebase.ts
@@ -1,7 +1,7 @@
 import { sew } from "@/middleware/sew";
 import { getConfiguredLanguageModels, getAISDKLanguageModelAndOptions, generateChatNameFromMessage, updateChatMessages } from "@/features/chat/utils.server";
 import { LanguageModelInfo, SBChatMessage, SearchScope } from "@/features/chat/types";
-import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage, getLanguageModelKey } from "@/features/chat/utils";
+import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage, isSameLanguageModelIdentity } from "@/features/chat/utils";
 import { ErrorCode } from "@/lib/errorCodes";
 import { ServiceError, ServiceErrorException } from "@/lib/serviceError";
 import { withOptionalAuth } from "@/middleware/withAuth";
@@ -58,7 +58,7 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
             let languageModelConfig = configuredModels[0];
             if (requestedLanguageModel) {
                 const matchingModel = configuredModels.find(
-                    (m) => getLanguageModelKey(m) === getLanguageModelKey(requestedLanguageModel)
+                    (m) => isSameLanguageModelIdentity(m, requestedLanguageModel)
                 );
                 if (!matchingModel) {
                     return {


### PR DESCRIPTION
## Summary
- Match MCP-requested language models by provider/model identity instead of the internal displayName-aware key
- Keep displayName in the returned selected model info
- Add a unit test covering displayName-less MCP model selection

## Why
MCP clients can call ask_codebase with the externally documented provider/model fields. If the configured model has a displayName, comparing with getLanguageModelKey includes displayName and rejects an otherwise valid request.

## Test
- yarn workspace @sourcebot/web vitest src/features/chat/utils.test.ts --run

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced internal language model identification utilities for consistent and reliable model matching across features, improving how the system compares model configurations.

* **Tests**
  * Added tests validating language model identity comparison behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1230?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->