### PR TITLE
feat(setup-wizard): improve setup wizard UX and Docker conflict handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Redesigned the app layout with a new collapsible sidebar navigation, replacing the previous top navigation bar. [#1097](https://github.com/sourcebot-dev/sourcebot/pull/1097)
 - Expired offline license keys no longer crash the process. An expired key now degrades to the unlicensed state. [#1109](https://github.com/sourcebot-dev/sourcebot/pull/1109)
+- Improved the `setup-sourcebot` wizard: prompts for a setup directory, clarifies that secrets are stored locally in `.env`, switches multi-select to Tab, hides "No results" until a real search runs, and detects/cleans up conflicting Docker deployments and volumes before starting. [#1232](https://github.com/sourcebot-dev/sourcebot/pull/1232)
 
 ## [4.17.2] - 2026-05-16
 

--- a/packages/setupWizard/package.json
+++ b/packages/setupWizard/package.json
@@ -1,6 +1,6 @@
 {
     "name": "setup-sourcebot",
-    "version": "0.1.3",
+    "version": "0.1.4",
     "description": "CLI wizard for creating a Sourcebot configuration.",
     "type": "module",
     "bin": "./dist/index.js",

--- a/packages/setupWizard/src/azuredevops.ts
+++ b/packages/setupWizard/src/azuredevops.ts
@@ -1,4 +1,5 @@
-import { checkbox, confirm, input, password, select } from '@inquirer/prompts';
+import { confirm, input, password, select } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import type { AzureDevOpsConnectionConfig } from '@sourcebot/schemas/v3/azuredevops.type';
 import type { CollectResult, EnvVars } from './utils.js';
 import { multiInput, note, toEnvKey } from './utils.js';
@@ -57,7 +58,7 @@ export async function collectAzureDevOpsConfig(connectionName: string): Promise<
 
     const envKey = toEnvKey(connectionName, 'TOKEN');
     const token = await password({
-        message: `Azure DevOps Personal Access Token (stored as ${envKey})`,
+        message: `Azure DevOps Personal Access Token (stored locally in .env as ${envKey})`,
         mask: true,
         validate: (v) => !v?.trim() ? 'Token is required' : true,
     });

--- a/packages/setupWizard/src/bitbucket.ts
+++ b/packages/setupWizard/src/bitbucket.ts
@@ -1,4 +1,5 @@
-import { checkbox, confirm, input, password, select } from '@inquirer/prompts';
+import { confirm, input, password, select } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import type { BitbucketConnectionConfig } from '@sourcebot/schemas/v3/bitbucket.type';
 import type { CollectResult, EnvVars } from './utils.js';
 import { multiInput, note, toEnvKey } from './utils.js';
@@ -78,7 +79,7 @@ async function collectBitbucketCloud(
 
         const tokenEnvKey = toEnvKey(connectionName, 'TOKEN');
         const token = await password({
-            message: `API Token (stored as ${tokenEnvKey})`,
+            message: `API Token (stored locally in .env as ${tokenEnvKey})`,
             mask: true,
             validate: (v) => !v?.trim() ? 'Token is required' : true,
         });
@@ -95,7 +96,7 @@ async function collectBitbucketCloud(
 
         const tokenEnvKey = toEnvKey(connectionName, 'TOKEN');
         const token = await password({
-            message: `Access Token (stored as ${tokenEnvKey})`,
+            message: `Access Token (stored locally in .env as ${tokenEnvKey})`,
             mask: true,
             validate: (v) => !v?.trim() ? 'Token is required' : true,
         });
@@ -121,7 +122,7 @@ async function collectBitbucketCloud(
 
         const tokenEnvKey = toEnvKey(connectionName, 'APP_PASSWORD');
         const token = await password({
-            message: `Bitbucket App Password (stored as ${tokenEnvKey})`,
+            message: `Bitbucket App Password (stored locally in .env as ${tokenEnvKey})`,
             mask: true,
             validate: (v) => !v?.trim() ? 'App Password is required' : true,
         });
@@ -193,7 +194,7 @@ async function collectBitbucketServer(
 
     const tokenEnvKey = toEnvKey(connectionName, 'TOKEN');
     const token = await password({
-        message: `Bitbucket HTTP Access Token (stored as ${tokenEnvKey})`,
+        message: `Bitbucket HTTP Access Token (stored locally in .env as ${tokenEnvKey})`,
         mask: true,
         validate: (v) => !v?.trim() ? 'Token is required' : true,
     });

--- a/packages/setupWizard/src/gitea.ts
+++ b/packages/setupWizard/src/gitea.ts
@@ -1,7 +1,8 @@
-import { checkbox, input, password } from '@inquirer/prompts';
+import { input, password } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import type { GiteaConnectionConfig } from '@sourcebot/schemas/v3/gitea.type';
 import type { CollectResult, EnvVars } from './utils.js';
-import { multiInput, toEnvKey } from './utils.js';
+import { INPUT_THEME, multiInput, toEnvKey } from './utils.js';
 
 export async function collectGiteaConfig(connectionName: string): Promise<CollectResult> {
     const env: EnvVars = {};
@@ -10,6 +11,7 @@ export async function collectGiteaConfig(connectionName: string): Promise<Collec
     const url = await input({
         message: 'Gitea URL',
         default: 'https://gitea.com',
+        theme: INPUT_THEME,
         validate: (v) => {
             if (!v?.trim()) {
                 return 'URL is required';
@@ -26,7 +28,7 @@ export async function collectGiteaConfig(connectionName: string): Promise<Collec
 
     const giteaEnvKey = toEnvKey(connectionName, 'TOKEN');
     const giteaToken = await password({
-        message: `Gitea Access Token (stored as ${giteaEnvKey}, leave blank for public repos only)`,
+        message: `Gitea Access Token (stored locally in .env as ${giteaEnvKey}, leave blank for public repos only)`,
         mask: true,
     });
     if (giteaToken.trim()) {

--- a/packages/setupWizard/src/github.ts
+++ b/packages/setupWizard/src/github.ts
@@ -1,8 +1,9 @@
-import { checkbox, input, password } from '@inquirer/prompts';
+import { input, password } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import { select as searchSelect, Separator } from 'inquirer-select-pro';
 import type { GithubConnectionConfig } from '@sourcebot/schemas/v3/github.type';
 import type { CollectResult, EnvVars } from './utils.js';
-import { note, toEnvKey } from './utils.js';
+import { createSearchSelectContext, INPUT_THEME, note, toEnvKey } from './utils.js';
 
 function githubApiBase(url: string): string {
     try {
@@ -75,6 +76,7 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
     const url = await input({
         message: 'GitHub URL',
         default: 'https://github.com',
+        theme: INPUT_THEME,
         validate: (v) => {
             if (!v?.trim()) {
                 return 'URL is required';
@@ -104,7 +106,7 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
 
     const tokenEnvKey = toEnvKey(connectionName, 'TOKEN');
     const token = await password({
-        message: `GitHub Personal Access Token (stored as ${tokenEnvKey}, leave blank for public repos only)`,
+        message: `GitHub Personal Access Token (stored locally in .env as ${tokenEnvKey}, leave blank for public repos only)`,
         mask: true,
     });
     if (token.trim()) {
@@ -125,18 +127,26 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
     });
 
     if (targets.includes('repos')) {
+        const ctx = createSearchSelectContext();
         const repos = await searchSelect<string, true>({
             message: 'Repositories to index (type to search, or type owner/repo)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitHub(apiBase, search, token, 'repo');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitHub(apiBase, search, token, 'repo');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
             validate: (selected) => {
                 for (const opt of selected) {
@@ -151,36 +161,52 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
     }
 
     if (targets.includes('orgs')) {
+        const ctx = createSearchSelectContext();
         const orgs = await searchSelect<string, true>({
             message: 'Organizations to index (type to search)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitHub(apiBase, search, token, 'org');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitHub(apiBase, search, token, 'org');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
         });
         config.orgs = orgs;
     }
 
     if (targets.includes('users')) {
+        const ctx = createSearchSelectContext();
         const users = await searchSelect<string, true>({
             message: 'GitHub users to index (type to search)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitHub(apiBase, search, token, 'user');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitHub(apiBase, search, token, 'user');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
         });
         config.users = users;

--- a/packages/setupWizard/src/gitlab.ts
+++ b/packages/setupWizard/src/gitlab.ts
@@ -1,8 +1,9 @@
-import { checkbox, input, password } from '@inquirer/prompts';
+import { input, password } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import { select as searchSelect, Separator } from 'inquirer-select-pro';
 import type { GitlabConnectionConfig } from '@sourcebot/schemas/v3/gitlab.type';
 import type { CollectResult, EnvVars } from './utils.js';
-import { note, toEnvKey } from './utils.js';
+import { createSearchSelectContext, INPUT_THEME, note, toEnvKey } from './utils.js';
 
 function gitlabApiBase(url: string): string {
     try {
@@ -89,6 +90,7 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
     const url = await input({
         message: 'GitLab URL',
         default: 'https://gitlab.com',
+        theme: INPUT_THEME,
         validate: (v) => {
             if (!v?.trim()) {
                 return 'URL is required';
@@ -114,7 +116,7 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
 
     const gitlabEnvKey = toEnvKey(connectionName, 'TOKEN');
     const gitlabToken = await password({
-        message: `GitLab Personal Access Token (stored as ${gitlabEnvKey}, leave blank for public repos only)`,
+        message: `GitLab Personal Access Token (stored locally in .env as ${gitlabEnvKey}, leave blank for public repos only)`,
         mask: true,
     });
     if (gitlabToken.trim()) {
@@ -143,36 +145,52 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
     }
 
     if (targets.includes('groups')) {
+        const ctx = createSearchSelectContext();
         const groups = await searchSelect<string, true>({
             message: 'Groups to index (type to search)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitLab(apiBase, search, gitlabToken, 'group');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitLab(apiBase, search, gitlabToken, 'group');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
         });
         config.groups = groups;
     }
 
     if (targets.includes('projects')) {
+        const ctx = createSearchSelectContext();
         const projects = await searchSelect<string, true>({
             message: 'Projects to index (type to search, or type group/project)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitLab(apiBase, search, gitlabToken, 'project');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitLab(apiBase, search, gitlabToken, 'project');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
             validate: (selected) => {
                 for (const opt of selected) {
@@ -187,18 +205,26 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
     }
 
     if (targets.includes('users')) {
+        const ctx = createSearchSelectContext();
         const users = await searchSelect<string, true>({
             message: 'Users to index (type to search)',
             multiple: true,
             required: true,
             loop: false,
             clearInputWhenSelected: true,
-            placeholder: 'Type 2+ characters to search...',
+            theme: ctx.theme,
+            placeholder: 'Type to search...',
             options: async (search) => {
-                if (!search || search.length < 2) {
+                ctx.trackSearch(search);
+                if (!search) {
                     return [];
                 }
-                return searchGitLab(apiBase, search, gitlabToken, 'user');
+                ctx.setLoading(true);
+                try {
+                    return await searchGitLab(apiBase, search, gitlabToken, 'user');
+                } finally {
+                    ctx.setLoading(false);
+                }
             },
         });
         config.users = users;

--- a/packages/setupWizard/src/index.ts
+++ b/packages/setupWizard/src/index.ts
@@ -3,8 +3,9 @@ import { confirm, input, select } from '@inquirer/prompts';
 import chalk from 'chalk';
 import ora from 'ora';
 import { spawn } from 'node:child_process';
-import { existsSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { writeFile } from 'fs/promises';
+import { basename } from 'path';
 import { collectAzureDevOpsConfig } from './azuredevops.js';
 import { collectBitbucketConfig } from './bitbucket.js';
 import { collectGenericGitConfig } from './genericGit.js';
@@ -20,6 +21,7 @@ import {
     type EnvVars,
     generateConnectionName,
     generateSecret,
+    INPUT_THEME,
     note,
 } from './utils.js';
 
@@ -53,6 +55,151 @@ async function openBrowserWhenReady(url: string, timeoutMs = 120_000): Promise<v
     }
 }
 
+// Parses the top-level `volumes:` block of a docker-compose.yml and returns the
+// declared volume names. Sufficient for our generated compose file; not a full
+// YAML parser.
+function parseTopLevelVolumes(composeYaml: string): string[] {
+    const names: string[] = [];
+    let inBlock = false;
+    for (const rawLine of composeYaml.split('\n')) {
+        const line = rawLine.replace(/\r$/, '');
+        if (/^volumes:\s*(#.*)?$/.test(line)) {
+            inBlock = true;
+            continue;
+        }
+        if (!inBlock) {
+            continue;
+        }
+        if (/^\s*$/.test(line) || /^\s+/.test(line)) {
+            const m = line.match(/^ {2}([A-Za-z0-9_.-]+):\s*(#.*)?$/);
+            if (m) {
+                names.push(m[1]);
+            }
+            continue;
+        }
+        // Any non-blank, non-indented line ends the top-level volumes block.
+        inBlock = false;
+    }
+    return names;
+}
+
+// Mirrors Docker Compose's project-name normalization for the default case
+// where the project name is derived from the working directory basename.
+function dockerComposeProjectName(): string {
+    return basename(process.cwd())
+        .toLowerCase()
+        .replace(/[^a-z0-9_-]/g, '');
+}
+
+async function listExistingDockerVolumes(expectedNames: string[]): Promise<string[]> {
+    if (expectedNames.length === 0) {
+        return [];
+    }
+    return new Promise<string[]>((resolve) => {
+        const child = spawn('docker', ['volume', 'ls', '--format', '{{.Name}}'], {
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        let out = '';
+        child.stdout?.on('data', (chunk: Buffer) => {
+            out += chunk.toString();
+        });
+        child.on('exit', (code) => {
+            if (code !== 0) {
+                resolve([]);
+                return;
+            }
+            const existing = new Set(out.split('\n').map((l) => l.trim()).filter(Boolean));
+            resolve(expectedNames.filter((name) => existing.has(name)));
+        });
+        child.on('error', () => resolve([]));
+    });
+}
+
+async function removeDockerVolumes(volumes: string[]): Promise<boolean> {
+    if (volumes.length === 0) {
+        return true;
+    }
+    return new Promise<boolean>((resolve) => {
+        const child = spawn('docker', ['volume', 'rm', ...volumes], { stdio: ['ignore', 'ignore', 'pipe'] });
+        let err = '';
+        child.stderr?.on('data', (chunk: Buffer) => {
+            err += chunk.toString();
+        });
+        child.on('exit', (code) => {
+            if (code !== 0 && err.trim()) {
+                console.error(chalk.red('✗ ') + err.trim());
+            }
+            resolve(code === 0);
+        });
+        child.on('error', () => resolve(false));
+    });
+}
+
+type ComposeContainer = { Name: string; Service: string; State: string };
+
+function parseComposePsOutput(output: string): ComposeContainer[] {
+    const trimmed = output.trim();
+    if (!trimmed) {
+        return [];
+    }
+    if (trimmed.startsWith('[')) {
+        try {
+            return JSON.parse(trimmed) as ComposeContainer[];
+        } catch {
+            // fall through to line-based parse
+        }
+    }
+    const containers: ComposeContainer[] = [];
+    for (const line of trimmed.split('\n')) {
+        if (!line.trim()) {
+            continue;
+        }
+        try {
+            containers.push(JSON.parse(line) as ComposeContainer);
+        } catch {
+            // skip unparseable line
+        }
+    }
+    return containers;
+}
+
+async function listComposeContainers(): Promise<ComposeContainer[]> {
+    return new Promise<ComposeContainer[]>((resolve) => {
+        const child = spawn('docker', ['compose', 'ps', '-a', '--format', 'json'], {
+            stdio: ['ignore', 'pipe', 'ignore'],
+        });
+        let out = '';
+        child.stdout?.on('data', (chunk: Buffer) => {
+            out += chunk.toString();
+        });
+        child.on('exit', (code) => {
+            if (code !== 0) {
+                resolve([]);
+                return;
+            }
+            resolve(parseComposePsOutput(out));
+        });
+        child.on('error', () => resolve([]));
+    });
+}
+
+async function runComposeCommand(args: string[], label: string): Promise<boolean> {
+    return new Promise<boolean>((resolve) => {
+        const child = spawn('docker', ['compose', ...args], { stdio: ['ignore', 'ignore', 'pipe'] });
+        let err = '';
+        child.stderr?.on('data', (chunk: Buffer) => {
+            err += chunk.toString();
+        });
+        child.on('exit', (code) => {
+            if (code !== 0 && err.trim()) {
+                console.error(chalk.red('✗ ') + `${label}: ` + err.trim());
+            }
+            resolve(code === 0);
+        });
+        child.on('error', () => resolve(false));
+    });
+}
+
 const PLATFORM_LABELS: Record<string, string> = {
     github: 'GitHub',
     gitlab: 'GitLab',
@@ -74,9 +221,41 @@ async function main() {
 ╚══════╝ ╚═════╝  ╚═════╝ ╚═╝  ╚═╝ ╚═════╝╚══════╝╚═════╝  ╚═════╝    ╚═╝╚═╝
 `);
 
+    const setupDir = await input({
+        message: 'What directory would you like to set up Sourcebot in?',
+        default: 'sourcebot',
+        theme: INPUT_THEME,
+        validate: (v: string) => {
+            if (!v?.trim()) {
+                return 'Directory is required';
+            }
+            return true;
+        },
+    });
+
+    if (existsSync(setupDir)) {
+        const overwrite = await confirm({
+            message: `Directory '${setupDir}' already exists. Do you want to overwrite it?`,
+            default: false,
+        });
+        if (!overwrite) {
+            console.log();
+            console.log(chalk.red('✗ ') + 'Setup cancelled.');
+            process.exit(0);
+        }
+    } else {
+        mkdirSync(setupDir, { recursive: true });
+    }
+
+    process.chdir(setupDir);
+
     const connections: Record<string, ConnectionConfig> = {};
     const allEnv: EnvVars = {};
     const localRepoIndex = new Map<string, number>();
+
+    note(
+        'Code is cloned and indexed locally on this machine. No code is ever transmitted to Sourcebot.',
+    );
 
     // eslint-disable-next-line no-constant-condition
     while (true) {
@@ -154,6 +333,7 @@ async function main() {
     const authUrl = await input({
         message: 'What URL will Sourcebot be hosted at?',
         default: SOURCEBOT_URL,
+        theme: INPUT_THEME,
         validate: (v) => {
             if (!v?.trim()) {
                 return 'URL is required';
@@ -296,10 +476,90 @@ async function main() {
         downloadedCompose = true;
     }
 
+    let leftDeploymentRunning = false;
+
+    if (downloadedCompose) {
+        const containers = await listComposeContainers();
+        const running = containers.filter((c) => c.State === 'running');
+        const stopped = containers.filter((c) => c.State !== 'running');
+
+        if (running.length > 0) {
+            console.log();
+            console.log(chalk.yellow('⚠ ') + 'A Sourcebot deployment is already running in this project:');
+            for (const c of running) {
+                console.log('  ' + chalk.dim('- ') + `${c.Name} ${chalk.dim(`(${c.Service})`)}`);
+            }
+            const stop = await confirm({
+                message: 'Stop and remove the running deployment? (required before any volume changes or restart can apply)',
+                default: true,
+            });
+            if (stop) {
+                const ds = ora('Stopping deployment...').start();
+                const ok = await runComposeCommand(['down'], 'docker compose down');
+                if (ok) {
+                    ds.succeed('Stopped deployment');
+                } else {
+                    ds.fail('Failed to stop deployment');
+                    leftDeploymentRunning = true;
+                }
+            } else {
+                leftDeploymentRunning = true;
+            }
+        } else if (stopped.length > 0) {
+            console.log();
+            console.log(chalk.yellow('⚠ ') + 'Stopped containers from a previous run exist and will conflict on next start:');
+            for (const c of stopped) {
+                console.log('  ' + chalk.dim('- ') + `${c.Name} ${chalk.dim(`(${c.Service})`)}`);
+            }
+            const remove = await confirm({
+                message: 'Remove them now to prevent name conflicts when Sourcebot starts?',
+                default: true,
+            });
+            if (remove) {
+                const rs = ora('Removing containers...').start();
+                const ok = await runComposeCommand(['rm', '-f'], 'docker compose rm');
+                if (ok) {
+                    rs.succeed('Removed containers');
+                } else {
+                    rs.fail('Failed to remove containers');
+                }
+            }
+        }
+    }
+
+    // Volume wipe is only safe (and only succeeds) once nothing is using the volumes.
+    if (downloadedCompose && !leftDeploymentRunning) {
+        const declaredVolumes = parseTopLevelVolumes(readFileSync('docker-compose.yml', 'utf-8'));
+        const project = dockerComposeProjectName();
+        const expectedNames = declaredVolumes.map((v) => `${project}_${v}`);
+        const existing = await listExistingDockerVolumes(expectedNames);
+
+        if (existing.length > 0) {
+            console.log();
+            console.log(chalk.yellow('⚠ ') + 'The following Docker volumes from a previous run already exist:');
+            for (const v of existing) {
+                console.log('  ' + chalk.dim('- ') + v);
+            }
+            const wipe = await confirm({
+                message: 'Wipe these volumes? This will permanently delete any existing Sourcebot data in them.',
+                default: false,
+            });
+            if (wipe) {
+                const ws = ora('Removing volumes...').start();
+                const ok = await removeDockerVolumes(existing);
+                if (ok) {
+                    ws.succeed(`Removed ${existing.length} volume${existing.length === 1 ? '' : 's'}`);
+                } else {
+                    ws.fail('Failed to remove one or more volumes (they may be in use by a running container)');
+                }
+            }
+        }
+    }
+
     console.log();
     console.log(chalk.green('✓ ') + chalk.bold('Your Sourcebot configuration is ready!'));
 
-    if (downloadedCompose) {
+    if (downloadedCompose && !leftDeploymentRunning) {
         const startNow = await confirm({
             message: 'Start Sourcebot now? (runs `docker compose up`)',
             default: true,
@@ -326,6 +586,17 @@ async function main() {
     const nextSteps: string[] = [];
     let step = 1;
 
+    if (leftDeploymentRunning) {
+        nextSteps.push('Your new configuration was saved, but the running deployment is still using the old config.');
+        nextSteps.push('');
+        nextSteps.push(`${step++}. Open ${SOURCEBOT_URL} to use the current deployment as-is.`);
+        nextSteps.push('');
+        nextSteps.push(`${step++}. To apply your new configuration, restart Sourcebot:`);
+        nextSteps.push('   docker compose down && docker compose up');
+        note(nextSteps.join('\n'), 'Sourcebot is already running');
+        return;
+    }
+
     if (!downloadedCompose) {
         nextSteps.push(`${step++}. Download docker-compose.yml:`);
         nextSteps.push(`   curl -o docker-compose.yml ${DOCKER_COMPOSE_URL}`);
@@ -335,7 +606,7 @@ async function main() {
     nextSteps.push(`${step++}. Start Sourcebot:`);
     nextSteps.push('   docker compose up');
     nextSteps.push('');
-    nextSteps.push(`${step}. Open http://localhost:3000`);
+    nextSteps.push(`${step}. Open ${SOURCEBOT_URL}`);
 
     note(nextSteps.join('\n'), 'Next steps');
 }

--- a/packages/setupWizard/src/localRepos.ts
+++ b/packages/setupWizard/src/localRepos.ts
@@ -1,4 +1,5 @@
-import { checkbox, input } from '@inquirer/prompts';
+import { input } from '@inquirer/prompts';
+import { tabCheckbox as checkbox } from './tabCheckbox.js';
 import { existsSync, statSync } from 'fs';
 import { readdir } from 'fs/promises';
 import { homedir } from 'os';

--- a/packages/setupWizard/src/models.ts
+++ b/packages/setupWizard/src/models.ts
@@ -8,7 +8,7 @@ import type {
     LanguageModel,
     OpenAICompatibleLanguageModel,
 } from '@sourcebot/schemas/v3/languageModel.type';
-import { note, type EnvVars } from './utils.js';
+import { INPUT_THEME, note, type EnvVars } from './utils.js';
 
 type Provider = LanguageModel['provider'];
 
@@ -151,7 +151,7 @@ async function ensureApiKey(provider: Provider, env: EnvVars): Promise<string> {
     const envKey = PROVIDER_ENV_KEYS[provider] ?? `${provider.toUpperCase().replace(/-/g, '_')}_API_KEY`;
     if (!env[envKey]) {
         const apiKey = await password({
-            message: `API key (stored as ${envKey})`,
+            message: `API key (stored locally in .env as ${envKey})`,
             mask: true,
             validate: (v) => !v?.trim() ? 'API key is required' : true,
         });
@@ -206,6 +206,7 @@ async function collectModelConfig(
             const apiVersion = await input({
                 message: 'API version',
                 default: '2024-08-01-preview',
+                theme: INPUT_THEME,
                 validate: (v) => !v?.trim() ? 'API version is required' : true,
             });
             const envKey = await ensureApiKey(provider, env);
@@ -229,7 +230,7 @@ async function collectModelConfig(
             if (!useDefaultChain) {
                 if (!env['AWS_ACCESS_KEY_ID']) {
                     env['AWS_ACCESS_KEY_ID'] = await input({
-                        message: 'AWS Access Key ID (stored as AWS_ACCESS_KEY_ID)',
+                        message: 'AWS Access Key ID (stored locally in .env as AWS_ACCESS_KEY_ID)',
                         validate: (v) => !v?.trim() ? 'Access Key ID is required' : true,
                     });
                 }
@@ -237,7 +238,7 @@ async function collectModelConfig(
 
                 if (!env['AWS_SECRET_ACCESS_KEY']) {
                     env['AWS_SECRET_ACCESS_KEY'] = await password({
-                        message: 'AWS Secret Access Key (stored as AWS_SECRET_ACCESS_KEY)',
+                        message: 'AWS Secret Access Key (stored locally in .env as AWS_SECRET_ACCESS_KEY)',
                         mask: true,
                         validate: (v) => !v?.trim() ? 'Secret Access Key is required' : true,
                     });
@@ -248,6 +249,7 @@ async function collectModelConfig(
             config.region = await input({
                 message: 'AWS region',
                 default: 'us-east-1',
+                theme: INPUT_THEME,
                 validate: (v) => !v?.trim() ? 'Region is required' : true,
             });
             return config;
@@ -256,14 +258,15 @@ async function collectModelConfig(
         case 'google-vertex-anthropic': {
             if (!env['GOOGLE_VERTEX_PROJECT']) {
                 env['GOOGLE_VERTEX_PROJECT'] = await input({
-                    message: 'Google Cloud project ID (stored as GOOGLE_VERTEX_PROJECT)',
+                    message: 'Google Cloud project ID (stored locally in .env as GOOGLE_VERTEX_PROJECT)',
                     validate: (v) => !v?.trim() ? 'Project ID is required' : true,
                 });
             }
             if (!env['GOOGLE_VERTEX_REGION']) {
                 env['GOOGLE_VERTEX_REGION'] = await input({
-                    message: 'Google Cloud region (stored as GOOGLE_VERTEX_REGION)',
+                    message: 'Google Cloud region (stored locally in .env as GOOGLE_VERTEX_REGION)',
                     default: 'us-central1',
+                    theme: INPUT_THEME,
                     validate: (v) => !v?.trim() ? 'Region is required' : true,
                 });
             }
@@ -281,7 +284,7 @@ async function collectModelConfig(
             if (!useAppDefault) {
                 if (!env['GOOGLE_APPLICATION_CREDENTIALS']) {
                     env['GOOGLE_APPLICATION_CREDENTIALS'] = await input({
-                        message: 'Path to service account credentials JSON (stored as GOOGLE_APPLICATION_CREDENTIALS)',
+                        message: 'Path to service account credentials JSON (stored locally in .env as GOOGLE_APPLICATION_CREDENTIALS)',
                         validate: (v) => !v?.trim() ? 'Credentials path is required' : true,
                     });
                 }

--- a/packages/setupWizard/src/tabCheckbox.ts
+++ b/packages/setupWizard/src/tabCheckbox.ts
@@ -1,0 +1,308 @@
+// Fork of @inquirer/checkbox that uses Tab (instead of Space) to toggle selection.
+// Kept in sync with @inquirer/checkbox 4.x — only the keybinding and help text differ.
+
+import {
+    createPrompt,
+    isDownKey,
+    isEnterKey,
+    isNumberKey,
+    isTabKey,
+    isUpKey,
+    makeTheme,
+    Separator,
+    useKeypress,
+    useMemo,
+    usePagination,
+    usePrefix,
+    useState,
+    ValidationError,
+    type Theme,
+    type Keybinding,
+} from '@inquirer/core';
+import type { PartialDeep } from '@inquirer/type';
+import { cursorHide } from '@inquirer/ansi';
+import { styleText } from 'node:util';
+import figures from '@inquirer/figures';
+
+type CheckboxTheme = {
+    icon: {
+        checked: string;
+        unchecked: string;
+        cursor: string;
+        disabledChecked: string;
+        disabledUnchecked: string;
+    };
+    style: {
+        disabled: (text: string) => string;
+        renderSelectedChoices: <T>(
+            selectedChoices: ReadonlyArray<NormalizedChoice<T>>,
+            allChoices: ReadonlyArray<NormalizedChoice<T> | Separator>,
+        ) => string;
+        description: (text: string) => string;
+        keysHelpTip: (keys: [key: string, action: string][]) => string | undefined;
+    };
+    i18n: { disabledError: string };
+    keybindings: ReadonlyArray<Keybinding>;
+};
+
+type CheckboxShortcuts = {
+    all?: string | null;
+    invert?: string | null;
+};
+
+type Choice<Value> = {
+    value: Value;
+    name?: string;
+    checkedName?: string;
+    description?: string;
+    short?: string;
+    disabled?: boolean | string;
+    checked?: boolean;
+    type?: never;
+};
+
+type NormalizedChoice<Value> = {
+    value: Value;
+    name: string;
+    checkedName: string;
+    description?: string;
+    short: string;
+    disabled: boolean | string;
+    checked: boolean;
+};
+
+const checkboxTheme: CheckboxTheme = {
+    icon: {
+        checked: styleText('green', figures.circleFilled),
+        unchecked: figures.circle,
+        cursor: figures.pointer,
+        disabledChecked: styleText('green', figures.circleDouble),
+        disabledUnchecked: '-',
+    },
+    style: {
+        disabled: (text: string) => styleText('dim', text),
+        renderSelectedChoices: (selectedChoices) =>
+            selectedChoices.map((choice) => choice.short).join(', '),
+        description: (text: string) => styleText('cyan', text),
+        keysHelpTip: (keys) =>
+            keys
+                .map(([key, action]) => `${styleText('bold', key)} ${styleText('dim', action)}`)
+                .join(styleText('dim', ' • ')),
+    },
+    i18n: { disabledError: 'This option is disabled and cannot be toggled.' },
+    keybindings: [],
+};
+
+function isSelectable<Value>(item: NormalizedChoice<Value> | Separator): item is NormalizedChoice<Value> {
+    return !Separator.isSeparator(item) && !item.disabled;
+}
+
+function isNavigable<Value>(item: NormalizedChoice<Value> | Separator): item is NormalizedChoice<Value> {
+    return !Separator.isSeparator(item);
+}
+
+function isChecked<Value>(item: NormalizedChoice<Value> | Separator): item is NormalizedChoice<Value> {
+    return !Separator.isSeparator(item) && item.checked;
+}
+
+function toggle<Value>(item: NormalizedChoice<Value> | Separator): NormalizedChoice<Value> | Separator {
+    return isSelectable(item) ? { ...item, checked: !item.checked } : item;
+}
+
+function check(checked: boolean) {
+    return function <Value>(item: NormalizedChoice<Value> | Separator): NormalizedChoice<Value> | Separator {
+        return isSelectable(item) ? { ...item, checked } : item;
+    };
+}
+
+function normalizeChoices<Value>(
+    choices: readonly (Separator | Value | Choice<Value>)[],
+): (NormalizedChoice<Value> | Separator)[] {
+    return choices.map((choice) => {
+        if (Separator.isSeparator(choice)) {
+            return choice;
+        }
+        if (typeof choice !== 'object' || choice === null || !('value' in (choice as object))) {
+            const name = String(choice);
+            return {
+                value: choice as Value,
+                name,
+                short: name,
+                checkedName: name,
+                disabled: false,
+                checked: false,
+            };
+        }
+        const c = choice as Choice<Value>;
+        const name = c.name ?? String(c.value);
+        const normalizedChoice: NormalizedChoice<Value> = {
+            value: c.value,
+            name,
+            short: c.short ?? name,
+            checkedName: c.checkedName ?? name,
+            disabled: c.disabled ?? false,
+            checked: c.checked ?? false,
+        };
+        if (c.description) {
+            normalizedChoice.description = c.description;
+        }
+        return normalizedChoice;
+    });
+}
+
+type TabCheckboxConfig<Value> = {
+    message: string;
+    prefix?: string;
+    pageSize?: number;
+    choices: readonly (Separator | Value | Choice<Value>)[];
+    loop?: boolean;
+    required?: boolean;
+    validate?: (
+        choices: readonly NormalizedChoice<Value>[],
+    ) => boolean | string | Promise<string | boolean>;
+    theme?: PartialDeep<Theme<CheckboxTheme>>;
+    shortcuts?: CheckboxShortcuts;
+};
+
+export const tabCheckbox = createPrompt(
+    <Value,>(config: TabCheckboxConfig<Value>, done: (value: Value[]) => void) => {
+        const { pageSize = 7, loop = true, required, validate = () => true } = config;
+        const shortcuts = { all: 'a', invert: 'i', ...config.shortcuts };
+        const theme = makeTheme<CheckboxTheme>(checkboxTheme, config.theme);
+        const { keybindings } = theme;
+        const [status, setStatus] = useState<'idle' | 'done'>('idle');
+        const prefix = usePrefix({ status, theme });
+        const [items, setItems] = useState<(NormalizedChoice<Value> | Separator)[]>(
+            normalizeChoices(config.choices),
+        );
+        const bounds = useMemo(() => {
+            const first = items.findIndex(isNavigable);
+            const last = items.findLastIndex(isNavigable);
+            if (first === -1) {
+                throw new ValidationError('[checkbox prompt] No selectable choices. All choices are disabled.');
+            }
+            return { first, last };
+        }, [items]);
+        const [active, setActive] = useState(bounds.first);
+        const [errorMsg, setError] = useState<string | undefined>();
+
+        useKeypress(async (key) => {
+            if (isEnterKey(key)) {
+                const selection = items.filter(isChecked);
+                const isValid = await validate([...selection]);
+                if (required && !selection.length) {
+                    setError('At least one choice must be selected');
+                } else if (isValid === true) {
+                    setStatus('done');
+                    done(selection.map((choice) => choice.value));
+                } else {
+                    setError(isValid || 'You must select a valid value');
+                }
+            } else if (isUpKey(key, keybindings) || isDownKey(key, keybindings)) {
+                if (errorMsg) {
+                    setError(undefined);
+                }
+                if (
+                    loop ||
+                    (isUpKey(key, keybindings) && active !== bounds.first) ||
+                    (isDownKey(key, keybindings) && active !== bounds.last)
+                ) {
+                    const offset = isUpKey(key, keybindings) ? -1 : 1;
+                    let next = active;
+                    do {
+                        next = (next + offset + items.length) % items.length;
+                    } while (!isNavigable(items[next]!));
+                    setActive(next);
+                }
+            } else if (isTabKey(key)) {
+                const activeItem = items[active];
+                if (activeItem && !Separator.isSeparator(activeItem)) {
+                    if (activeItem.disabled) {
+                        setError(theme.i18n.disabledError);
+                    } else {
+                        setError(undefined);
+                        setItems(items.map((choice, i) => (i === active ? toggle(choice) : choice)));
+                    }
+                }
+            } else if (key.name === shortcuts.all) {
+                const selectAll = items.some((choice) => isSelectable(choice) && !choice.checked);
+                setItems(items.map(check(selectAll)));
+            } else if (key.name === shortcuts.invert) {
+                setItems(items.map(toggle));
+            } else if (isNumberKey(key)) {
+                const selectedIndex = Number(key.name) - 1;
+                let selectableIndex = -1;
+                const position = items.findIndex((item) => {
+                    if (Separator.isSeparator(item)) {
+                        return false;
+                    }
+                    selectableIndex++;
+                    return selectableIndex === selectedIndex;
+                });
+                const selectedItem = items[position];
+                if (selectedItem && isSelectable(selectedItem)) {
+                    setActive(position);
+                    setItems(items.map((choice, i) => (i === position ? toggle(choice) : choice)));
+                }
+            }
+        });
+
+        const message = theme.style.message(config.message, status);
+        let description: string | undefined;
+        const page = usePagination({
+            items,
+            active,
+            renderItem({ item, isActive }) {
+                if (Separator.isSeparator(item)) {
+                    return ` ${item.separator}`;
+                }
+                const cursor = isActive ? theme.icon.cursor : ' ';
+                if (item.disabled) {
+                    const disabledLabel = typeof item.disabled === 'string' ? item.disabled : '(disabled)';
+                    const checkbox = item.checked ? theme.icon.disabledChecked : theme.icon.disabledUnchecked;
+                    return theme.style.disabled(`${cursor}${checkbox} ${item.name} ${disabledLabel}`);
+                }
+                if (isActive) {
+                    description = item.description;
+                }
+                const checkbox = item.checked ? theme.icon.checked : theme.icon.unchecked;
+                const name = item.checked ? item.checkedName : item.name;
+                const color = isActive ? theme.style.highlight : (x: string) => x;
+                return color(`${cursor}${checkbox} ${name}`);
+            },
+            pageSize,
+            loop,
+        });
+
+        if (status === 'done') {
+            const selection = items.filter(isChecked);
+            const answer = theme.style.answer(theme.style.renderSelectedChoices(selection, items));
+            return [prefix, message, answer].filter(Boolean).join(' ');
+        }
+
+        const keys: [string, string][] = [
+            ['↑↓', 'navigate'],
+            ['tab', 'select'],
+        ];
+        if (shortcuts.all) {
+            keys.push([shortcuts.all, 'all']);
+        }
+        if (shortcuts.invert) {
+            keys.push([shortcuts.invert, 'invert']);
+        }
+        keys.push(['⏎', 'submit']);
+        const helpLine = theme.style.keysHelpTip(keys);
+        const lines = [
+            [prefix, message].filter(Boolean).join(' '),
+            page,
+            ' ',
+            description ? theme.style.description(description) : '',
+            errorMsg ? theme.style.error(errorMsg) : '',
+            helpLine,
+        ]
+            .filter(Boolean)
+            .join('\n')
+            .trimEnd();
+        return `${lines}${cursorHide}`;
+    },
+);

--- a/packages/setupWizard/src/utils.ts
+++ b/packages/setupWizard/src/utils.ts
@@ -20,6 +20,53 @@ export type CollectResult = {
     localRepoHostPath?: string;
 };
 
+export const INPUT_THEME = {
+    style: {
+        defaultAnswer: (text: string) => chalk.dim(`(default: ${text})`),
+    },
+};
+
+// Per-prompt theme + filter tracker for `searchSelect` / `multiInput` callers.
+// The theme:
+//   - Renders selections as `a, b, c,` (with trailing comma) so the prompt
+//     visually invites adding more entries on the same line.
+//   - Suppresses the empty-results message when the filter is empty, so
+//     "No results" only appears once the user has actually typed something
+//     that returned zero matches.
+// Each prompt should get its own context so the closure-captured `lastSearch`
+// doesn't bleed between prompts.
+export function createSearchSelectContext() {
+    let lastSearch = '';
+    let isLoading = false;
+    return {
+        trackSearch: (search: string | undefined): void => {
+            lastSearch = search ?? '';
+        },
+        setLoading: (loading: boolean): void => {
+            isLoading = loading;
+        },
+        theme: {
+            style: {
+                renderSelectedOptions: <T>(
+                    selectedOptions: ReadonlyArray<{ focused?: boolean; name?: string; value: T }>,
+                ): string => {
+                    if (selectedOptions.length === 0) {
+                        return '';
+                    }
+                    const items = selectedOptions.map((option) =>
+                        option.focused
+                            ? chalk.inverse(option.name || String(option.value))
+                            : (option.name || String(option.value))
+                    );
+                    return items.join(', ') + ',';
+                },
+                emptyText: (text: string) =>
+                    (lastSearch && !isLoading) ? `${chalk.blue('ℹ')} ${chalk.bold(text)}` : '',
+            },
+        },
+    };
+}
+
 export function generateSecret(bytes: number): string {
     return randomBytes(bytes).toString('base64');
 }
@@ -44,14 +91,17 @@ export async function multiInput(options: {
     placeholder?: string;
     validate?: (value: string) => string | true;
 }): Promise<string[]> {
+    const ctx = createSearchSelectContext();
     return searchSelect<string, true>({
         message: options.message,
         multiple: true,
         required: true,
         loop: false,
         clearInputWhenSelected: true,
-        placeholder: options.placeholder ?? 'Type a value and press space to add, enter to finish',
+        theme: ctx.theme,
+        placeholder: options.placeholder ?? 'Type a value and press tab to add, enter to finish',
         options: async (search) => {
+            ctx.trackSearch(search);
             if (!search) {
                 return [];
             }


### PR DESCRIPTION
Fixes SOU-1206

- Prompt for a setup directory (default `sourcebot`) at the start, creating it if missing and confirming before reusing an existing one — keeps generated files isolated and avoids surprise overwrites of files in the user's cwd.
- Prepend `(default: ...)` to input prompts with a default value so the displayed default is unambiguous (previously rendered as bare `(value)` which read like an example, not a default).
- Replace `space` with `tab` to toggle items in the static "What do you want to index?" multi-select. Forked `@inquirer/checkbox` into a local `tabCheckbox` so both the keybinding and the help line use Tab. This matches the searchable selects (which always used Tab) so the whole wizard is consistent.
- Disambiguate where secrets live: every credential prompt now reads `(stored locally in .env as <KEY>)` instead of just `(stored as ...)`, so users see that secrets are written to a local `.env`, not exported to their shell or baked into compose.
- Add a privacy note above the code-host select: `Code is cloned and indexed locally on this machine. No code is ever transmitted to Sourcebot.` Surfaces the local-first model up front.
- Render multi-select selections with a trailing comma (`alice, bob,`) so it visually reads as a list-in-progress, making it obvious the user can add more entries in the same prompt.
- Suppress `No results.` until the user actually searches and the result is empty. Previously, immediately after selecting an item with `clearInputWhenSelected: true`, the prompt would re-fire `options('')` and flash "No results" even though no real search had run. New per-prompt context tracks the latest filter input and a loading flag so the empty area only renders when there's a real query that returned zero matches and no in-flight request.
- Lower the search threshold to 1 character (was 2) and drop the visible "Type 2+ characters to search" hint — the threshold is now purely background behavior, with a quieter `Type to search...` placeholder.
- After the compose file is available, check for an existing Sourcebot deployment via `docker compose ps -a`. If containers are running, prompt to stop+remove via `docker compose down` (default `Y`); if declined, skip the volume wipe and start prompts and show tailored next-steps explaining the new config won't take effect until the running deployment is restarted. Fixes the original `volume is in use` failure when wipe was attempted with live containers.
- If stopped containers from a previous run exist (no running deployment), prompt to remove them via `docker compose rm -f` (default `Y`) so the next `docker compose up` doesn't fail on a name conflict (e.g. `container_name: sourcebot`).
- After the conflict check (and only if the deployment isn't being kept running), check for the project's named Docker volumes and prompt to wipe them via `docker volume rm` (default `N`). Lets users start cleanly when reinstalling into the same directory.