### PR TITLE
chore(web): use neutral title in post-checkout activation dialog

### DIFF
--- a/packages/web/src/ee/features/lighthouse/licenseActivactionDialog.tsx
+++ b/packages/web/src/ee/features/lighthouse/licenseActivactionDialog.tsx
@@ -157,7 +157,7 @@ export function LicenseActivactionDialog({ userEmail }: CheckoutSuccessModalProp
                         <CheckCircle2 className="h-6 w-6 text-green-600 dark:text-green-400" />
                     </div>
                     <DialogTitle>
-                        {isPolling ? "Finalizing your purchase" : "One more step"}
+                        {isPolling ? "Activating your license" : "One more step"}
                     </DialogTitle>
                     <DialogDescription>
                         {isPolling


### PR DESCRIPTION
## Summary
The post-checkout `LicenseActivactionDialog` polling title read "Finalizing your purchase" — incorrect for the trial-start flow, which hits the same dialog with the same auto-claim sequence. Swap it for "Activating your license", which reads naturally for both paid checkouts and trials. No new state, no signal to propagate.

## Test plan
- [x] Complete a paid checkout → polling dialog title reads "Activating your license"
- [x] Start a free trial from the upsell dialog → same dialog appears with the same title
- [x] Confetti + success toast still fire on activation in both flows

🤖 Generated with [Claude Code](https://claude.com/claude-code)