### PR TITLE
chore(web): license page UI nits

### DIFF
--- a/packages/web/src/app/(app)/settings/license/page.tsx
+++ b/packages/web/src/app/(app)/settings/license/page.tsx
@@ -76,7 +76,11 @@ export default authenticatedPage<LicensePageProps>(async ({ prisma, org }, props
             </div>
             {showUpsell && (
                 <SettingsCard>
-                    <UpsellPanel source="license_settings" returnPath="/settings/license" />
+                    <UpsellPanel
+                        source="license_settings"
+                        returnPath="/settings/license"
+                        licenseState={isOnlineLicenseInactive ? 'expired' : 'free'}
+                    />
                 </SettingsCard>
             )}
             {offlineLicense && (

--- a/packages/web/src/components/ui/alert.tsx
+++ b/packages/web/src/components/ui/alert.tsx
@@ -63,7 +63,7 @@ function AlertAction({ className, ...props }: React.ComponentProps<"div">) {
   return (
     <div
       data-slot="alert-action"
-      className={cn("absolute top-2 right-2", className)}
+      className={cn("absolute top-1/2 right-2 -translate-y-1/2", className)}
       {...props}
     />
   )

--- a/packages/web/src/ee/features/lighthouse/upsellDialog.tsx
+++ b/packages/web/src/ee/features/lighthouse/upsellDialog.tsx
@@ -68,20 +68,27 @@ export function UpsellDialog({ open, onOpenChange, source, returnPath }: UpsellD
                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                     </div>
                 ) : (
-                    <UpsellPanelContent offers={offers} source={source} returnPath={returnPath} variant="dialog" />
+                    <UpsellPanelContent offers={offers} source={source} returnPath={returnPath} variant="dialog" licenseState="free" />
                 )}
             </DialogContent>
         </Dialog>
     );
 }
 
+// Whether the upsell is being shown to a workspace with no usable license at
+// all ('free') or to one with an existing online license that's lapsed
+// ('expired'). Drives the no-trial-eligible copy so an expired-license user
+// doesn't see misleading "free plan" framing.
+export type UpsellLicenseState = 'free' | 'expired';
+
 interface UpsellPanelProps {
     source: UpsellSource;
     returnPath?: string;
     className?: string;
+    licenseState?: UpsellLicenseState;
 }
 
-export function UpsellPanel({ source, returnPath, className }: UpsellPanelProps) {
+export function UpsellPanel({ source, returnPath, className, licenseState = 'free' }: UpsellPanelProps) {
     const { data: offers, isPending, isError } = useOffers();
 
     if (isError) {
@@ -98,7 +105,7 @@ export function UpsellPanel({ source, returnPath, className }: UpsellPanelProps)
 
     return (
         <div className={cn("flex flex-col gap-6", className)}>
-            <UpsellPanelContent offers={offers} source={source} returnPath={returnPath} variant="inline" />
+            <UpsellPanelContent offers={offers} source={source} returnPath={returnPath} variant="inline" licenseState={licenseState} />
         </div>
     );
 }
@@ -108,9 +115,10 @@ interface UpsellPanelContentProps {
     source: UpsellSource;
     returnPath?: string;
     variant: "dialog" | "inline";
+    licenseState: UpsellLicenseState;
 }
 
-function UpsellPanelContent({ offers, source, returnPath, variant }: UpsellPanelContentProps) {
+function UpsellPanelContent({ offers, source, returnPath, variant, licenseState }: UpsellPanelContentProps) {
     const [billingInterval, setBillingInterval] = useState<BillingInterval>("year");
     const [isCheckoutSessionCreating, setIsCheckoutSessionCreating] = useState(false);
     const { data: session } = useSession();
@@ -188,13 +196,20 @@ function UpsellPanelContent({ offers, source, returnPath, variant }: UpsellPanel
         }
         // no trial
         else {
+            if (licenseState === 'expired') {
+                return {
+                    title: "Your license has expired",
+                    description: "Upgrade to continue using paid features.",
+                    buttonText: "Upgrade"
+                }
+            }
             return {
                 title: "Your organization is on the free plan",
                 description: "Upgrade to unlock more features.",
                 buttonText: "Upgrade"
             }
         }
-    }, [isOwner, offers.trial.creditCardRequired, offers.trial.durationDays, offers.trial.eligible]);
+    }, [isOwner, offers.trial.creditCardRequired, offers.trial.durationDays, offers.trial.eligible, licenseState]);
 
     return (
         <>


### PR DESCRIPTION
- Vertically center the action button within the alert (was pinned to the top, looked off-center when title + multi-line description pushed the alert taller).
- Show "Your license has expired. Upgrade to continue using paid features." in the upsell panel on /settings/license when there's an existing online license that's lapsed (canceled/past_due/etc), instead of the generic "Your organization is on the free plan" copy.