### PR TITLE
feat(web): per-user chat preferences for response style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a per-user Chat Preferences settings page where users can tune the chat agent's response style across six dimensions (depth, code visibility, vocabulary, citation density, output structure, diagrams) plus a free-text custom-instructions field, applied as soft biases to the agent's system prompt. [#1243](https://github.com/sourcebot-dev/sourcebot/pull/1243)
+
 ### Changed
 - Documented session lifetime, repository visibility refresh behavior, and how permission sync handles transient code-host errors. [#1218](https://github.com/sourcebot-dev/sourcebot/pull/1218)
 

--- a/packages/db/prisma/migrations/20260528092627_add_chat_preferences/migration.sql
+++ b/packages/db/prisma/migrations/20260528092627_add_chat_preferences/migration.sql
@@ -1,0 +1,3 @@
+-- AlterTable
+ALTER TABLE "User" ADD COLUMN     "chatCustomInstructions" TEXT,
+ADD COLUMN     "chatPreferences" JSONB NOT NULL DEFAULT '{}';

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -380,6 +380,19 @@ model User {
   /// claim baked into the JWT cookie at mint time.
   sessionVersion Int @default(0)
 
+  /// Per-user chat response style preferences. JSON object keyed by dimension
+  /// (depth, codeVisibility, vocabulary, citationDensity, outputStructure,
+  /// diagrams). Each value is a 3-level enum string (see
+  /// `packages/web/src/features/chat/userPreferences.ts`). An empty object
+  /// means no preferences have been set and the agent uses default behavior.
+  chatPreferences Json @default("{}")
+
+  /// Free-text custom instructions appended to the agent's system prompt for
+  /// every chat owned by this user. Length is capped at the application
+  /// layer (see `chatCustomInstructionsSchema`). Null means no custom
+  /// instructions.
+  chatCustomInstructions String?
+
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt
 

--- a/packages/web/src/__mocks__/prisma.ts
+++ b/packages/web/src/__mocks__/prisma.ts
@@ -42,6 +42,8 @@ export const MOCK_USER_WITH_ACCOUNTS: User & { accounts: Account[] } = {
     emailVerified: null,
     image: null,
     sessionVersion: 0,
+    chatPreferences: {},
+    chatCustomInstructions: null,
     accounts: [],
 }
 

--- a/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
+++ b/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useToast } from "@/components/hooks/use-toast";
+import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { LoadingButton } from "@/components/ui/loading-button";
 import { Textarea } from "@/components/ui/textarea";
 import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
@@ -25,6 +26,7 @@ export function ChatPreferencesPage({
     initialCustomInstructions,
 }: ChatPreferencesPageProps) {
     const { toast } = useToast();
+    const captureEvent = useCaptureEvent();
 
     const [preferences, setPreferences] = useState<ChatPreferences>(initialPreferences);
     const [customInstructions, setCustomInstructions] = useState<string>(initialCustomInstructions ?? "");
@@ -102,6 +104,11 @@ export function ChatPreferencesPage({
                 preferences,
                 customInstructions,
             });
+            captureEvent("wa_chat_preferences_saved", {
+                dimensionsSet: Object.keys(preferences).length,
+                hasCustomInstructions: trimmedCustom.length > 0,
+                customInstructionsLength: trimmedCustom.length,
+            });
             toast({
                 title: "Chat preferences saved",
                 description: "Sourcebot will apply these to future chats.",
@@ -115,7 +122,7 @@ export function ChatPreferencesPage({
         } finally {
             setIsSaving(false);
         }
-    }, [preferences, customInstructions, isOverLimit, toast]);
+    }, [preferences, customInstructions, isOverLimit, toast, captureEvent]);
 
     return (
         <div className="flex flex-col gap-8">

--- a/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
+++ b/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
@@ -152,7 +152,6 @@ export function ChatPreferencesPage({
                                 value={currentValue}
                                 onValueChange={(value) => handleDimensionChange(dimension, value)}
                                 variant="outline"
-                                size="sm"
                                 className="flex-wrap justify-start gap-2"
                                 aria-label={spec.label}
                             >
@@ -161,6 +160,7 @@ export function ChatPreferencesPage({
                                         key={level.value}
                                         value={level.value}
                                         aria-label={`${spec.label}: ${level.label}`}
+                                        className="h-9 w-auto min-w-0 px-3"
                                     >
                                         {level.label}
                                     </ToggleGroupItem>

--- a/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
+++ b/packages/web/src/app/(app)/settings/chatPreferences/chatPreferencesPage.tsx
@@ -1,0 +1,218 @@
+'use client';
+
+import { useToast } from "@/components/hooks/use-toast";
+import { LoadingButton } from "@/components/ui/loading-button";
+import { Textarea } from "@/components/ui/textarea";
+import { ToggleGroup, ToggleGroupItem } from "@/components/ui/toggle-group";
+import { updateChatPreferences } from "@/features/chat/actions";
+import {
+    CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH,
+    CHAT_PREFERENCE_SPEC,
+    ChatPreferenceDimension,
+    ChatPreferences,
+    VISIBLE_CHAT_PREFERENCE_DIMENSIONS,
+} from "@/features/chat/userPreferences";
+import { isServiceError } from "@/lib/utils";
+import { useCallback, useMemo, useState } from "react";
+
+interface ChatPreferencesPageProps {
+    initialPreferences: ChatPreferences;
+    initialCustomInstructions: string | null;
+}
+
+export function ChatPreferencesPage({
+    initialPreferences,
+    initialCustomInstructions,
+}: ChatPreferencesPageProps) {
+    const { toast } = useToast();
+
+    const [preferences, setPreferences] = useState<ChatPreferences>(initialPreferences);
+    const [customInstructions, setCustomInstructions] = useState<string>(initialCustomInstructions ?? "");
+    const [isSaving, setIsSaving] = useState(false);
+
+    // Compare current form state against the last-saved baseline to enable/disable
+    // the save button and reset link.
+    const [savedSnapshot, setSavedSnapshot] = useState({
+        preferences: initialPreferences,
+        customInstructions: initialCustomInstructions ?? "",
+    });
+
+    const hasUnsavedChanges = useMemo(() => {
+        if (customInstructions !== savedSnapshot.customInstructions) {
+            return true;
+        }
+        const currentKeys = Object.keys(preferences) as ChatPreferenceDimension[];
+        const savedKeys = Object.keys(savedSnapshot.preferences) as ChatPreferenceDimension[];
+        if (currentKeys.length !== savedKeys.length) {
+            return true;
+        }
+        for (const k of currentKeys) {
+            if (preferences[k] !== savedSnapshot.preferences[k]) {
+                return true;
+            }
+        }
+        return false;
+    }, [preferences, customInstructions, savedSnapshot]);
+
+    const isOverLimit = customInstructions.length > CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH;
+
+    const handleDimensionChange = useCallback((dimension: ChatPreferenceDimension, value: string) => {
+        setPreferences((prev) => {
+            const next: Record<string, string> = { ...prev };
+            if (value === "") {
+                delete next[dimension];
+            } else {
+                // The string value originates from a ToggleGroupItem whose `value`
+                // attribute is one of this dimension's level values; the write
+                // path then validates the full object against `chatPreferencesSchema`.
+                next[dimension] = value;
+            }
+            return next as ChatPreferences;
+        });
+    }, []);
+
+    const handleReset = useCallback(() => {
+        setPreferences(savedSnapshot.preferences);
+        setCustomInstructions(savedSnapshot.customInstructions);
+    }, [savedSnapshot]);
+
+    const handleSave = useCallback(async () => {
+        if (isOverLimit) {
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            const trimmedCustom = customInstructions.trim();
+            const result = await updateChatPreferences({
+                preferences,
+                customInstructions: trimmedCustom.length > 0 ? trimmedCustom : null,
+            });
+
+            if (isServiceError(result)) {
+                toast({
+                    title: "Failed to save chat preferences",
+                    description: result.message,
+                    variant: "destructive",
+                });
+                return;
+            }
+
+            setSavedSnapshot({
+                preferences,
+                customInstructions,
+            });
+            toast({
+                title: "Chat preferences saved",
+                description: "Sourcebot will apply these to future chats.",
+            });
+        } catch (error) {
+            toast({
+                title: "Failed to save chat preferences",
+                description: error instanceof Error ? error.message : String(error),
+                variant: "destructive",
+            });
+        } finally {
+            setIsSaving(false);
+        }
+    }, [preferences, customInstructions, isOverLimit, toast]);
+
+    return (
+        <div className="flex flex-col gap-8">
+            <div>
+                <h3 className="text-lg font-medium">Chat Preferences</h3>
+                <p className="text-sm text-muted-foreground max-w-xl">
+                    Tune how Sourcebot writes its answers. These preferences are applied as soft
+                    biases to every chat you start. They never override the explicit content of
+                    your message, and you can leave any row unset to keep the default behavior.
+                </p>
+            </div>
+
+            <div className="flex flex-col gap-6">
+                {VISIBLE_CHAT_PREFERENCE_DIMENSIONS.map((dimension) => {
+                    const spec = CHAT_PREFERENCE_SPEC[dimension];
+                    const currentValue = preferences[dimension] ?? "";
+                    return (
+                        <div key={dimension} className="flex flex-col gap-2">
+                            <div>
+                                <h4 className="text-sm font-medium">{spec.label}</h4>
+                                <p className="text-sm text-muted-foreground">
+                                    {spec.description}
+                                </p>
+                            </div>
+                            <ToggleGroup
+                                type="single"
+                                value={currentValue}
+                                onValueChange={(value) => handleDimensionChange(dimension, value)}
+                                variant="outline"
+                                size="sm"
+                                className="flex-wrap justify-start gap-2"
+                                aria-label={spec.label}
+                            >
+                                {spec.levels.map((level) => (
+                                    <ToggleGroupItem
+                                        key={level.value}
+                                        value={level.value}
+                                        aria-label={`${spec.label}: ${level.label}`}
+                                    >
+                                        {level.label}
+                                    </ToggleGroupItem>
+                                ))}
+                            </ToggleGroup>
+                        </div>
+                    );
+                })}
+
+                <div className="flex flex-col gap-2">
+                    <div>
+                        <h4 className="text-sm font-medium">Custom instructions</h4>
+                        <p className="text-sm text-muted-foreground">
+                            Anything else you want Sourcebot to keep in mind when answering.
+                            Used as soft guidance, never as an override.
+                        </p>
+                    </div>
+                    <Textarea
+                        value={customInstructions}
+                        onChange={(e) => setCustomInstructions(e.target.value)}
+                        placeholder={
+                            "e.g. \"I'm a PM, not an engineer. Skip implementation details and " +
+                            "focus on what the feature does for end users.\""
+                        }
+                        maxLength={CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH}
+                        className="min-h-[120px]"
+                        aria-label="Custom instructions"
+                    />
+                    <div
+                        className={
+                            isOverLimit
+                                ? "text-xs text-destructive self-end"
+                                : "text-xs text-muted-foreground self-end"
+                        }
+                    >
+                        {customInstructions.length} / {CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH}
+                    </div>
+                </div>
+            </div>
+
+            <div className="flex flex-row gap-2 justify-end items-center">
+                {hasUnsavedChanges && (
+                    <button
+                        type="button"
+                        onClick={handleReset}
+                        className="text-sm text-muted-foreground hover:text-foreground underline-offset-4 hover:underline"
+                        disabled={isSaving}
+                    >
+                        Discard changes
+                    </button>
+                )}
+                <LoadingButton
+                    onClick={handleSave}
+                    loading={isSaving}
+                    disabled={!hasUnsavedChanges || isOverLimit}
+                >
+                    Save changes
+                </LoadingButton>
+            </div>
+        </div>
+    );
+}

--- a/packages/web/src/app/(app)/settings/chatPreferences/page.tsx
+++ b/packages/web/src/app/(app)/settings/chatPreferences/page.tsx
@@ -1,0 +1,19 @@
+import { getChatPreferences } from "@/features/chat/actions";
+import { authenticatedPage } from "@/middleware/authenticatedPage";
+import { isServiceError } from "@/lib/utils";
+import { ServiceErrorException } from "@/lib/serviceError";
+import { ChatPreferencesPage } from "./chatPreferencesPage";
+
+export default authenticatedPage(async () => {
+    const result = await getChatPreferences();
+    if (isServiceError(result)) {
+        throw new ServiceErrorException(result);
+    }
+
+    return (
+        <ChatPreferencesPage
+            initialPreferences={result.preferences}
+            initialCustomInstructions={result.customInstructions}
+        />
+    );
+});

--- a/packages/web/src/app/(app)/settings/layout.tsx
+++ b/packages/web/src/app/(app)/settings/layout.tsx
@@ -100,6 +100,10 @@ export const getSidebarNavItems = async () =>
                     href: `/settings/apiKeys`,
                 }
             ] : []),
+            {
+                title: "Chat Preferences",
+                href: `/settings/chatPreferences`,
+            },
             ...(role === OrgRole.OWNER ? [
                 {
                     title: "Analytics",

--- a/packages/web/src/app/api/(server)/chat/route.ts
+++ b/packages/web/src/app/api/(server)/chat/route.ts
@@ -1,8 +1,9 @@
 import { sew } from "@/middleware/sew";
-import { createMessageStream } from "@/features/chat/agent";
+import { createMessageStream, ResolvedChatUserPreferences } from "@/features/chat/agent";
 import { additionalChatRequestParamsSchema } from "@/features/chat/types";
 import { getLanguageModelKey } from "@/features/chat/utils";
 import { getAISDKLanguageModelAndOptions, getConfiguredLanguageModels, isOwnerOfChat, updateChatMessages } from "@/features/chat/utils.server";
+import { chatPreferencesSchema } from "@/features/chat/userPreferences";
 import { apiHandler } from "@/lib/apiHandler";
 import { ErrorCode } from "@/lib/errorCodes";
 import { captureEvent } from "@/lib/posthog";
@@ -93,6 +94,27 @@ export const POST = apiHandler(async (req: NextRequest) => {
 
             const source = req.headers.get('X-Sourcebot-Client-Source') ?? undefined;
 
+            // Load the user's chat-style preferences. Anonymous users skip this
+            // entirely so the agent uses default behavior with no
+            // `<user_preferences>` block in the system prompt.
+            let userPreferences: ResolvedChatUserPreferences | undefined;
+            if (user) {
+                const row = await prisma.user.findUnique({
+                    where: { id: user.id },
+                    select: {
+                        chatPreferences: true,
+                        chatCustomInstructions: true,
+                    },
+                });
+                if (row) {
+                    const parsed = chatPreferencesSchema.safeParse(row.chatPreferences);
+                    userPreferences = {
+                        preferences: parsed.success ? parsed.data : {},
+                        customInstructions: row.chatCustomInstructions,
+                    };
+                }
+            }
+
             await captureEvent('ask_message_sent', {
                 chatId: id,
                 messageCount: messages.length,
@@ -112,6 +134,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 modelName: languageModelConfig.displayName ?? languageModelConfig.model,
                 modelProviderOptions: providerOptions,
                 modelTemperature: temperature,
+                userPreferences,
                 onFinish: async ({ messages }) => {
                     await updateChatMessages({ chatId: id, messages, prisma });
                 },

--- a/packages/web/src/app/api/(server)/chat/route.ts
+++ b/packages/web/src/app/api/(server)/chat/route.ts
@@ -108,8 +108,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 });
                 if (row) {
                     const parsed = chatPreferencesSchema.safeParse(row.chatPreferences);
+                    // Cast back to the narrower literal-union map: the schema
+                    // is built dynamically so its inferred type widens to
+                    // `string`, but the runtime validation still constrains
+                    // each value to its per-dimension level list.
                     userPreferences = {
-                        preferences: parsed.success ? parsed.data : {},
+                        preferences: parsed.success
+                            ? (parsed.data as ResolvedChatUserPreferences["preferences"])
+                            : {},
                         customInstructions: row.chatCustomInstructions,
                     };
                 }

--- a/packages/web/src/features/chat/actions.ts
+++ b/packages/web/src/features/chat/actions.ts
@@ -582,7 +582,13 @@ export const getChatPreferences = async (): Promise<{
         }
 
         const parsed = chatPreferencesSchema.safeParse(row.chatPreferences);
-        const preferences: ChatPreferences = parsed.success ? parsed.data : {};
+        // The schema is built with a dynamic `z.enum(string[])` so its inferred
+        // type widens each level to `string`. The runtime values are still
+        // validated against the per-dimension level lists, so the cast back to
+        // the narrower `ChatPreferences` literal-union map is sound.
+        const preferences: ChatPreferences = parsed.success
+            ? (parsed.data as ChatPreferences)
+            : {};
 
         return {
             preferences,

--- a/packages/web/src/features/chat/actions.ts
+++ b/packages/web/src/features/chat/actions.ts
@@ -11,6 +11,12 @@ import { ChatVisibility, Prisma } from "@sourcebot/db";
 import { env } from "@sourcebot/shared";
 import { StatusCodes } from "http-status-codes";
 import { SBChatMessage } from "./types";
+import {
+    ChatPreferences,
+    chatPreferencesSchema,
+    updateChatPreferencesInputSchema,
+    type UpdateChatPreferencesInput,
+} from "./userPreferences";
 import { generateChatNameFromMessage, getConfiguredLanguageModels, isChatSharedWithUser, isOwnerOfChat } from "./utils.server";
 
 const auditService = getAuditService();
@@ -549,6 +555,73 @@ export const submitFeedback = async ({
         return { success: true };
     })
 )
+
+/**
+ * Returns the signed-in user's chat preferences and custom instructions.
+ *
+ * The stored JSONB column is parsed through `chatPreferencesSchema` so a
+ * corrupt or out-of-spec value (e.g. left over from a previous schema
+ * version) is silently degraded to an empty object rather than crashing
+ * the settings page.
+ */
+export const getChatPreferences = async (): Promise<{
+    preferences: ChatPreferences,
+    customInstructions: string | null,
+} | ServiceError> => sew(() =>
+    withAuth(async ({ user, prisma }) => {
+        const row = await prisma.user.findUnique({
+            where: { id: user.id },
+            select: {
+                chatPreferences: true,
+                chatCustomInstructions: true,
+            },
+        });
+
+        if (!row) {
+            return notFound();
+        }
+
+        const parsed = chatPreferencesSchema.safeParse(row.chatPreferences);
+        const preferences: ChatPreferences = parsed.success ? parsed.data : {};
+
+        return {
+            preferences,
+            customInstructions: row.chatCustomInstructions,
+        };
+    })
+);
+
+/**
+ * Persists the signed-in user's chat preferences and custom instructions.
+ *
+ * Input is validated end-to-end with `updateChatPreferencesInputSchema` —
+ * unknown dimensions are rejected, level values must match the enum, and
+ * custom instructions are length-capped.
+ */
+export const updateChatPreferences = async (
+    input: UpdateChatPreferencesInput,
+): Promise<{ success: true } | ServiceError> => sew(() =>
+    withAuth(async ({ user, prisma }) => {
+        const parsed = updateChatPreferencesInputSchema.safeParse(input);
+        if (!parsed.success) {
+            return {
+                statusCode: StatusCodes.BAD_REQUEST,
+                errorCode: ErrorCode.INVALID_REQUEST_BODY,
+                message: `Invalid chat preferences: ${parsed.error.message}`,
+            } satisfies ServiceError;
+        }
+
+        await prisma.user.update({
+            where: { id: user.id },
+            data: {
+                chatPreferences: parsed.data.preferences as Prisma.InputJsonValue,
+                chatCustomInstructions: parsed.data.customInstructions,
+            },
+        });
+
+        return { success: true };
+    })
+);
 
 // eslint-disable-next-line authz/require-auth-wrapper -- returns identity provider metadata for the login wall, consulted before auth
 export const getAskGhLoginWallData = async () => sew(async () => {

--- a/packages/web/src/features/chat/agent.ts
+++ b/packages/web/src/features/chat/agent.ts
@@ -17,6 +17,20 @@ import { ANSWER_TAG, FILE_REFERENCE_PREFIX } from "./constants";
 import { Source } from "./types";
 import { addLineNumbers, fileReferenceToString } from "./utils";
 import { createTools } from "./tools";
+import {
+    ChatPreferences,
+    renderChatPreferencesPromptBlock,
+} from "./userPreferences";
+
+/**
+ * Resolved chat-style preferences for the user who is sending this message.
+ * `undefined` means no signed-in user (or no preferences loaded) and the
+ * agent uses default behavior with no `<user_preferences>` block.
+ */
+export interface ResolvedChatUserPreferences {
+    preferences: ChatPreferences;
+    customInstructions: string | null;
+}
 
 const dedent = _dedent.withOptions({ alignValues: true });
 
@@ -43,6 +57,12 @@ interface CreateMessageStreamResponseProps {
     modelProviderOptions?: Record<string, Record<string, JSONValue>>;
     modelTemperature?: number;
     metadata?: Partial<SBChatMessageMetadata>;
+    /**
+     * Per-user response-style preferences. When omitted (e.g. anonymous user
+     * or MCP caller), the agent uses default behavior with no
+     * `<user_preferences>` block injected into the system prompt.
+     */
+    userPreferences?: ResolvedChatUserPreferences;
 }
 
 export const createMessageStream = async ({
@@ -56,6 +76,7 @@ export const createMessageStream = async ({
     modelTemperature,
     onFinish,
     onError,
+    userPreferences,
 }: CreateMessageStreamResponseProps) => {
     const latestMessage = messages[messages.length - 1];
     const sources = latestMessage.parts
@@ -109,6 +130,7 @@ export const createMessageStream = async ({
                 },
                 traceId,
                 chatId,
+                userPreferences,
             });
 
             await mergeStreamAsync(researchStream, writer, {
@@ -154,6 +176,7 @@ interface AgentOptions {
     onWriteSource: (source: Source) => void;
     traceId: string;
     chatId: string;
+    userPreferences?: ResolvedChatUserPreferences;
 }
 
 const createAgentStream = async ({
@@ -166,6 +189,7 @@ const createAgentStream = async ({
     onWriteSource,
     traceId,
     chatId,
+    userPreferences,
 }: AgentOptions) => {
     // For every file source, resolve the source code so that we can include it in the system prompt.
     const fileSources = inputSources.filter((source) => source.type === 'file');
@@ -195,6 +219,7 @@ const createAgentStream = async ({
     const systemPrompt = createPrompt({
         repos: selectedRepos,
         files: resolvedFileSources,
+        userPreferences,
     });
 
     const stream = streamText({
@@ -234,6 +259,7 @@ const createAgentStream = async ({
 const createPrompt = ({
     files,
     repos,
+    userPreferences,
 }: {
     files?: {
         path: string;
@@ -243,7 +269,12 @@ const createPrompt = ({
         revision: string;
     }[],
     repos: string[],
+    userPreferences?: ResolvedChatUserPreferences,
 }) => {
+    const preferencesBlock = userPreferences
+        ? renderChatPreferencesPromptBlock(userPreferences)
+        : null;
+
     return dedent`
     You are a powerful agentic AI code assistant built into Sourcebot, the world's best code-intelligence platform. Your job is to help developers understand and navigate their large codebases.
 
@@ -317,6 +348,8 @@ const createPrompt = ({
     Authentication in Sourcebot is built on NextAuth.js with a session-based approach using JWT tokens and Prisma as the database adapter ${fileReferenceToString({ repo: 'github.com/sourcebot-dev/sourcebot', path: 'auth.ts', range: { startLine: 135, endLine: 140 } })}. The system supports multiple authentication providers and implements organization-based authorization with role-defined permissions.
     \`\`\`
     </answer_instructions>
+
+    ${preferencesBlock ?? ''}
     `
 }
 

--- a/packages/web/src/features/chat/userPreferences.ts
+++ b/packages/web/src/features/chat/userPreferences.ts
@@ -150,6 +150,23 @@ type LevelValueFor<D extends ChatPreferenceDimension> =
 export const CHAT_PREFERENCE_DIMENSIONS = Object.keys(CHAT_PREFERENCE_SPEC) as ChatPreferenceDimension[];
 
 /**
+ * Dimensions to hide from the Settings UI. The data model still accepts these
+ * values (so a maintainer can flip a single boolean to unhide), but the row
+ * does not render on the Chat Preferences page until then.
+ *
+ * `diagrams` is gated because mermaid diagram rendering is a separate
+ * in-flight feature (see PR #1241). When that lands, remove `diagrams` from
+ * this set so the row becomes visible.
+ */
+export const HIDDEN_CHAT_PREFERENCE_DIMENSIONS: ReadonlySet<ChatPreferenceDimension> = new Set([
+    "diagrams",
+]);
+
+export const VISIBLE_CHAT_PREFERENCE_DIMENSIONS = CHAT_PREFERENCE_DIMENSIONS.filter(
+    (d) => !HIDDEN_CHAT_PREFERENCE_DIMENSIONS.has(d),
+);
+
+/**
  * Build a zod object schema whose shape is derived from {@link CHAT_PREFERENCE_SPEC}.
  * Each dimension is an optional enum of its level values, and unknown keys are
  * rejected (`.strict()`) so we never persist garbage to the JSONB column.

--- a/packages/web/src/features/chat/userPreferences.ts
+++ b/packages/web/src/features/chat/userPreferences.ts
@@ -1,0 +1,241 @@
+import { z } from "zod";
+
+/**
+ * Spec for the per-user "Chat Preferences" feature.
+ *
+ * Each dimension is a multiple-choice axis the user can set on the Settings >
+ * Chat Preferences page. The selected value is appended as a soft bias to the
+ * agent's system prompt via `renderChatPreferencesPromptBlock`. A value of
+ * `undefined` (i.e. the dimension is absent from the persisted object) means
+ * the user has not expressed a preference and the agent should fall back to
+ * its default behavior for that axis.
+ *
+ * To add a new dimension: add an entry below and the rest of the system
+ * (zod schema, UI rendering, prompt block) updates automatically.
+ */
+export const CHAT_PREFERENCE_SPEC = {
+    depth: {
+        label: "Depth",
+        description: "How deep should the answer go?",
+        levels: [
+            {
+                value: "full_detail",
+                label: "Full detail",
+                promptHint: "Provide deep, comprehensive answers with full implementation detail.",
+            },
+            {
+                value: "concept_level",
+                label: "Concept-level",
+                promptHint: "Keep answers at the concept level. Avoid implementation detail unless the user explicitly asks for it.",
+            },
+            {
+                value: "one_paragraph",
+                label: "One-paragraph summary",
+                promptHint: "Keep answers brief. Aim for a single paragraph that summarizes the key points.",
+            },
+        ],
+    },
+    codeVisibility: {
+        label: "Code visibility",
+        description: "How much real code should appear in answers?",
+        levels: [
+            {
+                value: "show_full",
+                label: "Show full snippets",
+                promptHint: "Include complete, runnable code snippets where they aid the explanation.",
+            },
+            {
+                value: "show_minimal",
+                label: "Show minimal code",
+                promptHint: "Include only the essential lines of code. Trim or summarize surrounding boilerplate.",
+            },
+            {
+                value: "describe_only",
+                label: "Skip code, describe it",
+                promptHint: "Avoid showing source code. Describe what the code does in plain language instead.",
+            },
+        ],
+    },
+    vocabulary: {
+        label: "Vocabulary",
+        description: "How technical should the language be?",
+        levels: [
+            {
+                value: "jargon_ok",
+                label: "Jargon OK",
+                promptHint: "Use technical terms and acronyms freely. Assume a technical reader.",
+            },
+            {
+                value: "define_terms",
+                label: "Define terms",
+                promptHint: "Define technical terms on first use. Avoid unexplained acronyms.",
+            },
+            {
+                value: "business_framing",
+                label: "Business framing",
+                promptHint: "Frame answers around business impact and outcomes. Minimize implementation jargon.",
+            },
+        ],
+    },
+    citationDensity: {
+        label: "Citation density",
+        description: "How often should answers cite source files?",
+        levels: [
+            {
+                value: "every_claim",
+                label: "Every claim",
+                promptHint: "Cite the relevant source file for every factual claim about the codebase.",
+            },
+            {
+                value: "key_claims",
+                label: "Key claims",
+                promptHint: "Cite source files for the key claims, not every minor detail.",
+            },
+            {
+                value: "sources_at_end",
+                label: "Sources at the end",
+                promptHint: "List the relevant source files at the end of the answer rather than citing inline.",
+            },
+        ],
+    },
+    outputStructure: {
+        label: "Output structure",
+        description: "How should answers be formatted?",
+        levels: [
+            {
+                value: "headers_bullets",
+                label: "Headers + bullets + code",
+                promptHint: "Use markdown headers, bullet lists, and code blocks to structure the answer.",
+            },
+            {
+                value: "plain_prose",
+                label: "Plain prose + bullets",
+                promptHint: "Prefer plain prose with light use of bullet lists. Avoid heavy markdown structure.",
+            },
+            {
+                value: "tldr_three_points",
+                label: "TL;DR + 3 key points",
+                promptHint: "Lead with a one-sentence TL;DR followed by up to 3 key points. Keep it short.",
+            },
+        ],
+    },
+    diagrams: {
+        label: "Diagrams",
+        description: "How often should answers include diagrams?",
+        levels: [
+            {
+                value: "when_useful",
+                label: "When useful",
+                promptHint: "Include a diagram only when it meaningfully aids understanding.",
+            },
+            {
+                value: "often",
+                label: "Often",
+                promptHint: "Bias toward including a diagram when the topic involves flows, sequences, or structures.",
+            },
+            {
+                value: "almost_always",
+                label: "Almost always (visual-first)",
+                promptHint: "Lead with a diagram whenever possible. Treat visualizations as a first-class part of the answer.",
+            },
+        ],
+    },
+} as const;
+
+export type ChatPreferenceDimension = keyof typeof CHAT_PREFERENCE_SPEC;
+
+type LevelValueFor<D extends ChatPreferenceDimension> =
+    typeof CHAT_PREFERENCE_SPEC[D]["levels"][number]["value"];
+
+export const CHAT_PREFERENCE_DIMENSIONS = Object.keys(CHAT_PREFERENCE_SPEC) as ChatPreferenceDimension[];
+
+/**
+ * Build a zod object schema whose shape is derived from {@link CHAT_PREFERENCE_SPEC}.
+ * Each dimension is an optional enum of its level values, and unknown keys are
+ * rejected (`.strict()`) so we never persist garbage to the JSONB column.
+ */
+const buildChatPreferencesSchema = () => {
+    const shape = {} as Record<ChatPreferenceDimension, z.ZodOptional<z.ZodEnum<[string, ...string[]]>>>;
+    for (const dimension of CHAT_PREFERENCE_DIMENSIONS) {
+        const levelValues = CHAT_PREFERENCE_SPEC[dimension].levels.map((l) => l.value);
+        shape[dimension] = z.enum(levelValues as [string, ...string[]]).optional();
+    }
+    return z.object(shape).strict();
+};
+
+export const chatPreferencesSchema = buildChatPreferencesSchema();
+
+export type ChatPreferences = {
+    [D in ChatPreferenceDimension]?: LevelValueFor<D>;
+};
+
+export const CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH = 1000;
+
+export const chatCustomInstructionsSchema = z
+    .string()
+    .max(CHAT_CUSTOM_INSTRUCTIONS_MAX_LENGTH)
+    .nullable();
+
+/**
+ * Full payload accepted by the `updateChatPreferences` server action.
+ */
+export const updateChatPreferencesInputSchema = z.object({
+    preferences: chatPreferencesSchema,
+    customInstructions: chatCustomInstructionsSchema,
+});
+
+export type UpdateChatPreferencesInput = z.infer<typeof updateChatPreferencesInputSchema>;
+
+/**
+ * Renders the `<user_preferences>` block that gets appended to the agent's
+ * system prompt. Returns `null` when the user has no preferences set and no
+ * custom instructions, so callers can cleanly omit the block.
+ *
+ * Soft-bias framing is intentional: preferences must never override
+ * correctness or the explicit content of the user's most recent message.
+ */
+export const renderChatPreferencesPromptBlock = ({
+    preferences,
+    customInstructions,
+}: {
+    preferences: ChatPreferences;
+    customInstructions: string | null;
+}): string | null => {
+    const hints: string[] = [];
+
+    for (const dimension of CHAT_PREFERENCE_DIMENSIONS) {
+        const value = preferences[dimension];
+        if (!value) {
+            continue;
+        }
+        const spec = CHAT_PREFERENCE_SPEC[dimension];
+        const level = spec.levels.find((l) => l.value === value);
+        if (level) {
+            hints.push(`- **${spec.label}**: ${level.promptHint}`);
+        }
+    }
+
+    const trimmedCustom = customInstructions?.trim();
+
+    if (hints.length === 0 && !trimmedCustom) {
+        return null;
+    }
+
+    const sections: string[] = [];
+
+    if (hints.length > 0) {
+        sections.push(
+            "The user has expressed the following response-style preferences. Treat each one as a soft bias that shapes how you write the final answer. Never let these preferences override correctness, override an explicit instruction in the user's most recent message, or cause you to skip steps you would otherwise take.\n\n" +
+                hints.join("\n"),
+        );
+    }
+
+    if (trimmedCustom) {
+        sections.push(
+            "The user has provided the following custom instructions. Apply them when forming your final answer, again as soft guidance that does not override correctness or the explicit user message:\n\n" +
+                `"${trimmedCustom}"`,
+        );
+    }
+
+    return `<user_preferences>\n${sections.join("\n\n")}\n</user_preferences>`;
+};

--- a/packages/web/src/features/mcp/askCodebase.ts
+++ b/packages/web/src/features/mcp/askCodebase.ts
@@ -148,6 +148,10 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
                 } : {}),
             });
 
+            // `userPreferences` is intentionally omitted here. Chat preferences
+            // are a web-app UI feature and there is no MCP-side surface to set
+            // or override them today. Revisit if/when MCP grows a user-settings
+            // story (tracked in #1242).
             const stream = await createMessageStream({
                 chatId: chat.id,
                 messages: [userMessage],

--- a/packages/web/src/lib/posthogEvents.ts
+++ b/packages/web/src/lib/posthogEvents.ts
@@ -185,6 +185,14 @@ export type PosthogEventMap = {
         chatId: string,
         currentVisibility: 'PUBLIC' | 'PRIVATE',
     },
+    wa_chat_preferences_saved: {
+        /** Number of preference dimensions the user has set (0-6). */
+        dimensionsSet: number,
+        /** True if the user supplied any non-empty custom instructions. */
+        hasCustomInstructions: boolean,
+        /** Length of the custom instructions string, for adoption sizing. */
+        customInstructionsLength: number,
+    },
     wa_chat_visibility_changed: {
         chatId: string,
         fromVisibility: 'PUBLIC' | 'PRIVATE',


### PR DESCRIPTION
Fixes #1242

## What this adds

A per-user **Chat Preferences** settings page that lets each signed-in user tune how Sourcebot's chat agent writes its answers. The selections are appended to the agent's system prompt as a `<user_preferences>` block phrased as a soft bias, so they never override correctness or the explicit user message.

## Why

Today the agent writes in one voice for everyone. PMs and VPs asking high-level questions get the same dense, code-heavy answers as engineers asking implementation questions. This is the most-flagged piece of feedback we hear internally from non-engineering users. A per-user preference set lets the same agent serve a wider audience without needing per-team or per-role presets.

## Design

Six dimensions, three levels each (one level is the "default" leftmost, but the user can leave any row unset to keep the truly-default behavior):

| Dimension | Levels |
|---|---|
| **Depth** | Full detail / Concept-level / One-paragraph summary |
| **Code visibility** | Show full snippets / Show minimal code / Skip code, describe it |
| **Vocabulary** | Jargon OK / Define terms / Business framing |
| **Citation density** | Every claim / Key claims / Sources at the end |
| **Output structure** | Headers + bullets + code / Plain prose + bullets / TL;DR + 3 key points |
| **Diagrams** | When useful / Often / Almost always (visual-first) — *gated, see below* |

Plus a **free-text "Custom instructions" textarea**, capped at 1000 chars at the schema layer.

### Key design choices

1. **Internal server actions, not public API.** Matches `apiKeys` / `linked-accounts`. There's no realistic external-script use case for reading/writing another user's prompt-style settings. Easy to promote later if that changes.
2. **Explicit Save button**, not immediate-persist toggles. With 6 dimensions + a textarea, per-field saves would be chatty. Explicit save is also more in line with what users expect for a multi-field settings form.
3. **`ToggleGroup type="single"`** rather than introducing a new `RadioGroup` primitive. The codebase doesn't have one, and a button-bar is fine for 3 options. Open to feedback if you'd prefer I add a real `RadioGroup`.
4. **Diagrams row is gated** behind `HIDDEN_CHAT_PREFERENCE_DIMENSIONS` because inline mermaid rendering (PR #1241) hasn't merged. The data model accepts the value either way, so it's a one-line flip when #1241 lands.
5. **MCP path intentionally not touched.** MCP has no user-settings surface today; passing `undefined` keeps MCP behavior identical. There's a comment at the call site pointing back to #1242.
6. **All-or-nothing soft-bias prompt block.** When the user has set nothing, no `<user_preferences>` block is emitted — zero behavior change for everyone who hasn't visited the settings page.
7. **Defensive JSONB parsing.** `getChatPreferences()` and the chat route both run the stored JSON through `chatPreferencesSchema.safeParse()` so a corrupt or out-of-spec value degrades to `{}` rather than crashing.

## Commits

Split into reviewable chunks. Each commit compiles, lints, and is self-contained:

1. `feat(db): add chatPreferences fields to User model` — pure additive migration
2. `feat(web): add chat preferences validation schema and server actions` — types/zod/prompt helper + `get`/`update` server actions
3. `feat(web): add Chat Preferences settings page` — UI + nav entry
4. `feat(web): apply chat preferences to agent system prompt` — agent integration, chat route loads prefs, MCP path intentionally untouched
5. `feat(web): add posthog event for chat preferences saved` — `wa_chat_preferences_saved` with adoption-only properties (no preference content sent)

## Test plan

- [ ] As a signed-in user, visit Settings → Chat Preferences. The page loads with no preferences selected.
- [ ] Toggle one option in each dimension. Click "Save changes". A success toast appears.
- [ ] Refresh the page. Selections persist.
- [ ] Click an already-selected toggle to clear it. Save. Refresh. Confirm the dimension is cleared.
- [ ] Enter custom instructions, save, reload, confirm round-trip.
- [ ] Type over 1000 chars — the counter turns red and Save is disabled.
- [ ] In a new chat, ask a question and verify the answer style reflects the preferences (e.g. setting "One-paragraph summary" + "Skip code, describe it" should produce a noticeably shorter, prose-only answer).
- [ ] As an anonymous user (if anonymous access is enabled), confirm chat works unchanged — no `<user_preferences>` block should appear in the system prompt.
- [ ] Run `yarn workspace @sourcebot/web lint` — 0 new errors.

## Things I'd particularly appreciate feedback on

- **Prompt placement.** I put the `<user_preferences>` block after `</answer_instructions>` so the model sees it last (recency bias). Open to moving it.
- **Nav placement.** I put "Chat Preferences" immediately after "API Keys". If you'd prefer it grouped differently or under a sub-heading, easy change.
- **Gated diagrams row.** Happy to drop the dimension entirely if you'd rather not have it in the data model until #1241 lands.
- **Custom instructions char limit.** 1000 feels right to me (long enough for a paragraph, short enough not to bloat every prompt). If you'd prefer 500 or 2000, easy change at the zod layer.

## Out of scope (deferred, happy to follow up)

- Per-org default preferences (so an org owner can set the house style)
- Per-chat overrides (some users may want to flip the style for a specific conversation)
- MCP-side preference support
- A "preview your prompt block" affordance on the settings page

## CHANGELOG

Follow-up commit to come once the PR number is assigned, per the workflow used for #1241.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Chat Preferences settings page: configure chat agent response style across six dimensions and enter free-text custom instructions.
  * UI includes per-dimension toggles, a textarea with live character counter and max-length enforcement, and actions to save or discard changes.
  * Saved preferences are applied to personalize the chat agent’s responses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/sourcebot-dev/sourcebot/pull/1243?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->