### PR TITLE
feat(web): track AI provider and model type in ask_message_sent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ask connectors: connect 3rd party MCP servers to your ask agent. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Added progress bar when navigating between pages. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Added a integrated changelog into the sidebar. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
-- [EE] Added `modelProvider` and `model` properties to the `ask_message_sent` analytics event. [#1248](https://github.com/sourcebot-dev/sourcebot/pull/1248)
 
 ### Changed
 - [**Breaking Change**] Changed the default role assignment to `Owner` for organizations on the free tier. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added ask connectors: connect 3rd party MCP servers to your ask agent. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Added progress bar when navigating between pages. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Added a integrated changelog into the sidebar. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
+- [EE] Added `modelProvider` and `model` properties to the `ask_message_sent` analytics event. [#1248](https://github.com/sourcebot-dev/sourcebot/pull/1248)
 
 ### Changed
 - [**Breaking Change**] Changed the default role assignment to `Owner` for organizations on the free tier. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)

--- a/packages/web/src/app/api/(server)/ee/chat/route.ts
+++ b/packages/web/src/app/api/(server)/ee/chat/route.ts
@@ -114,6 +114,8 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 messageCount: messages.length,
                 selectedReposCount: expandedRepos.length,
                 source,
+                modelProvider: languageModelConfig.provider,
+                model: languageModelConfig.model,
                 ...askMcpAvailability,
                 ...(env.EXPERIMENT_ASK_GH_ENABLED === 'true' ? { selectedRepos: expandedRepos } : {}),
             });

--- a/packages/web/src/ee/features/mcp/askCodebase.ts
+++ b/packages/web/src/ee/features/mcp/askCodebase.ts
@@ -154,6 +154,8 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
                 messageCount: 1,
                 selectedReposCount: selectedRepos.length,
                 source,
+                modelProvider: languageModelConfig.provider,
+                model: languageModelConfig.model,
                 hasAskMcpServersAvailable: false,
                 askMcpConnectedServerCount: 0,
                 askMcpEnabledServerCount: 0,

--- a/packages/web/src/lib/posthogEvents.ts
+++ b/packages/web/src/lib/posthogEvents.ts
@@ -186,6 +186,12 @@ export type PosthogEventMap = {
         messageCount: number,
         selectedReposCount: number,
         source?: string,
+        /**
+         * The configured AI provider type (e.g. 'anthropic', 'openai') and
+         * model ID for the language model used to handle this message.
+         */
+        modelProvider: string,
+        model: string,
         hasAskMcpServersAvailable: boolean,
         askMcpConnectedServerCount: number,
         askMcpEnabledServerCount: number,


### PR DESCRIPTION
Fixes SOU-1203

## Summary

Adds `modelProvider` and `model` properties to the `ask_message_sent` PostHog event so Ask usage can be broken down by the configured AI provider type and model.

`ask_message_sent` is the natural home for these: it fires exactly once per user message, on both Ask entry points, and the resolved language model config is already in scope at both call sites.

## Changes

- `posthogEvents.ts`: added `modelProvider: string` and `model: string` to the `ask_message_sent` schema.
- `app/api/(server)/ee/chat/route.ts`: populate from `languageModelConfig` (web chat path).
- `ee/features/mcp/askCodebase.ts`: populate from `languageModelConfig` (MCP / ask-agent path).

`ask_message_sent` is a multi-source event, so it intentionally does not use the `wa_` prefix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)