### PR TITLE
fix(web): derive over capacity indicator locally from currentUsers vs committedSeats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expired offline license keys no longer crash the process. An expired key now degrades to the unlicensed state. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Improved the `setup-sourcebot` wizard: prompts for a setup directory, clarifies that secrets are stored locally in `.env`, switches multi-select to Tab, hides "No results" until a real search runs, and detects/cleans up conflicting Docker deployments and volumes before starting. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 
+### Fixed
+- [EE] Fixed yearly seat usage card over-capacity indicator not appearing immediately when members are added past committed seats. [#1250](https://github.com/sourcebot-dev/sourcebot/pull/1250)
+
 ## [4.17.4] - 2026-05-30
 
 ### Changed

--- a/packages/web/src/app/(app)/settings/license/yearlyTermSeatsUsageCard.tsx
+++ b/packages/web/src/app/(app)/settings/license/yearlyTermSeatsUsageCard.tsx
@@ -61,13 +61,20 @@ export function YearlyTermSeatsUsageCard({
             });
     }, [router, toast]);
 
-    const hasOverage = billableOverageSeats > 0;
-    const committedUsedPercent = hasOverage
+    // Derive "currently over committed" locally from the live currentUsers count
+    // vs the synced committedSeats. This ensures the visual indicator appears
+    // immediately when a member is added past committed seats, without waiting
+    // for a Lighthouse sync.
+    const isCurrentlyOverCommitted = currentUsers > committedSeats;
+
+    // Show the blue segment whenever we're currently over committed (local check).
+    // The bar uses a fixed 90/10 split for visual clarity when over capacity.
+    const committedUsedPercent = isCurrentlyOverCommitted
         ? 90
         : committedSeats > 0
             ? Math.min(100, (currentUsers / committedSeats) * 100)
             : 0;
-    const overagePercent = hasOverage ? 10 : 0;
+    const overagePercent = isCurrentlyOverCommitted ? 10 : 0;
 
     return (
         <div className="flex flex-col gap-3">
@@ -104,19 +111,19 @@ export function YearlyTermSeatsUsageCard({
                                             You&apos;ll be invoiced for {billableOverageSeats} additional {billableOverageSeats === 1 ? 'seat' : 'seats'} at the end of the current quarter on {formatDate(currentQuarterEndsAt)}.
                                         </TooltipContent>
                                     </Tooltip>
-                                ) : (
-                                    overageSeats > 0 &&
-                                    billableOverageSeats === 0 &&
-                                    (currentUsers - committedSeats) > 0
-                                ) ? (
+                                ) : isCurrentlyOverCommitted ? (
                                     <Tooltip>
                                         <TooltipTrigger asChild>
-                                            <Info className="h-4 w-4 text-muted-foreground cursor-help" />
+                                            <Badge className="bg-blue-500/20 text-blue-400 border-blue-500/30 cursor-help">
+                                                Over capacity
+                                            </Badge>
                                         </TooltipTrigger>
                                         <TooltipContent className="max-w-xs">
-                                            {overageSeats === 1
-                                                ? `The additional seat in use will not be billed in the current subscription term. Instead, it will be billed upon renewal on ${formatDate(termEndsAt)}.`
-                                                : `The ${overageSeats} additional seats in use will not be billed in the current subscription term. Instead, they will be billed upon renewal on ${formatDate(termEndsAt)}.`}
+                                            {overageSeats > 0
+                                                ? (overageSeats === 1
+                                                    ? `The additional seat in use will not be billed in the current subscription term. Instead, it will be billed upon renewal on ${formatDate(termEndsAt)}.`
+                                                    : `The ${overageSeats} additional seats in use will not be billed in the current subscription term. Instead, they will be billed upon renewal on ${formatDate(termEndsAt)}.`)
+                                                : `You're currently using ${currentUsers - committedSeats} more ${currentUsers - committedSeats === 1 ? 'seat' : 'seats'} than your subscription includes. Additional users will be billed as overage at the end of each quarter.`}
                                         </TooltipContent>
                                     </Tooltip>
                                 ) : (


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-1250

## Summary

The yearly seat usage card was showing a **live** member count (`currentUsers`) but gating the blue "over capacity" visual indicator on the **synced** `overageSeats` value from Lighthouse. This created a confusing mismatch where the card would show "2 / 1" with a full-black bar, "0 seats owed", and no blue overage segment until a Lighthouse sync landed.

## Changes

- Add `isCurrentlyOverCommitted` derived locally from `currentUsers > committedSeats`
- Use this local check to show the blue bar segment immediately when over capacity
- Add "Over capacity" badge that appears immediately when over committed (before Lighthouse syncs)
- Keep "Bill pending" badge for when Lighthouse has computed `billableOverageSeats`
- Keep `peakSeats` and `billableOverageSeats` sourced from Lighthouse (genuinely server-computed and cannot be derived locally)

## Before/After

| State | Before | After |
|-------|--------|-------|
| 2 users, 1 committed (before sync) | "2 / 1", full black bar, no indicator | "2 / 1", black+blue bar, "Over capacity" badge |
| 2 users, 1 committed (after sync) | "2 / 1", black+blue bar, "Bill pending" badge | Same (unchanged) |

## Testing

- Lint passes with no new warnings
- Existing tests pass (unrelated pre-existing failures in v5 branch)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-1250](https://linear.app/sourcebot/issue/SOU-1250/yearly-seat-usage-card-derive-over-capacity-indicator-locally-instead)

<div><a href="https://cursor.com/agents/bc-198989f6-e0ac-4d92-9328-4e35e64104dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-198989f6-e0ac-4d92-9328-4e35e64104dc"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

