### PR TITLE
fix: set git safe.directory at system level for non-root container users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Expired offline license keys no longer crash the process. An expired key now degrades to the unlicensed state. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 - Improved the `setup-sourcebot` wizard: prompts for a setup directory, clarifies that secrets are stored locally in `.env`, switches multi-select to Tab, hides "No results" until a real search runs, and detects/cleans up conflicting Docker deployments and volumes before starting. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
 
+### Fixed
+- Fixed git "dubious ownership" errors when the container runs as a non-root user by setting `safe.directory` at the system level instead of the global (root-only) level. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
+
 ## [4.17.4] - 2026-05-30
 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -250,7 +250,7 @@ COPY --chown=sourcebot:sourcebot --from=shared-libs-builder /app/packages/shared
 COPY --chown=sourcebot:sourcebot --from=shared-libs-builder /app/packages/queryLanguage ./packages/queryLanguage
 
 # Fixes git "dubious ownership" issues when the volume is mounted with different permissions to the container.
-RUN git config --global safe.directory "*"
+RUN git config --system safe.directory "*"
 
 # Configure the database
 RUN mkdir -p /run/postgresql && \


### PR DESCRIPTION
## Summary

Switches the `safe.directory "*"` git config in the Dockerfile from `--global` to `--system`.

`--global` writes only to the home directory of the build-time user (`/root/.gitconfig`). The image intentionally sets **no `USER` directive** (see the comment near the entrypoint) and can be run as `sourcebot` or an arbitrary `--user` at runtime. In those cases git reads that user's `$HOME/.gitconfig`, never sees `safe.directory`, and the "dubious ownership" error this line is meant to prevent still fires.

`--system` writes to `/etc/gitconfig`, which is read by every user regardless of who invokes git, so the fix now actually covers all three run modes (root, `sourcebot`, arbitrary `--user`).

## Risk

Low / net risk reduction:
- `RUN` runs as root at build time, so it can write `/etc/gitconfig`.
- `/etc/gitconfig` is created with default umask (`644`), world-readable, and nothing later chmods `/etc`, so non-root runtime users can read it.
- `safe.directory` is multi-valued and accumulated across config levels, so the lower-precedence system scope can't be clobbered by a user-level gitconfig.

🤖 Generated with [Claude Code](https://claude.com/claude-code)