### PR TITLE
feat(web): graceful error and loading states for billing/offers surfaces

### DIFF
--- a/packages/web/src/app/(app)/settings/accountAskAgent/accountAskAgentEntitlementMessage.tsx
+++ b/packages/web/src/app/(app)/settings/accountAskAgent/accountAskAgentEntitlementMessage.tsx
@@ -17,6 +17,7 @@ export function AccountAskAgentEntitlementMessage() {
                 title="Upgrade to use Ask Sourcebot connectors"
                 description="Connect Ask Sourcebot to your team's tools (like Linear, Notion, and Sentry) so it can pull in context beyond your indexed code."
                 className="w-full max-w-2xl"
+                loadingVariant="spinner"
             />
         </div>
     )

--- a/packages/web/src/app/(app)/settings/analytics/analyticsEntitlementMessage.tsx
+++ b/packages/web/src/app/(app)/settings/analytics/analyticsEntitlementMessage.tsx
@@ -17,6 +17,7 @@ export function AnalyticsEntitlementMessage() {
                 title="Upgrade to view analytics"
                 description="Get insights into your organization's usage patterns and activity across search and Ask Sourcebot."
                 className="w-full max-w-2xl"
+                loadingVariant="spinner"
             />
         </div>
     )

--- a/packages/web/src/app/(app)/settings/mcp/mcpEntitlementMessage.tsx
+++ b/packages/web/src/app/(app)/settings/mcp/mcpEntitlementMessage.tsx
@@ -17,6 +17,7 @@ export function McpEntitlementMessage() {
                 title="Upgrade to use the MCP server"
                 description="Connect your agents to Sourcebot to allow them to fetch code context, and more."
                 className="w-full max-w-2xl"
+                loadingVariant="spinner"
             />
         </div>
     )

--- a/packages/web/src/app/(app)/settings/workspaceAskAgent/workspaceAskAgentEntitlementMessage.tsx
+++ b/packages/web/src/app/(app)/settings/workspaceAskAgent/workspaceAskAgentEntitlementMessage.tsx
@@ -18,6 +18,7 @@ export function WorkspaceAskAgentEntitlementMessage() {
                 title="Upgrade to configure Ask Sourcebot connectors"
                 description="Approve the external tools (like Linear, Notion, and Sentry) that your users can connect to Ask Sourcebot."
                 className="w-full max-w-2xl"
+                loadingVariant="spinner"
             />
         </div>
     )

--- a/packages/web/src/app/onboard/components/trialStep.tsx
+++ b/packages/web/src/app/onboard/components/trialStep.tsx
@@ -29,8 +29,8 @@ function useTrialStepCopy(): TrialStepCopy | null {
     }
     if (isError || !offers) {
         return {
-            title: "Upgrade to Sourcebot Pro",
-            subtitle: "Unlock advanced features for your team. You can upgrade later from your license settings.",
+            title: "You're all set",
+            subtitle: "Your Sourcebot deployment is ready to go.",
         };
     }
     if (!offers.trial.eligible) {
@@ -203,13 +203,23 @@ export function TrialStep({ stepIndex }: TrialStepProps) {
 
     if (isError || !offers) {
         return (
-            <LoadingButton
-                onClick={onSkipCheckout}
-                loading={isSkipLoading}
-                className="w-full"
-            >
-                Continue to Sourcebot
-            </LoadingButton>
+            <div className="flex flex-col">
+                <LoadingButton
+                    onClick={onSkipCheckout}
+                    loading={isSkipLoading}
+                    className="w-full"
+                >
+                    Continue to Sourcebot
+                </LoadingButton>
+                <a
+                    href="https://www.sourcebot.dev/pricing"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="mx-auto text-sm text-muted-foreground hover:text-foreground mt-8"
+                >
+                    View pricing
+                </a>
+            </div>
         );
     }
 

--- a/packages/web/src/features/billing/upsellDialog.tsx
+++ b/packages/web/src/features/billing/upsellDialog.tsx
@@ -52,7 +52,7 @@ export function UpsellDialog({ open, onOpenChange, source, returnPath }: UpsellD
                     // closing it out from under the user — the built-in close button
                     // is still the dismiss affordance.
                     <UpsellLoadError variant="dialog" onRetry={() => { void refetch(); }} />
-                ) : isPending || !offers ? (
+                ) : isPending ? (
                     <div className="flex items-center justify-center py-12">
                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                     </div>

--- a/packages/web/src/features/billing/upsellDialog.tsx
+++ b/packages/web/src/features/billing/upsellDialog.tsx
@@ -21,10 +21,11 @@ import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { UpsellSource } from "@/lib/posthogEvents";
 import { cn, isServiceError } from "@/lib/utils";
 import { OrgRole } from "@sourcebot/db";
-import { ArrowUpCircle, ExternalLink, Loader2 } from "lucide-react";
+import { AlertCircle, ArrowUpCircle, ExternalLink, Loader2 } from "lucide-react";
 import { useSession } from "next-auth/react";
 import { ReactNode, useCallback, useEffect, useMemo, useState } from "react";
 import { CheckoutDisclosures } from "./checkoutDisclosures";
+import { CodeSnippet } from "@/app/components/codeSnippet";
 
 interface UpsellDialogProps {
     open: boolean;
@@ -34,8 +35,7 @@ interface UpsellDialogProps {
 }
 
 export function UpsellDialog({ open, onOpenChange, source, returnPath }: UpsellDialogProps) {
-    const { data: offers, isPending, isError } = useOffers();
-    const { toast } = useToast();
+    const { data: offers, isPending, isError, refetch } = useOffers();
     const captureEvent = useCaptureEvent();
 
     useEffect(() => {
@@ -44,28 +44,15 @@ export function UpsellDialog({ open, onOpenChange, source, returnPath }: UpsellD
         }
     }, [open, source, captureEvent]);
 
-    // Surface pricing-fetch failures via a toast and dismiss the dialog. Without
-    // closing it ourselves, the parent's `open` state would keep us mounted but
-    // we'd have nothing to render — leaving the user stuck with an invisible
-    // dialog they can't dismiss.
-    useEffect(() => {
-        if (open && isError) {
-            toast({
-                description: "Something went wrong loading pricing. Please try again.",
-                variant: "destructive",
-            });
-            onOpenChange(false);
-        }
-    }, [open, isError, toast, onOpenChange]);
-
-    if (isError) {
-        return null;
-    }
-
     return (
         <Dialog open={open} onOpenChange={onOpenChange}>
             <DialogContent className="max-w-2xl gap-6 focus:outline-none">
-                {isPending || !offers ? (
+                {isError ? (
+                    // Keep the dialog open with a recoverable error state rather than
+                    // closing it out from under the user — the built-in close button
+                    // is still the dismiss affordance.
+                    <UpsellLoadError variant="dialog" onRetry={() => { void refetch(); }} />
+                ) : isPending || !offers ? (
                     <div className="flex items-center justify-center py-12">
                         <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
                     </div>
@@ -74,6 +61,77 @@ export function UpsellDialog({ open, onOpenChange, source, returnPath }: UpsellD
                 )}
             </DialogContent>
         </Dialog>
+    );
+}
+
+interface UpsellLoadErrorProps {
+    variant: "dialog" | "inline";
+    onRetry: () => void;
+    className?: string;
+}
+
+// Shared fallback for when the offers/pricing fetch fails. Offers a retry plus a
+// link to the public pricing page — the latter is resilient to the very failure
+// that triggered this state, since it doesn't depend on the offers endpoint.
+function UpsellLoadError({ variant, onRetry, className }: UpsellLoadErrorProps) {
+    const role = useRole();
+    const isOwner = role === OrgRole.OWNER;
+    const heading = "Something went wrong";
+    const body = (
+        <>
+            We couldn&apos;t reach Sourcebot&apos;s deployments server.{" "}
+            {/* Owners get an actionable hint (the most common cause on self-hosted
+                deployments is outbound access to the lighthouse host being blocked);
+                members can't act on this themselves, so route them to an admin. */}
+            {isOwner ? (
+                <>
+                    Check that outbound access to{" "}
+                    <CodeSnippet>deployments.sourcebot.dev</CodeSnippet>{" "}isn&apos;t blocked.{" "}
+                    <a
+                        href="https://docs.sourcebot.dev/docs/misc/service-ping"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-link hover:underline"
+                    >
+                        Learn more
+                    </a>
+                    .
+                </>
+            ) : (
+                <>Contact your organization admin.</>
+            )}
+        </>
+    );
+    return (
+        <div className={cn("flex flex-col gap-6", className)}>
+            <div className="flex flex-col gap-2 text-center sm:text-left">
+                <AlertCircle className="h-6 w-6 text-destructive" />
+                {variant === "dialog" ? (
+                    <DialogTitle>{heading}</DialogTitle>
+                ) : (
+                    <h3 className="text-lg font-semibold leading-none tracking-tight">{heading}</h3>
+                )}
+                {variant === "dialog" ? (
+                    <DialogDescription className="text-sm">{body}</DialogDescription>
+                ) : (
+                    <p className="text-sm text-muted-foreground">{body}</p>
+                )}
+            </div>
+
+            <div className="flex flex-col-reverse items-center gap-2 sm:flex-row sm:justify-end sm:gap-4">
+                <Button variant="ghost" asChild>
+                    <a
+                        href="https://status.sourcebot.dev"
+                        target="_blank"
+                        rel="noopener noreferrer"
+                    >
+                        Status page
+                        <ExternalLink className="h-3.5 w-3.5 ml-2" />
+                    </a>
+                </Button>
+                <Button onClick={onRetry}>Try again</Button>
+            </div>
+        </div>
     );
 }
 
@@ -92,16 +150,29 @@ interface UpsellPanelProps {
     // Sourcebot history"). Fall back to the billing-state-derived copy when omitted.
     title?: string;
     description?: ReactNode;
+    // How to render the pending state. Use 'skeleton' (default) when the panel is
+    // embedded in-flow alongside other content, so the reserved space avoids
+    // layout shift. Use 'spinner' when the panel is the sole, centered element in
+    // a large empty region (e.g. a full-area feature gate), where a shaped
+    // skeleton reads as heavier than a simple spinner.
+    loadingVariant?: 'skeleton' | 'spinner';
 }
 
-export function UpsellPanel({ source, returnPath, className, licenseState = 'free', title, description }: UpsellPanelProps) {
-    const { data: offers, isPending, isError } = useOffers();
+export function UpsellPanel({ source, returnPath, className, licenseState = 'free', title, description, loadingVariant = 'skeleton' }: UpsellPanelProps) {
+    const { data: offers, isPending, isError, refetch } = useOffers();
 
     if (isError) {
-        return null;
+        return <UpsellLoadError variant="inline" onRetry={() => { void refetch(); }} className={className} />;
     }
 
     if (isPending || !offers) {
+        if (loadingVariant === 'spinner') {
+            return (
+                <div className={cn("flex items-center justify-center py-12", className)} aria-busy="true">
+                    <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+                </div>
+            );
+        }
         return (
             <div className={cn("flex flex-col gap-6", className)} aria-busy="true">
                 <div className="flex flex-col gap-2">

--- a/packages/web/src/features/billing/useOffers.ts
+++ b/packages/web/src/features/billing/useOffers.ts
@@ -10,6 +10,7 @@ export const useOffers = (params?: {
     return useQuery({
         queryKey: ["offers"],
         queryFn: async () => unwrapServiceError(getOffers()),
-        retry: params?.retry
+        retry: params?.retry,
+        refetchOnWindowFocus: false
     });
 }

--- a/packages/web/src/features/chat/components/chatEntitlementMessage.tsx
+++ b/packages/web/src/features/chat/components/chatEntitlementMessage.tsx
@@ -33,6 +33,7 @@ export function ChatEntitlementMessage({
                 title={title}
                 description={description}
                 className="w-full max-w-2xl"
+                loadingVariant="spinner"
             />
         </div>
     )


### PR DESCRIPTION
Fixes SOU-1271

## Summary

When the offers/pricing fetch from the deployments server fails, several billing surfaces previously rendered nothing (`return null`) or silently dismissed themselves, leaving users with a blank area or a vanished dialog. This PR replaces those with recoverable, role-aware error states and tidies the loading UX.

## Changes

- **Onboarding trial step** (`trialStep.tsx`): on error, reframe the copy to "You're all set" and add a **View pricing** link instead of a bare Continue button.
- **Upsell dialog & panel** (`upsellDialog.tsx`): introduce a shared `UpsellLoadError` fallback used by both `UpsellDialog` and `UpsellPanel`:
  - **Something went wrong** heading + generic "We couldn't reach Sourcebot's deployments server" copy (no longer presumes the user came for pricing).
  - **Try again** (retry via react-query `refetch`) and a **Status page** link (`status.sourcebot.dev`), which is resilient to the very failure that triggered the state.
  - Role-aware: owners get an actionable outbound-access hint naming `deployments.sourcebot.dev` plus a **Learn more** link to the service-ping docs; members are routed to contact their org admin.
  - The dialog now keeps itself open with this error state (built-in close button remains the dismiss affordance) rather than toasting and auto-closing.
- **Loading state** (`upsellDialog.tsx` + the five entitlement-message wrappers): add a `loadingVariant` prop to `UpsellPanel`. Full-area, centered feature gates (chat, MCP, analytics, account/workspace Ask connectors) now render a centered spinner; the in-flow license-settings card keeps its layout-matching skeleton.

## Test plan

- Block outbound access to `deployments.sourcebot.dev` (or otherwise force the offers fetch to fail) and verify the error state renders on: the onboarding trial step, the upsell dialog, and each feature-gate page.
- Confirm owner vs member see the role-appropriate copy.
- Confirm **Try again** refetches and **Status page** / **Learn more** open the right URLs.
- Confirm feature gates show a spinner while loading and the license card shows a skeleton.

🤖 Generated with [Claude Code](https://claude.com/claude-code)