### PR TITLE
fix(setup-wizard): keep users out of GitHub orgs / GitLab groups

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ Checkout the [migration guide](https://docs.sourcebot.dev/docs/upgrade/v4-to-v5-
 
 ### Fixed
 - Fixed git "dubious ownership" errors when the container runs as a non-root user by setting `safe.directory` at the system level instead of the global (root-only) level. [#1106](https://github.com/sourcebot-dev/sourcebot/pull/1106)
+- Fixed the `setup-sourcebot` wizard accepting a user account in the GitHub organizations (or GitLab groups) list by validating each selection against the code host's account-type API. [#1271](https://github.com/sourcebot-dev/sourcebot/pull/1271)
 
 ## [4.17.4] - 2026-05-30
 

--- a/packages/setupWizard/src/github.ts
+++ b/packages/setupWizard/src/github.ts
@@ -22,6 +22,64 @@ type GitHubSearchType = 'org' | 'user' | 'repo';
 const githubSearchCache = new Map<string, Array<SearchOption | Separator>>();
 const REPO_PATTERN = /^[\w.-]+\/[\w.-]+$/;
 
+// A GitHub login is exactly one of these. `unknown` means we couldn't determine it
+// (network error, rate limit, or a private account the token can't see) — in which
+// case we don't block the user, to keep the self-hosted / offline path working.
+type GitHubAccountType = 'Organization' | 'User' | 'unknown';
+const githubAccountTypeCache = new Map<string, GitHubAccountType>();
+
+// Resolves whether a login is an organization or a user via `GET /users/{login}`,
+// which authoritatively reports the account `type`. Used to keep users out of the
+// orgs list (and vice-versa) — an org search can surface a literal typed login, and
+// a user sent as an org makes indexing fail.
+export async function getGitHubAccountType(apiBase: string, login: string, token: string): Promise<GitHubAccountType> {
+    const key = `${apiBase}|${login.toLowerCase()}`;
+    const cached = githubAccountTypeCache.get(key);
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    let result: GitHubAccountType = 'unknown';
+    try {
+        const headers: Record<string, string> = {
+            'User-Agent': 'setup-sourcebot',
+            ...(token ? { Authorization: `Bearer ${token}` } : {}),
+        };
+        const res = await fetch(`${apiBase}/users/${encodeURIComponent(login)}`, { headers });
+        if (res.ok) {
+            const data = await res.json() as { type?: string };
+            if (data.type === 'Organization' || data.type === 'User') {
+                result = data.type;
+            }
+        }
+    } catch {
+        // Network error — leave as 'unknown' so we don't block the user.
+    }
+
+    githubAccountTypeCache.set(key, result);
+    return result;
+}
+
+// Builds a submit-time validator that rejects any selected login whose resolved
+// account type contradicts `expected`. `unknown` is allowed through.
+function makeAccountTypeValidator(
+    apiBase: string,
+    token: string,
+    expected: 'Organization' | 'User',
+): (selected: ReadonlyArray<{ value: string }>) => Promise<string | boolean> {
+    return async (selected) => {
+        for (const opt of selected) {
+            const actual = await getGitHubAccountType(apiBase, opt.value, token);
+            if (actual !== 'unknown' && actual !== expected) {
+                const isUser = actual === 'User';
+                return `"${opt.value}" is a ${isUser ? 'user account' : 'organization'}, not ${expected === 'Organization' ? 'an organization' : 'a user'}. `
+                    + `Add it under the "${isUser ? 'Users' : 'Organizations'}" option instead.`;
+            }
+        }
+        return true;
+    };
+}
+
 async function searchGitHub(
     apiBase: string,
     query: string,
@@ -182,6 +240,7 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
                     ctx.setLoading(false);
                 }
             },
+            validate: makeAccountTypeValidator(apiBase, token, 'Organization'),
         });
         config.orgs = orgs;
     }
@@ -208,6 +267,7 @@ export async function collectGitHubConfig(connectionName: string): Promise<Colle
                     ctx.setLoading(false);
                 }
             },
+            validate: makeAccountTypeValidator(apiBase, token, 'User'),
         });
         config.users = users;
     }

--- a/packages/setupWizard/src/gitlab.ts
+++ b/packages/setupWizard/src/gitlab.ts
@@ -19,6 +19,79 @@ type GitLabSearchType = 'group' | 'project' | 'user';
 const gitlabSearchCache = new Map<string, Array<SearchOption | Separator>>();
 const PROJECT_PATTERN = /^[\w.-]+(\/[\w.-]+)+$/;
 
+// A GitLab namespace is either a group or a user. `unknown` means we couldn't
+// determine it (network error, or a private namespace the token can't see) — in
+// which case we don't block the user.
+type GitLabNamespaceKind = 'group' | 'user' | 'unknown';
+const gitlabNamespaceKindCache = new Map<string, GitLabNamespaceKind>();
+
+// Resolves whether a namespace path is a group or a user. A nested path (contains
+// "/") can only be a subgroup. For a top-level path, `GET /users?username=` confirms
+// a user (exact match) and `GET /groups/{path}` confirms a group. Used to keep users
+// out of the groups list (and vice-versa) — a user sent as a group makes indexing fail.
+export async function getGitLabNamespaceKind(apiBase: string, path: string, token: string): Promise<GitLabNamespaceKind> {
+    const key = `${apiBase}|${path.toLowerCase()}`;
+    const cached = gitlabNamespaceKindCache.get(key);
+    if (cached !== undefined) {
+        return cached;
+    }
+
+    const headers: Record<string, string> = {
+        'User-Agent': 'setup-sourcebot',
+        ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    };
+
+    let result: GitLabNamespaceKind = 'unknown';
+    try {
+        if (path.includes('/')) {
+            // Usernames can't contain "/", so this is a subgroup path — confirm it's a group.
+            const res = await fetch(`${apiBase}/groups/${encodeURIComponent(path)}`, { headers });
+            if (res.ok) {
+                result = 'group';
+            }
+        } else {
+            const userRes = await fetch(`${apiBase}/users?username=${encodeURIComponent(path)}`, { headers });
+            if (userRes.ok) {
+                const users = await userRes.json() as Array<{ username?: string }>;
+                if (users.some((u) => u.username?.toLowerCase() === path.toLowerCase())) {
+                    result = 'user';
+                }
+            }
+            if (result === 'unknown') {
+                const groupRes = await fetch(`${apiBase}/groups/${encodeURIComponent(path)}`, { headers });
+                if (groupRes.ok) {
+                    result = 'group';
+                }
+            }
+        }
+    } catch {
+        // Network error — leave as 'unknown' so we don't block the user.
+    }
+
+    gitlabNamespaceKindCache.set(key, result);
+    return result;
+}
+
+// Builds a submit-time validator that rejects any selected path whose resolved
+// namespace kind contradicts `expected`. `unknown` is allowed through.
+function makeNamespaceKindValidator(
+    apiBase: string,
+    token: string,
+    expected: 'group' | 'user',
+): (selected: ReadonlyArray<{ value: string }>) => Promise<string | boolean> {
+    return async (selected) => {
+        for (const opt of selected) {
+            const actual = await getGitLabNamespaceKind(apiBase, opt.value, token);
+            if (actual !== 'unknown' && actual !== expected) {
+                const isUser = actual === 'user';
+                return `"${opt.value}" is a ${isUser ? 'user' : 'group'}, not a ${expected}. `
+                    + `Add it under the "${isUser ? 'Users' : 'Groups'}" option instead.`;
+            }
+        }
+        return true;
+    };
+}
+
 async function searchGitLab(
     apiBase: string,
     query: string,
@@ -166,6 +239,7 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
                     ctx.setLoading(false);
                 }
             },
+            validate: makeNamespaceKindValidator(apiBase, gitlabToken, 'group'),
         });
         config.groups = groups;
     }
@@ -226,6 +300,7 @@ export async function collectGitLabConfig(connectionName: string): Promise<Colle
                     ctx.setLoading(false);
                 }
             },
+            validate: makeNamespaceKindValidator(apiBase, gitlabToken, 'user'),
         });
         config.users = users;
     }


### PR DESCRIPTION
## Problem

In the setup wizard, the GitHub **organization** search (and the GitLab **group** search) could end up with a *user* account in the final config. The org/group autocomplete offers the literal typed value when there are no API matches, and there was no check that the selection was actually an org/group. A user account sent as an org/group causes indexing to fail.

## Fix

Each selected entry is now validated on submit against the authoritative account-type API, and a confirmed wrong-type entry is rejected with a message pointing the user to the correct prompt:

- **GitHub** — `GET /users/{login}` returns `type: "User" | "Organization"`. The org prompt rejects confirmed users; the users prompt rejects confirmed orgs.
- **GitLab** — `GET /users?username=` confirms a user (exact match) and `GET /groups/{path}` confirms a group (nested `a/b` paths are always subgroups). The groups prompt rejects confirmed users; the users prompt rejects confirmed groups.

Entries that can't be resolved (offline, rate-limited, or a private namespace the token can't see) resolve to `unknown` and are allowed through, so the self-hosted / no-token path keeps working. Results are cached per login/path.

Gitea, Bitbucket, Azure DevOps, and Gerrit use free-text input (no API-backed search), so they don't have this leak and are unchanged.

## Testing

Validated the classifier helpers against the live public APIs:

- GitHub: `docker` → Organization, `torvalds` → User, nonexistent → unknown.
- GitLab: `gitlab-org` → group, `jramsay` → user, `gitlab-org/api` (subgroup) → group, nonexistent → unknown.

`tsc --noEmit` and `yarn build` pass.