### PR TITLE
chore: upgrade protobufjs to ^7.6.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)
+
 ## [5.0.1] - 2026-06-04
 
 ### Fixed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -321,7 +321,7 @@ CVEs often arrive in clusters because one package release fixes several at once.
 
    - **Sibling PR exists and its branch already pins ≥ `<min-patched-version>`**:
      - `gh pr checkout <number>`
-     - **Edit** the existing CHANGELOG line for this PR — append this CVE ID to the comma-separated list. Do not add a new CHANGELOG line.
+     - Leave the CHANGELOG line as-is — it does not enumerate CVEs, so no edit is needed. Do not add a new CHANGELOG line.
      - `gh pr edit <number>` to append the CVE ID to the title and body, and add a `Fixes <LINEAR-ID>` line to the PR body alongside any existing `Fixes` lines (this auto-links the Linear issue and Linear will mark it Done when the PR merges).
      - Do not transition the Linear issue manually — leave it for the merge to close.
      - **Do not open a new PR.**
@@ -329,7 +329,7 @@ CVEs often arrive in clusters because one package release fixes several at once.
    - **Sibling PR exists but its pin is too low to cover this CVE**:
      - Check out the branch.
      - Bump the resolution / package version higher to cover both.
-     - **Edit** the existing CHANGELOG line — append this CVE and update the version. Update the PR title and body, and add `Fixes <LINEAR-ID>` to the PR body.
+     - **Edit** the existing CHANGELOG line — update the version. Update the PR title and body, and add `Fixes <LINEAR-ID>` to the PR body.
      - Do not transition the Linear issue manually — leave it for the merge to close.
 
    - **No sibling PR exists**:
@@ -339,10 +339,10 @@ CVEs often arrive in clusters because one package release fixes several at once.
 
 ### CHANGELOG and PR conventions for CVE fixes
 
-- CHANGELOG entry (under `[Unreleased] → Fixed`): `Upgraded \`<pkg>\` to \`^x.y.z\` to address CVE-A, CVE-B, .... [#<PR>]`
-- **One CHANGELOG line per PR**, not per CVE. When the PR addresses multiple CVEs (batched), list all of them comma-separated on a single line.
+- CHANGELOG entry (under `[Unreleased] → Fixed`): `Upgraded \`<pkg>\` to \`^x.y.z\`. [#<PR>]`. Do NOT list CVE IDs in the CHANGELOG.
+- **One CHANGELOG line per PR**, not per CVE. A batched PR addressing multiple CVEs still gets a single line that does not enumerate them.
 - PR title format: `chore: upgrade <pkg> to ^x.y.z to address CVE-A, CVE-B, ...` (list every CVE the PR resolves).
-- Keep entries short. The CVE IDs are enough.
+- Keep entries short. CVE IDs belong in the PR title and body, not the CHANGELOG.
 
 ## Branches and Pull Requests
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -5469,27 +5469,26 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/codegen@npm:^2.0.4":
-  version: 2.0.4
-  resolution: "@protobufjs/codegen@npm:2.0.4"
-  checksum: 10c0/26ae337c5659e41f091606d16465bbcc1df1f37cc1ed462438b1f67be0c1e28dfb2ca9f294f39100c52161aef82edf758c95d6d75650a1ddf31f7ddee1440b43
+"@protobufjs/codegen@npm:^2.0.5":
+  version: 2.0.5
+  resolution: "@protobufjs/codegen@npm:2.0.5"
+  checksum: 10c0/1b8a2ae56ee60a56e9d205cd4b6072a1503c5069b8ebb905710f974ff0098a0d0700641c137e0a8d98dedf14423156a106a9433695cbf52574810f55000fdcab
   languageName: node
   linkType: hard
 
-"@protobufjs/eventemitter@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/eventemitter@npm:1.1.0"
-  checksum: 10c0/1eb0a75180e5206d1033e4138212a8c7089a3d418c6dfa5a6ce42e593a4ae2e5892c4ef7421f38092badba4040ea6a45f0928869989411001d8c1018ea9a6e70
+"@protobufjs/eventemitter@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/eventemitter@npm:1.1.1"
+  checksum: 10c0/8e06193d4629c5e7c09d4f8c2ddba8fc4dfa739f0149f33a1d901568d35bb7b8b5277a4e8452baf3bdd0b302fd599cf255d193267aa93a0a4747e23cd073c4ac
   languageName: node
   linkType: hard
 
-"@protobufjs/fetch@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/fetch@npm:1.1.0"
+"@protobufjs/fetch@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/fetch@npm:1.1.1"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.1"
-    "@protobufjs/inquire": "npm:^1.1.0"
-  checksum: 10c0/cda6a3dc2d50a182c5865b160f72077aac197046600091dbb005dd0a66db9cce3c5eaed6d470ac8ed49d7bcbeef6ee5f0bc288db5ff9a70cbd003e5909065233
+  checksum: 10c0/a497ff5433854e8577f0427983ea39b9113b49a8120f94515291d763327061d2c3013e60e24ea436d091dafae01a0f6eb1867e3b1616045d96a31d8b3c646ed4
   languageName: node
   linkType: hard
 
@@ -5521,10 +5520,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@protobufjs/utf8@npm:^1.1.0":
-  version: 1.1.0
-  resolution: "@protobufjs/utf8@npm:1.1.0"
-  checksum: 10c0/a3fe31fe3fa29aa3349e2e04ee13dc170cc6af7c23d92ad49e3eeaf79b9766264544d3da824dba93b7855bd6a2982fb40032ef40693da98a136d835752beb487
+"@protobufjs/utf8@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "@protobufjs/utf8@npm:1.1.1"
+  checksum: 10c0/641fc145f00626405e8984b6e90b9edcbcc072ffc82d0647ca3176e09c730b2d022f988e65f011a7a17e2e4d77cde7733643aa10d8ac2bfa30f134dbcad553fd
   languageName: node
   linkType: hard
 
@@ -16842,7 +16841,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"long@npm:^5.0.0":
+"long@npm:^5.0.0, long@npm:^5.3.2":
   version: 5.3.2
   resolution: "long@npm:5.3.2"
   checksum: 10c0/7130fe1cbce2dca06734b35b70d380ca3f70271c7f8852c922a7c62c86c4e35f0c39290565eca7133c625908d40e126ac57c02b1b1a4636b9457d77e1e60b981
@@ -19458,22 +19457,22 @@ __metadata:
   linkType: hard
 
 "protobufjs@npm:^7.3.0, protobufjs@npm:^7.4.0, protobufjs@npm:^7.5.3, protobufjs@npm:^7.5.4":
-  version: 7.5.4
-  resolution: "protobufjs@npm:7.5.4"
+  version: 7.6.2
+  resolution: "protobufjs@npm:7.6.2"
   dependencies:
     "@protobufjs/aspromise": "npm:^1.1.2"
     "@protobufjs/base64": "npm:^1.1.2"
-    "@protobufjs/codegen": "npm:^2.0.4"
-    "@protobufjs/eventemitter": "npm:^1.1.0"
-    "@protobufjs/fetch": "npm:^1.1.0"
+    "@protobufjs/codegen": "npm:^2.0.5"
+    "@protobufjs/eventemitter": "npm:^1.1.1"
+    "@protobufjs/fetch": "npm:^1.1.1"
     "@protobufjs/float": "npm:^1.0.2"
-    "@protobufjs/inquire": "npm:^1.1.0"
+    "@protobufjs/inquire": "npm:^1.1.2"
     "@protobufjs/path": "npm:^1.1.2"
     "@protobufjs/pool": "npm:^1.1.0"
-    "@protobufjs/utf8": "npm:^1.1.0"
+    "@protobufjs/utf8": "npm:^1.1.1"
     "@types/node": "npm:>=13.7.0"
-    long: "npm:^5.0.0"
-  checksum: 10c0/913b676109ffb3c05d3d31e03a684e569be91f3bba8613da4a683d69d9dba948daa2afd7d2e7944d1aa6c417890c35d9d9a8883c1160affafb0f9670d59ef722
+    long: "npm:^5.3.2"
+  checksum: 10c0/3c552dfe3cbcfad2d6c312a76cd189cf5be9fb36b203f6292f79c6020d675f7f33d5531ce312441c42ae75deb24ced32760e64fe4aa3d5b3c2295fd67cea270c
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1115
Fixes SOU-1116
Fixes SOU-1117
Fixes SOU-1118
Fixes SOU-1119
Fixes SOU-1120
Fixes SOU-1282
Fixes SOU-1283

Refreshes the lockfile to bump the transitive `protobufjs` dependency from `7.5.4` to `7.6.2`. Every requester range already allowed this version (`^7.x`), so only `yarn.lock` changed (no `package.json` / `resolutions` edit). This clears the open protobufjs CVE cluster reported by Trivy/Dependabot:

- CVE-2026-41242 — arbitrary code execution via injected type fields
- CVE-2026-44289 — unbounded recursion DoS
- CVE-2026-44290 — unsafe option path traversal
- CVE-2026-44291 — codegen gadget post prototype-pollution
- CVE-2026-44292 — per-instance prototype injection
- CVE-2026-44293 — bytes-field code injection
- CVE-2026-44294 — control-char codegen DoS
- CVE-2026-45740 — recursive JSON descriptor DoS

Also includes a docs commit updating the CVE-fix CHANGELOG convention in `CLAUDE.md` (CHANGELOG entries no longer enumerate CVE IDs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded protobufjs to ^7.6.2 to address security vulnerabilities.

* **Documentation**
  * Clarified CVE/upgrade workflow: guidance for batching related fixes and handling sibling PRs.
  * Tightened CHANGELOG and PR conventions for CVE fixes, including required changelog entry format and one-line-per-PR rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->