### PR TITLE
chore: upgrade qs to ^6.15.2 to address CVE-2026-8723

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)
+- Upgraded `qs` to `^6.14.2`. [#1282](https://github.com/sourcebot-dev/sourcebot/pull/1282)
 
 ## [5.0.1] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)
-- Upgraded `qs` to `^6.14.2`. [#1282](https://github.com/sourcebot-dev/sourcebot/pull/1282)
 
 ## [5.0.1] - 2026-06-04
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -19549,11 +19549,11 @@ __metadata:
   linkType: hard
 
 "qs@npm:^6.14.2":
-  version: 6.15.0
-  resolution: "qs@npm:6.15.0"
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
   dependencies:
     side-channel: "npm:^1.1.0"
-  checksum: 10c0/ff341078a78a991d8a48b4524d52949211447b4b1ad907f489cac0770cbc346a28e47304455c0320e5fb000f8762d64b03331e3b71865f663bf351bcba8cdb4b
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1186

Upgrades the transitive `qs` dependency from 6.15.0 to 6.15.2 to address CVE-2026-8723 (qs.stringify DoS/TypeError). `qs` is pulled in via gitbeaker, express, azure-devops-node-api, and the MCP SDK. The existing `^6.14.2` resolution already admits the patched version, so this is a yarn.lock refresh only (`yarn up -R qs`) with no package.json change. `yarn why qs --recursive` confirms every instance now resolves to 6.15.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Upgraded qs dependency to version ^6.14.2 for improved stability and security.
  * Retained the existing protobufjs upgrade entry in the changelog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->