### PR TITLE
chore: upgrade picomatch to ^4.0.4 to address CVE-2026-33671, CVE-2026-33672

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)
+- Upgraded `picomatch` to `^4.0.4`. [#1283](https://github.com/sourcebot-dev/sourcebot/pull/1283)
 
 ## [5.0.1] - 2026-06-04
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18993,17 +18993,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"picomatch@npm:^4.0.2, picomatch@npm:^4.0.4":
+"picomatch@npm:^4.0.2, picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
   version: 4.0.4
   resolution: "picomatch@npm:4.0.4"
   checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
-  languageName: node
-  linkType: hard
-
-"picomatch@npm:^4.0.3":
-  version: 4.0.3
-  resolution: "picomatch@npm:4.0.3"
-  checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1280
Fixes SOU-1281

Refreshes `yarn.lock` so all `picomatch` instances resolve to patched versions. The 4.x line now resolves to 4.0.4 (previously a stale `^4.0.3` requester pinned 4.0.3) and the 2.x line resolves to 2.3.2. No `resolutions` change was needed since the existing ranges already admit the patched versions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded a pattern-matching dependency to improve stability and reliability, reducing crashes and addressing related issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->