### PR TITLE
chore: upgrade libxml2 to 2.13.9-r1 to address CVE-2026-6732

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `protobufjs` to `^7.6.2`. [#1281](https://github.com/sourcebot-dev/sourcebot/pull/1281)
+- Upgraded `libxml2` to `2.13.9-r1` in the container image. [#1284](https://github.com/sourcebot-dev/sourcebot/pull/1284)
 
 ## [5.0.1] - 2026-06-04
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -179,6 +179,7 @@ ENV SOURCEBOT_LOG_LEVEL=info
 
 # Configure dependencies
 RUN apk add --no-cache git ca-certificates bind-tools tini jansson wget supervisor uuidgen curl perl jq openssl util-linux unzip && \
+    apk add --no-cache --upgrade "libxml2>=2.13.9-r1" && \
     apk upgrade --no-cache
 
 # Remove npm (unused — we use Yarn). The Node.js base image bundles npm


### PR DESCRIPTION
Fixes SOU-1259

Upgrades `libxml2` to `2.13.9-r1` in the final runtime (`runner`) stage of the Docker image, addressing CVE-2026-6732 (HIGH-severity DoS via crafted XSD-validated documents). Trivy flagged the installed `libxml2 2.13.9-r0` on `ghcr.io/sourcebot-dev/sourcebot:main` (Alpine), fixed in `2.13.9-r1`.

The fix adds an explicit `apk add --no-cache --upgrade "libxml2>=2.13.9-r1"` alongside the existing apk commands in the runner stage.

⚠️ Not verifiable in CI without building the image — please rebuild the container and re-run Trivy to confirm libxml2 >= 2.13.9-r1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated changelog with dependency upgrade information.

* **Chores**
  * Upgraded libxml2 to a newer version in the container image.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->