### PR TITLE
chore: ignore CVE-2026-41305 (postcss build-time XSS) in Trivy

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -1,0 +1,10 @@
+# Trivy vulnerability ignore file
+# Docs: https://trivy.dev/latest/docs/configuration/filtering/#by-finding-ids
+# Auto-detected by Trivy in the repo root (see trivy.yaml / .github/workflows/vulnerability-triage.yml).
+# Each entry should note why it is suppressed.
+
+# CVE-2026-41305 — PostCSS XSS via unescaped </style> in CSS stringify output.
+# postcss is a build-time-only dependency here (Tailwind/Next CSS tooling); we do
+# not stringify untrusted CSS ASTs at runtime, so this is not exploitable.
+# @see https://github.com/vercel/next.js/issues/93234#issuecomment-4333397286
+CVE-2026-41305


### PR DESCRIPTION
Fixes SOU-995

Suppresses CVE-2026-41305 (PostCSS XSS via unescaped `</style>` in CSS stringify output) via a root `.trivyignore`, auto-detected by Trivy in the vulnerability-triage workflow.

`postcss` is a build-time-only dependency (Tailwind/Next CSS tooling); we never stringify untrusted CSS ASTs at runtime, so the vulnerability is not exploitable in Sourcebot.

This supersedes #1285, which fixed the same CVE by forcing `postcss` past `next@16.2.6`'s pin of `8.4.31` via a qualified `resolutions` override. Ignoring avoids overriding Next's pinned transitive dependency.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added security detection exception for a development-time dependency vulnerability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->