### PR TITLE
chore: upgrade hono to ^4.12.24 to address CVE-2026-47673, CVE-2026-47674, CVE-2026-47675, CVE-2026-47676

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `picomatch` to `^4.0.4`. [#1283](https://github.com/sourcebot-dev/sourcebot/pull/1283)
 - Fixed GitLab MR inline review comments returning 400 Bad Request on context (unchanged) lines and renamed files. [#1149](https://github.com/sourcebot-dev/sourcebot/pull/1149)
 - Upgraded `ws` to `^8.20.1`. [#1286](https://github.com/sourcebot-dev/sourcebot/pull/1286)
+- Upgraded `hono` to `^4.12.24`. [#1289](https://github.com/sourcebot-dev/sourcebot/pull/1289)
 
 ## [5.0.1] - 2026-06-04
 

--- a/package.json
+++ b/package.json
@@ -50,7 +50,6 @@
         "brace-expansion@npm:^2.0.2": "^2.0.3",
         "brace-expansion@npm:^5.0.2": "^5.0.5",
         "brace-expansion@npm:^1.1.7": "^1.1.13",
-        "@modelcontextprotocol/sdk/hono": "^4.12.18",
         "@modelcontextprotocol/sdk/@hono/node-server": "^1.19.13",
         "markdown-it@npm:^14.1.0": "^14.1.1",
         "yaml@npm:^2.3.4": "^2.8.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15347,10 +15347,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hono@npm:^4.12.18":
-  version: 4.12.18
-  resolution: "hono@npm:4.12.18"
-  checksum: 10c0/b0b9688fd9e41a1847b077d579dc0e92a28b67c247c6ee7d1e751c0bae269824c30c7773feff1a2874e40ea36a3d2f9d1fc5ba618a28ecdf2ca1b33ed2473864
+"hono@npm:^4.11.4":
+  version: 4.12.24
+  resolution: "hono@npm:4.12.24"
+  checksum: 10c0/1a1394e48618c34b0ea627d7de7e5d59f1d90aedcd518f9d19b987260bbf16c362043e417bbb64290110c3cd54ef51017f7786438a0c2d811af01566d6ca3e94
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1291
Fixes SOU-1292
Fixes SOU-1293
Fixes SOU-1294

Resolves the new Hono CVE cluster (all fixed in 4.12.21) by **dropping the redundant `@modelcontextprotocol/sdk/hono` resolution** and refreshing the lockfile.

`hono` is transitive via `@modelcontextprotocol/sdk`, which declares `hono: ^4.11.4` — a range that already admits the patched release. The override (added for the previous cluster) was therefore unnecessary: a plain `yarn up -R hono` bumps hono **4.12.18 → 4.12.24** across the tree with no `resolutions` entry. This is the CVE-fix playbook's preferred lightest fix (refresh over override), and it removes an override that was never needed.

CVEs addressed:
- CVE-2026-47673 — JWT/JWK middleware accepts any Authorization scheme, not only Bearer
- CVE-2026-47674 — `ip-restriction` middleware bypasses deny rules for non-canonical IPv6
- CVE-2026-47675 — cookie helper allows Set-Cookie injection via unsanitized `sameSite`/`priority`
- CVE-2026-47676 — `app.mount()` incorrect path stripping for percent-encoded multi-byte chars

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated a development tooling dependency to a newer release to incorporate stability and bug fixes. No changes to public APIs or user-facing features; routine maintenance to keep the project up to date and reduce potential dev-time issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->