### PR TITLE
chore: bump zoekt submodule to upgrade go-git to v5.19.1 (CVE-2026-45571)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed GitLab MR inline review comments returning 400 Bad Request on context (unchanged) lines and renamed files. [#1149](https://github.com/sourcebot-dev/sourcebot/pull/1149)
 - Upgraded `ws` to `^8.20.1`. [#1286](https://github.com/sourcebot-dev/sourcebot/pull/1286)
 - Upgraded `hono` to `^4.12.24`. [#1289](https://github.com/sourcebot-dev/sourcebot/pull/1289)
-- Upgraded `go-git` to `v5.19.1` in the bundled zoekt search backend. [#1290](https://github.com/sourcebot-dev/sourcebot/pull/1290)
 
 ## [5.0.1] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed GitLab MR inline review comments returning 400 Bad Request on context (unchanged) lines and renamed files. [#1149](https://github.com/sourcebot-dev/sourcebot/pull/1149)
 - Upgraded `ws` to `^8.20.1`. [#1286](https://github.com/sourcebot-dev/sourcebot/pull/1286)
 - Upgraded `hono` to `^4.12.24`. [#1289](https://github.com/sourcebot-dev/sourcebot/pull/1289)
+- Upgraded `go-git` to `v5.19.1` in the bundled zoekt search backend. [#1290](https://github.com/sourcebot-dev/sourcebot/pull/1290)
 
 ## [5.0.1] - 2026-06-04
 


### PR DESCRIPTION
Fixes SOU-1170

Advances the `vendor/zoekt` submodule to [sourcebot-dev/zoekt#15](https://github.com/sourcebot-dev/zoekt/pull/15) (`2566953` → `3d1f49a`), which upgrades `go-git` from v5.19.0 to **v5.19.1** in the bundled zoekt search backend.

That release patches CVE-2026-45571 (crafted repositories may modify `.git` directories), the sourcebot-tracked advisory for this issue. `go-git` lives in zoekt's `go.mod`, so the fix had to land upstream first; this PR just moves the submodule pointer to the merged commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated vendor dependencies to include the latest available revisions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->