### PR TITLE
feat(web): add isLanguageModelConfigured to service ping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - [EE] Added prompt caching for Ask Sourcebot. For Anthropic models, the static prompt prefix (tool definitions, system prompt, and conversation history) is marked with a cache breakpoint so it is billed at the provider's discounted cache-read rate on subsequent agent steps and follow-up turns. Toggle with `SOURCEBOT_CHAT_PROMPT_CACHING_ENABLED` (default `true`). [#1278](https://github.com/sourcebot-dev/sourcebot/pull/1278)
 - [EE] Added a cached-token breakdown to the Ask Sourcebot message details, showing what share of the input tokens were served from the model provider's prompt cache. [#1278](https://github.com/sourcebot-dev/sourcebot/pull/1278)
+- Added `isLanguageModelConfigured` to the service ping, indicating whether at least one language model is configured. [#1296](https://github.com/sourcebot-dev/sourcebot/pull/1296)
 
 ### Changed
 - Anthropic thinking mode (adaptive vs. extended) is now resolved from the model's capabilities via the Anthropic Models API instead of a hardcoded model list. [#1294](https://github.com/sourcebot-dev/sourcebot/pull/1294)

--- a/docs/docs/misc/service-ping.mdx
+++ b/docs/docs/misc/service-ping.mdx
@@ -23,6 +23,7 @@ The data contained within the Service Ping is limited to:
 | `mauCount` | `integer` | Monthly active users. |
 | `deploymentType` | `string` | Deployment flavor (e.g. `docker`, `helm`). |
 | `isTelemetryEnabled` | `boolean` | Whether anonymous product telemetry is enabled. |
+| `isLanguageModelConfigured` | `boolean` | Whether at least one language model is configured. |
 | `activationCode` | `string` | Activation code, if your instance has one bound. |
 
 
@@ -57,6 +58,7 @@ body: {
   "mauCount": 1,
   "deploymentType": "other",
   "isTelemetryEnabled": true,
+  "isLanguageModelConfigured": true,
   "activationCode": "sb_act_3a925f51...."
 }
 ```

--- a/packages/web/src/features/billing/CLAUDE.md
+++ b/packages/web/src/features/billing/CLAUDE.md
@@ -16,3 +16,13 @@ This applies to:
 - Adding, removing, or renaming fields on any `*RequestSchema` / `*ResponseSchema`.
 - Changing a field's type, nullability, or validation (e.g. `.optional()`, `.nullable()`, `.datetime()`).
 - Adding new route schemas.
+
+## Keeping the Service Ping docs in sync
+
+Whenever you change the `servicePingRequestSchema` (the `/ping` request payload) in `types.ts`, you MUST also update the user-facing Service Ping documentation:
+
+```
+docs/docs/misc/service-ping.mdx
+```
+
+This includes updating the field reference table and the example payload to reflect any added, removed, or renamed fields.

--- a/packages/web/src/features/billing/servicePing.ts
+++ b/packages/web/src/features/billing/servicePing.ts
@@ -6,6 +6,7 @@ import { createLogger, decryptActivationCode, env, SOURCEBOT_VERSION } from "@so
 import { client } from "./client";
 import { ServicePingRequest } from "./types";
 import { ServiceErrorException } from "@/lib/serviceError";
+import { getConfiguredLanguageModels } from "@/features/chat/utils.server";
 
 const logger = createLogger('service-ping');
 
@@ -65,6 +66,8 @@ export const syncWithLighthouse = async (orgId: number) => {
         ? decryptActivationCode(license.activationCode)
         : undefined;
 
+    const isLanguageModelConfigured = (await getConfiguredLanguageModels()).length > 0;
+
     const payload: ServicePingRequest = {
         installId: env.SOURCEBOT_INSTALL_ID,
         version: SOURCEBOT_VERSION,
@@ -76,6 +79,7 @@ export const syncWithLighthouse = async (orgId: number) => {
         mauCount,
         deploymentType: inferDeploymentType(),
         isTelemetryEnabled: env.SOURCEBOT_TELEMETRY_DISABLED === 'false',
+        isLanguageModelConfigured,
         ...(activationCode && { activationCode }),
     };
 

--- a/packages/web/src/features/billing/types.ts
+++ b/packages/web/src/features/billing/types.ts
@@ -11,6 +11,7 @@ export const servicePingRequestSchema = z.object({
     mauCount: z.number().int().nonnegative(),
     deploymentType: z.string(),
     isTelemetryEnabled: z.boolean(),
+    isLanguageModelConfigured: z.boolean(),
     activationCode: z.string().optional(),
 });
 export type ServicePingRequest = z.infer<typeof servicePingRequestSchema>;


### PR DESCRIPTION
Fixes SOU-1278

Adds `isLanguageModelConfigured` to the service ping payload, set to `true` when at least one language model is configured. Updates the mirrored lighthouse request schema (sourcebot-dev/lighthouse#16) and the Service Ping docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Service Ping now includes an `isLanguageModelConfigured` field to indicate whether at least one language model has been configured in your system.

* **Documentation**
  * Updated Service Ping documentation with the new field and example payload.
  * Added guidelines ensuring Service Ping documentation remains synchronized with implementation updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->