### PR TITLE
fix(backend): prevent duplicate index jobs from indexedAt race

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Surfaced an actionable error when the Lighthouse licensing service is unreachable, instead of a generic "unexpected error". [#1293](https://github.com/sourcebot-dev/sourcebot/pull/1293)
 - Fixed the selected language model rapidly flipping in local storage after a language model was removed. [#1295](https://github.com/sourcebot-dev/sourcebot/pull/1295)
 - Fixed issue where using multiple identity providers of the same type (e.g., gitlab) would result in unexpected behaviours. [#1177](https://github.com/sourcebot-dev/sourcebot/pull/1177)
+- Fixed a race condition where large repositories could be indexed twice within a single reindex interval. [#1298](https://github.com/sourcebot-dev/sourcebot/pull/1298)
 
 ## [5.0.1] - 2026-06-04
 

--- a/packages/backend/src/repoIndexManager.test.ts
+++ b/packages/backend/src/repoIndexManager.test.ts
@@ -525,17 +525,16 @@ describe('RepoIndexManager', () => {
 
             manager = new RepoIndexManager(mockPrisma, mockSettings, mockRedis, mockPromClient as any);
 
+            // The onJobCompleted handler reads the job via findUniqueOrThrow, then marks it
+            // COMPLETED and updates the repo (indexedAt, etc.) in a single repoIndexingJob.update
+            // with a nested repo update.
             (mockPrisma.repoIndexingJob.findUniqueOrThrow as Mock).mockResolvedValue({
-                status: RepoIndexingJobStatus.PENDING,
-            });
-            // The onJobCompleted handler calls repoIndexingJob.update once and then repo.update
-            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({
                 type: RepoIndexingJobType.INDEX,
                 repoId: repo.id,
                 repo,
                 metadata: {},
             });
-            (mockPrisma.repo.update as Mock).mockResolvedValue(repo);
+            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({ repo });
 
             // Get the onCompleted handler
             const onCompletedHandler = mockWorkerOn.mock.calls.find((call: unknown[]) => call[0] === 'completed')?.[1];
@@ -552,22 +551,20 @@ describe('RepoIndexManager', () => {
 
             await onCompletedHandler(mockJob);
 
+            // The job status and indexedAt must be written together (single transaction) to
+            // close the race where the scheduler sees a completed job but a stale indexedAt.
             expect(mockPrisma.repoIndexingJob.update).toHaveBeenCalledWith(
                 expect.objectContaining({
                     where: { id: 'job-1' },
                     data: expect.objectContaining({
                         status: RepoIndexingJobStatus.COMPLETED,
                         completedAt: expect.any(Date),
-                    }),
-                })
-            );
-
-            expect(mockPrisma.repo.update).toHaveBeenCalledWith(
-                expect.objectContaining({
-                    where: { id: repo.id },
-                    data: expect.objectContaining({
-                        indexedAt: expect.any(Date),
-                        indexedCommitHash: 'abc123',
+                        repo: {
+                            update: expect.objectContaining({
+                                indexedAt: expect.any(Date),
+                                indexedCommitHash: 'abc123',
+                            }),
+                        },
                     }),
                 })
             );
@@ -754,14 +751,12 @@ describe('RepoIndexManager', () => {
             manager = new RepoIndexManager(mockPrisma, mockSettings, mockRedis, mockPromClient as any);
 
             (mockPrisma.repoIndexingJob.findUniqueOrThrow as Mock).mockResolvedValue({
-                status: RepoIndexingJobStatus.PENDING,
-            });
-            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({
                 type: RepoIndexingJobType.CLEANUP,
                 repoId: repo.id,
                 repo,
                 metadata: {},
             });
+            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({ repo });
             (mockPrisma.repo.delete as Mock).mockResolvedValue(repo);
 
             const onCompletedHandler = mockWorkerOn.mock.calls.find((call: unknown[]) => call[0] === 'completed')?.[1];
@@ -840,13 +835,13 @@ describe('RepoIndexManager', () => {
 
             manager = new RepoIndexManager(mockPrisma, mockSettings, mockRedis, mockPromClient as any);
 
-            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({
+            (mockPrisma.repoIndexingJob.findUniqueOrThrow as Mock).mockResolvedValue({
                 type: RepoIndexingJobType.INDEX,
                 repoId: repo.id,
                 repo,
                 metadata: {},
             });
-            (mockPrisma.repo.update as Mock).mockResolvedValue(repo);
+            (mockPrisma.repoIndexingJob.update as Mock).mockResolvedValue({ repo });
 
             const onCompletedHandler = mockWorkerOn.mock.calls.find((call: unknown[]) => call[0] === 'completed')?.[1];
 
@@ -867,9 +862,9 @@ describe('RepoIndexManager', () => {
                     data: expect.objectContaining({
                         status: RepoIndexingJobStatus.COMPLETED,
                         repo: {
-                            update: {
+                            update: expect.objectContaining({
                                 latestIndexingJobStatus: RepoIndexingJobStatus.COMPLETED,
-                            },
+                            }),
                         },
                     }),
                 })

--- a/packages/backend/src/repoIndexManager.ts
+++ b/packages/backend/src/repoIndexManager.ts
@@ -545,23 +545,16 @@ export class RepoIndexManager {
     private async onJobCompleted(job: Job<JobPayload>) {
         try {
             const logger = createJobLogger(job.data.jobId);
-            const jobData = await this.db.repoIndexingJob.update({
+            const jobData = await this.db.repoIndexingJob.findUniqueOrThrow({
                 where: { id: job.data.jobId },
-                data: {
-                    status: RepoIndexingJobStatus.COMPLETED,
-                    completedAt: new Date(),
-                    repo: {
-                        update: {
-                            latestIndexingJobStatus: RepoIndexingJobStatus.COMPLETED,
-                        }
-                    }
-                },
                 include: {
                     repo: true,
                 }
             });
 
             const jobTypeLabel = getJobTypePrometheusLabel(jobData.type);
+            // @note: capture this before the update below, since the update sets indexedAt.
+            const isFirstIndex = jobData.repo.indexedAt === null;
 
             if (jobData.type === RepoIndexingJobType.INDEX) {
                 const { path: repoPath } = getRepoPath(jobData.repo);
@@ -576,29 +569,47 @@ export class RepoIndexManager {
 
                 const jobMetadata = repoIndexingJobMetadataSchema.parse(jobData.metadata);
 
-                const repo = await this.db.repo.update({
-                    where: { id: jobData.repoId },
+                const { repo } = await this.db.repoIndexingJob.update({
+                    where: { id: job.data.jobId },
                     data: {
-                        indexedAt: new Date(),
-                        indexedCommitHash: commitHash,
-                        pushedAt: pushedAt,
-                        metadata: {
-                            ...(jobData.repo.metadata as RepoMetadata),
-                            indexedRevisions: jobMetadata.indexedRevisions,
-                        } satisfies RepoMetadata,
-                        // @note: always update the default branch. While this field can be set
-                        // during connection syncing, by setting it here we ensure that a) the
-                        // default branch is as up to date as possible (since repo indexing happens
-                        // more frequently than connection syncing) and b) for hosts where it is
-                        // impossible to determine the default branch from the host's API
-                        // (e.g., generic git url), we still set the default branch here.
-                        defaultBranch: defaultBranch,
+                        status: RepoIndexingJobStatus.COMPLETED,
+                        completedAt: new Date(),
+                        repo: {
+                            update: {
+                                latestIndexingJobStatus: RepoIndexingJobStatus.COMPLETED,
+                                indexedAt: new Date(),
+                                indexedCommitHash: commitHash,
+                                pushedAt: pushedAt,
+                                metadata: {
+                                    ...(jobData.repo.metadata as RepoMetadata),
+                                    indexedRevisions: jobMetadata.indexedRevisions,
+                                } satisfies RepoMetadata,
+                                // @note: always update the default branch. While this field can be set
+                                // during connection syncing, by setting it here we ensure that a) the
+                                // default branch is as up to date as possible (since repo indexing happens
+                                // more frequently than connection syncing) and b) for hosts where it is
+                                // impossible to determine the default branch from the host's API
+                                // (e.g., generic git url), we still set the default branch here.
+                                defaultBranch: defaultBranch,
+                            }
+                        }
+                    },
+                    include: {
+                        repo: true,
                     }
                 });
 
                 logger.debug(`Completed index job ${job.data.jobId} for repo ${repo.name} (id: ${repo.id})`);
             }
             else if (jobData.type === RepoIndexingJobType.CLEANUP) {
+                await this.db.repoIndexingJob.update({
+                    where: { id: job.data.jobId },
+                    data: {
+                        status: RepoIndexingJobStatus.COMPLETED,
+                        completedAt: new Date(),
+                    }
+                });
+
                 const repo = await this.db.repo.delete({
                     where: { id: jobData.repoId },
                 });
@@ -610,7 +621,7 @@ export class RepoIndexManager {
             this.promClient.activeRepoIndexJobs.dec({ repo: job.data.repoName, type: jobTypeLabel });
             this.promClient.repoIndexJobSuccessTotal.inc({ repo: job.data.repoName, type: jobTypeLabel });
 
-            if (jobData.type === RepoIndexingJobType.INDEX && jobData.repo.indexedAt === null) {
+            if (jobData.type === RepoIndexingJobType.INDEX && isFirstIndex) {
                 captureEvent('backend_repo_first_indexed', {
                     repoId: job.data.repoId,
                     type: jobData.repo.external_codeHostType,


### PR DESCRIPTION
Fixes SOU-1150

## Problem

Large repositories could be indexed twice within a single reindex interval due to a race in `RepoIndexManager.onJobCompleted` (`packages/backend/src/repoIndexManager.ts`).

The handler did three things in order:
1. Mark the index job `COMPLETED` (one DB write, which also flips `repo.latestIndexingJobStatus`).
2. Run several git reads — `isRepoEmpty`, `getCommitHashForRefName`, `getLatestCommitTimestamp`, `getLocalDefaultBranch`.
3. Update `repo.indexedAt` (a separate DB write).

Between steps 1 and 3 there is a window — the duration of the git reads in step 2 — where the job is already `COMPLETED` but `indexedAt` is still stale. The scheduler (`scheduleIndexJobs`) polls every `reindexRepoPollingIntervalMs` (default **1s**) and creates a new index job when **both**:
- `indexedAt IS NULL OR indexedAt < now - reindexIntervalMs` (still true — step 3 hasn't run), **and**
- there is no `INDEX` job in `PENDING`/`IN_PROGRESS` (now true — step 1 already flipped it to `COMPLETED`).

So a poll landing in that window schedules a **duplicate** index job. On large repos the git reads take long enough that the 1s poll hits the window routinely; the Redlock doesn't help because `onJobCompleted` runs as a BullMQ `completed` event handler, after the lock from `processJob` has already been released (and the duplicate job row is created regardless of execution serialization).

## Fix

Run the git reads **first**, then write `status = COMPLETED` **and** `indexedAt` (plus `indexedCommitHash`, `pushedAt`, metadata, `defaultBranch`) together in a **single** `repoIndexingJob.update` with a nested `repo` update.

Now the job remains `IN_PROGRESS` for the entire git-read window and only flips to `COMPLETED` at the same instant `indexedAt` becomes fresh. The scheduler's two guards can never both pass simultaneously: before the write, the active-job guard blocks; after it, the fresh `indexedAt` guards.

## Verification

Reproduced the original bug locally by injecting a 5s sleep between the `COMPLETED` write and the `indexedAt` update — a single repo cascaded into 4 index jobs within ~11s. After the fix, with the sleep moved to before the combined write (so the job stays `IN_PROGRESS`), no duplicate is scheduled.

- `yarn workspace @sourcebot/backend build` passes.
- `yarn workspace @sourcebot/backend test --run repoIndexManager` — 15/15 pass. The "updates repo.indexedAt" test now asserts `status: COMPLETED` and `indexedAt` are written in the same `repoIndexingJob.update` call, which serves as the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed a race condition that could cause large repositories to be indexed twice within a single reindex interval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->