### PR TITLE
chore: upgrade shell-quote to ^1.8.4 to address CVE-2026-9277

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the selected language model rapidly flipping in local storage after a language model was removed. [#1295](https://github.com/sourcebot-dev/sourcebot/pull/1295)
 - Fixed issue where using multiple identity providers of the same type (e.g., gitlab) would result in unexpected behaviours. [#1177](https://github.com/sourcebot-dev/sourcebot/pull/1177)
 - Fixed a race condition where large repositories could be indexed twice within a single reindex interval. [#1298](https://github.com/sourcebot-dev/sourcebot/pull/1298)
+- Upgraded `shell-quote` to `^1.8.4`. [#1299](https://github.com/sourcebot-dev/sourcebot/pull/1299)
 
 ## [5.0.1] - 2026-06-04
 

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
         "smol-toml@npm:^1.6.0": "^1.6.1",
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
-        "fast-uri@npm:^3.0.1": "^3.1.2"
+        "fast-uri@npm:^3.0.1": "^3.1.2",
+        "shell-quote@npm:1.8.3": "^1.8.4"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -21137,17 +21137,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"shell-quote@npm:1.8.3":
-  version: 1.8.3
-  resolution: "shell-quote@npm:1.8.3"
-  checksum: 10c0/bee87c34e1e986cfb4c30846b8e6327d18874f10b535699866f368ade11ea4ee45433d97bf5eada22c4320c27df79c3a6a7eb1bf3ecfc47f2c997d9e5e2672fd
-  languageName: node
-  linkType: hard
-
-"shell-quote@npm:^1.6.1":
-  version: 1.8.2
-  resolution: "shell-quote@npm:1.8.2"
-  checksum: 10c0/85fdd44f2ad76e723d34eb72c753f04d847ab64e9f1f10677e3f518d0e5b0752a176fd805297b30bb8c3a1556ebe6e77d2288dbd7b7b0110c7e941e9e9c20ce1
+"shell-quote@npm:^1.6.1, shell-quote@npm:^1.8.4":
+  version: 1.8.4
+  resolution: "shell-quote@npm:1.8.4"
+  checksum: 10c0/86c93678bc394cb81f5ddcdc87df9c95d279ef9652775cd1cd1eed361404169a8d8cbaacaeed232ab09919e36ee1e5363863570390d78571f8c22b7f6312fb40
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1303

Addresses **CVE-2026-9277** ([GHSA-w7jw-789q-3m8p](https://github.com/ljharb/shell-quote/security/advisories/GHSA-w7jw-789q-3m8p)) — command injection via unescaped line terminators in shell-quote's `quote()`.

`shell-quote` is pulled in transitively (dev-only) by two top-level devDependencies:
- `concurrently@9.2.1` pins it to exactly `1.8.3` (vulnerable). No patched 9.x exists; the only top-level fix is a major bump to `concurrently@10`, so per our CVE guidelines this falls back to a qualified `resolutions` override forcing `^1.8.4`.
- `npm-run-all@4.1.5` requested `^1.6.1` but the lockfile was stale at `1.8.2`; `yarn up -R shell-quote` refreshed it to `1.8.4`.

After the change, `yarn why shell-quote` shows both consumers resolving to the patched `1.8.4`, and the two lockfile entries collapse into one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Upgraded a core dependency to improve stability and security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->