### PR TITLE
fix(worker): pass logger to getAuthCredentialsForRepo during repo sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where using multiple identity providers of the same type (e.g., gitlab) would result in unexpected behaviours. [#1177](https://github.com/sourcebot-dev/sourcebot/pull/1177)
 - Fixed a race condition where large repositories could be indexed twice within a single reindex interval. [#1298](https://github.com/sourcebot-dev/sourcebot/pull/1298)
 - Upgraded `shell-quote` to `^1.8.4`. [#1299](https://github.com/sourcebot-dev/sourcebot/pull/1299)
-- Passed the logger into `getAuthCredentialsForRepo` during repo sync so its debug logs surface which auth path was taken. [#1300](https://github.com/sourcebot-dev/sourcebot/pull/1300)
 
 ## [5.0.1] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed issue where using multiple identity providers of the same type (e.g., gitlab) would result in unexpected behaviours. [#1177](https://github.com/sourcebot-dev/sourcebot/pull/1177)
 - Fixed a race condition where large repositories could be indexed twice within a single reindex interval. [#1298](https://github.com/sourcebot-dev/sourcebot/pull/1298)
 - Upgraded `shell-quote` to `^1.8.4`. [#1299](https://github.com/sourcebot-dev/sourcebot/pull/1299)
+- Passed the logger into `getAuthCredentialsForRepo` during repo sync so its debug logs surface which auth path was taken. [#1300](https://github.com/sourcebot-dev/sourcebot/pull/1300)
 
 ## [5.0.1] - 2026-06-04
 

--- a/packages/backend/src/repoIndexManager.ts
+++ b/packages/backend/src/repoIndexManager.ts
@@ -351,7 +351,7 @@ export class RepoIndexManager {
 
         const metadata = repoMetadataSchema.parse(repo.metadata);
 
-        const credentials = await getAuthCredentialsForRepo(repo);
+        const credentials = await getAuthCredentialsForRepo(repo, logger);
         const cloneUrlMaybeWithToken = credentials?.cloneUrlWithToken ?? repo.cloneUrl;
         const authHeader = credentials?.authHeader ?? undefined;
 


### PR DESCRIPTION
Related to SOU-1194.

`getAuthCredentialsForRepo` was called without a logger during repo indexing, so its debug lines (e.g. `Using GitHub App for service auth...`) were no-ops. Passing the logger surfaces which auth branch is taken, which is needed to diagnose the GitHub App clone failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Debug logs during repository synchronization now accurately reflect which authentication method was used.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->