### PR TITLE
fix(web): prevent crash when User-Agent header is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Validated that `SOURCEBOT_ENCRYPTION_KEY` is exactly 32 characters at startup, failing fast with an actionable message instead of a runtime encryption error. [#1305](https://github.com/sourcebot-dev/sourcebot/pull/1305)
+- Fixed the web UI crashing when anonymous access is enabled and a request omits the `User-Agent` header (e.g. proxy or health-check probes). [#1309](https://github.com/sourcebot-dev/sourcebot/pull/1309)
 
 ## [5.0.2] - 2026-06-11
 

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -148,7 +148,7 @@ export default async function Layout(props: LayoutProps) {
     const headersList = await headers();
     const cookieStore = await cookies()
     const userAgent = headersList.get('user-agent');
-    const { isMobile } = getSelectorsByUserAgent(userAgent ?? '');
+    const { isMobile } = userAgent ? getSelectorsByUserAgent(userAgent) : { isMobile: false };
 
     if (isMobile && !cookieStore.has(MOBILE_UNSUPPORTED_SPLASH_SCREEN_DISMISSED_COOKIE_NAME)) {
         return (


### PR DESCRIPTION
Fixes SOU-1328
Fixes #1308

## Problem

Enabling anonymous access made the web UI unavailable, with the Docker logs showing a recurring `No valid user agent string was provided` warning followed by a `TypeError` destructuring `isMobile` from `undefined`.

**Root cause:** In `packages/web/src/app/(app)/layout.tsx`, the mobile-detection check calls `getSelectorsByUserAgent(userAgent ?? '')`. `react-device-detect` returns `undefined` (not an object) for an empty string, so destructuring `{ isMobile }` throws.

**Why anonymous access is the trigger:** With anonymous access disabled, session-less requests are redirected to `/login` earlier in the layout and never reach this line. With anonymous access enabled, they fall through to the mobile check. Requests that omit the `User-Agent` header (proxy/health-check probes, e.g. HAProxy `option httpchk`) then crash the root `(app)` layout, taking down the whole UI. These recurring probes are what produced the repeating error in the logs.

## Fix

Only call `getSelectorsByUserAgent` when a non-empty `User-Agent` is present; otherwise treat the client as non-mobile.

## Reproduction

Against a single-tenant instance with **anonymous access enabled**, send a request to the app root with an empty/missing User-Agent:

```bash
curl -sS -o /dev/null -w "%{http_code}\n" -H "User-Agent;" http://localhost:3000/
```

Before: `500` (crashed layout). After: renders normally. With anonymous access disabled, the same request 307-redirects to `/login` (unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a web UI crash that occurred when accessing the application anonymously without providing a User-Agent header.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->