### PR TITLE
chore: upgrade @grpc/grpc-js to ^1.14.4 to address CVE-2026-48068, CVE-2026-48069

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
+
 ## [5.0.3] - 2026-06-17
 
 ### Changed

--- a/yarn.lock
+++ b/yarn.lock
@@ -2492,23 +2492,13 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@grpc/grpc-js@npm:^1.12.6":
-  version: 1.14.0
-  resolution: "@grpc/grpc-js@npm:1.14.0"
+"@grpc/grpc-js@npm:^1.12.6, @grpc/grpc-js@npm:^1.14.1":
+  version: 1.14.4
+  resolution: "@grpc/grpc-js@npm:1.14.4"
   dependencies:
     "@grpc/proto-loader": "npm:^0.8.0"
     "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10c0/51e0eb32f6dac68c49502b227e565c4244f53983d2efab8ef3fd2cc923999751c059f6c77fec4941a93c44eaa58cbc321ce1e9868e1ec226fba5a6c93722c3b1
-  languageName: node
-  linkType: hard
-
-"@grpc/grpc-js@npm:^1.14.1":
-  version: 1.14.1
-  resolution: "@grpc/grpc-js@npm:1.14.1"
-  dependencies:
-    "@grpc/proto-loader": "npm:^0.8.0"
-    "@js-sdsl/ordered-map": "npm:^4.4.2"
-  checksum: 10c0/a9a8fc7f4dfa374a34e37350b37ad2c092ed533b203fe16d45ba3220fe38195d17a87527dade2e5546afeeeccfcf68d3e914705d94e44e8df461321b0c02cc7a
+  checksum: 10c0/0ff6395e8112ad30e8f99dbb684b997ebc3264e770b8e354f23effeedf181a380e0ecef8bca466cbbf3e9141968656144851de1da50f840a1efd9314c9812449
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1307

Refreshes the lockfile so all instances of `@grpc/grpc-js` resolve to `1.14.4`, patching a server crash via malformed HTTP/2 stream (CVE-2026-48068) and CVE-2026-48069, both fixed in the same release.

The package was present below the patched threshold via two paths:
- Direct dependency in `packages/web` (`^1.14.1` → was `1.14.1`)
- Transitive via `@sourcebot/shared` → `@google-cloud/secret-manager` → `google-gax` (`^1.12.6` → was `1.14.0`)

Both ranges already permit `1.14.4`, so only `yarn.lock` needed refreshing (`yarn up -R @grpc/grpc-js`). No `package.json` or `resolutions` change required.

Verified with `yarn why @grpc/grpc-js --recursive` — all instances now resolve to `1.14.4`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated changelog to document dependency upgrade addressing stability and compatibility enhancements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->