### PR TITLE
chore: upgrade hono to ^4.12.25 to address CVE-2026-54287

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `hono` to `^4.12.25`. [#1322](https://github.com/sourcebot-dev/sourcebot/pull/1322)
 
 ## [5.0.3] - 2026-06-17
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -15370,9 +15370,9 @@ __metadata:
   linkType: hard
 
 "hono@npm:^4.11.4":
-  version: 4.12.24
-  resolution: "hono@npm:4.12.24"
-  checksum: 10c0/1a1394e48618c34b0ea627d7de7e5d59f1d90aedcd518f9d19b987260bbf16c362043e417bbb64290110c3cd54ef51017f7786438a0c2d811af01566d6ca3e94
+  version: 4.12.25
+  resolution: "hono@npm:4.12.25"
+  checksum: 10c0/9216d647fe2f39b17855b0e74913688b837e3fa9519d367c7beeec399265b36608a820928cc33ab926eee58fe2daf7e33296235b52e56dbfac0fbcd51a5e818e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1346

Refreshes the `hono` lockfile entry to `4.12.25` to address CVE-2026-54287 (GHSA-j6c9-x7qj-28xf), where the AWS Lambda adapter merges multiple `Set-Cookie` headers into one comma-joined value.

`hono` is a transitive dependency (`@modelcontextprotocol/sdk → hono@^4.11.4`). The existing range already admitted the patched version, so only `yarn.lock` needed refreshing (`yarn up -R hono`) — no `package.json` or `resolutions` change. Verified with `yarn why hono` that all instances now resolve to `4.12.25`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated release documentation with dependency maintenance notes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->