### PR TITLE
chore: upgrade dompurify to ^3.4.11 to address CVE-2026-49459

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `dompurify` to `^3.4.11`. [#1323](https://github.com/sourcebot-dev/sourcebot/pull/1323)
 
 ## [5.0.3] - 2026-06-17
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13127,14 +13127,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.3.2":
-  version: 3.4.0
-  resolution: "dompurify@npm:3.4.0"
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1349

Refreshes the `yarn.lock` entry for `dompurify` (transitive via `posthog-js`) from `3.4.0` to `3.4.11`, addressing CVE-2026-49459 (IN_PLACE mode preserving clobbered root element attributes, enabling XSS).

The existing `^3.3.2` range already admitted the patched version, so this is a lockfile refresh (`yarn up -R dompurify`) with no `package.json` or `resolutions` change.