### PR TITLE
chore: upgrade ws to ^8.21.0 to address CVE-2026-48779

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `ws` to `^8.21.0`. [#1324](https://github.com/sourcebot-dev/sourcebot/pull/1324)
 
 ## [5.0.3] - 2026-06-17
 

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
         "teeny-request@npm:^10.0.0": "^10.1.2",
         "uuid": "^14.0.0",
         "fast-uri@npm:^3.0.1": "^3.1.2",
-        "shell-quote@npm:1.8.3": "^1.8.4"
+        "shell-quote@npm:1.8.3": "^1.8.4",
+        "ws@npm:~8.20.1": "^8.21.0"
     }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -23448,9 +23448,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ws@npm:^8.18.0, ws@npm:~8.20.1":
-  version: 8.20.1
-  resolution: "ws@npm:8.20.1"
+"ws@npm:^8.18.0, ws@npm:^8.21.0":
+  version: 8.21.0
+  resolution: "ws@npm:8.21.0"
   peerDependencies:
     bufferutil: ^4.0.1
     utf-8-validate: ">=5.0.2"
@@ -23459,7 +23459,7 @@ __metadata:
       optional: true
     utf-8-validate:
       optional: true
-  checksum: 10c0/ce162433218399cdedeb76fd33363d4d86a7d910058d4e3c679dce08cea65d6da6b39f11baa4d7808d024cf46ed88f6a05c17611621aaad8fc5e62edacc30c5d
+  checksum: 10c0/ef4a243476283fc49bc7550966c4af4aa0eef56273837211e700de3b664e08604a760cdddcb5ba43c049140e74ccfec5b0ee0bb439e08c2adf9138902fdde5f9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1342

Addresses CVE-2026-48779, a memory exhaustion DoS in `ws` where a malicious client can send many tiny WebSocket fragments to cause unbounded memory accumulation before a message is processed. Fixed in `ws@8.21.0`.

`ws` is pulled in transitively (via `@google/genai`, `jsdom`, and `socket.io`/`engine.io`). Refreshing the lockfile bumped most consumers to `8.21.0`, but `engine.io` and `socket.io-adapter` request `~8.20.1`, which cannot reach `8.21.0`. Since the only top-level path is `react-email → socket.io` (a breaking upgrade), a qualified `resolutions` override keyed to the `~8.20.1` range pins those requesters to `^8.21.0`.

Verified with `yarn why ws --recursive` that all instances now resolve to `8.21.0`.