### PR TITLE
chore: upgrade nodemailer to ^8.0.11 to address GHSA-wqvq-jvpq-h66f

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `nodemailer` to `^8.0.11`. [#1327](https://github.com/sourcebot-dev/sourcebot/pull/1327)
 
 ## [5.0.3] - 2026-06-17
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -18226,9 +18226,9 @@ __metadata:
   linkType: hard
 
 "nodemailer@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "nodemailer@npm:8.0.5"
-  checksum: 10c0/5e8450499bd059c56d74ba96fa5f9928de2ecdae0d53c083dba5661d797114c1f9524d30f992d0263cc5a7dcf5a54b9c1d92dc1f766da150c9d0bde7d3798431
+  version: 8.0.11
+  resolution: "nodemailer@npm:8.0.11"
+  checksum: 10c0/19229216c63a32eae59d7b39f3dffeba20be317f2335d08d86fb70bd01845a1bf108fecd019c0e90ef186e3d9177cf478192b333cf38620ad0f8c7a6e1e5ae05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1353

Refreshes the `nodemailer` lockfile entry to `8.0.11` to address [GHSA-wqvq-jvpq-h66f](https://github.com/sourcebot-dev/sourcebot/security/dependabot/248), where `jsonTransport` bypasses the `disableFileAccess` and `disableUrlAccess` flags (fixed in `8.0.9`).

The existing `^8.0.5` range in `packages/web/package.json` already admits the patched version, so only `yarn.lock` needed updating (`yarn up -R nodemailer`).