### PR TITLE
chore: upgrade nodemailer to ^8.0.9 to address GHSA-r7g4-qg5f-qqm2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `nodemailer` to `^8.0.9`. [#1331](https://github.com/sourcebot-dev/sourcebot/pull/1331)
 
 ## [5.0.3] - 2026-06-17
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -163,7 +163,7 @@
     "next-auth": "^5.0.0-beta.30",
     "next-navigation-guard": "^0.2.0",
     "next-themes": "^0.3.0",
-    "nodemailer": "^8.0.5",
+    "nodemailer": "^8.0.9",
     "octokit": "^4.1.3",
     "openai": "^4.98.0",
     "parse-diff": "^0.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9548,7 +9548,7 @@ __metadata:
     next-auth: "npm:^5.0.0-beta.30"
     next-navigation-guard: "npm:^0.2.0"
     next-themes: "npm:^0.3.0"
-    nodemailer: "npm:^8.0.5"
+    nodemailer: "npm:^8.0.9"
     npm-run-all: "npm:^4.1.5"
     octokit: "npm:^4.1.3"
     openai: "npm:^4.98.0"
@@ -18225,10 +18225,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"nodemailer@npm:^8.0.5":
-  version: 8.0.5
-  resolution: "nodemailer@npm:8.0.5"
-  checksum: 10c0/5e8450499bd059c56d74ba96fa5f9928de2ecdae0d53c083dba5661d797114c1f9524d30f992d0263cc5a7dcf5a54b9c1d92dc1f766da150c9d0bde7d3798431
+"nodemailer@npm:^8.0.9":
+  version: 8.0.11
+  resolution: "nodemailer@npm:8.0.11"
+  checksum: 10c0/19229216c63a32eae59d7b39f3dffeba20be317f2335d08d86fb70bd01845a1bf108fecd019c0e90ef186e3d9177cf478192b333cf38620ad0f8c7a6e1e5ae05
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1354

Upgrades `nodemailer` from `8.0.5` to `^8.0.9` (resolves to `8.0.11`) to address [GHSA-r7g4-qg5f-qqm2](https://github.com/sourcebot-dev/sourcebot/security/dependabot/247), where Nodemailer's internal HTTPS fetch client disabled TLS certificate verification (`rejectUnauthorized: false`) for OAuth2 token requests. This release also covers the other open Nodemailer advisories.

`nodemailer` is a direct dependency of `@sourcebot/web`, so this is a top-level bump.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated email service dependency to the latest patch version for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->