### PR TITLE
chore: upgrade dompurify to ^3.4.11 to address GHSA-x4vx-rjvf-j5p4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)
+- Upgraded `dompurify` to `^3.4.11`. [#1332](https://github.com/sourcebot-dev/sourcebot/pull/1332)
 
 ## [5.0.3] - 2026-06-17
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -13127,14 +13127,14 @@ __metadata:
   linkType: hard
 
 "dompurify@npm:^3.3.2":
-  version: 3.4.0
-  resolution: "dompurify@npm:3.4.0"
+  version: 3.4.11
+  resolution: "dompurify@npm:3.4.11"
   dependencies:
     "@types/trusted-types": "npm:^2.0.7"
   dependenciesMeta:
     "@types/trusted-types":
       optional: true
-  checksum: 10c0/5593ac44ee20b9aa521c2120884effc98927fb9128c548183c75e79e0a04357c62ee913a049a267c8f396cb8c9d520ecf72562826c5524c46d4fe03c12063638
+  checksum: 10c0/31439481c7e8fc3805d40c376936fd66936620fb1b1a31a2ec097f6165412c37f2d868e082c9ceba62bb37661c1ea132a5db4d5213434317e30df68d4aca9cc9
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1356

Addresses GHSA-x4vx-rjvf-j5p4 (DOMPurify `IN_PLACE` mode trusts attacker-controlled `nodeName` on live non-form nodes). The advisory affects `dompurify <= 3.4.6`; `dompurify` reaches us transitively via `posthog-js`, whose `^3.3.2` range already admits the patched releases, so this is just a stale-lockfile refresh (`yarn up -R dompurify`) bumping the resolved version from `3.4.0` to `3.4.11`. No `package.json` or `resolutions` changes needed.

Verified with `yarn why dompurify --recursive` that the only resolution is now `3.4.11`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated dompurify to version 3.4.11 for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->