### PR TITLE
feat(ci): tag triaged Linear issues with the source repository

### DIFF
--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -563,9 +563,36 @@ jobs:
             exit 1
           fi
 
+          # Resolve (or create) a team label named after the repository, so each created
+          # issue is tagged with its source repo (e.g. "sourcebot-dev/sourcebot").
+          REPO_LABEL_QUERY='query($teamId: String!, $name: String!) { team(id: $teamId) { labels(filter: { name: { eq: $name } }) { nodes { id } } } }'
+          REPO_LABEL_PAYLOAD=$(jq -n --arg query "$REPO_LABEL_QUERY" --arg teamId "$TEAM_UUID" --arg name "$REPOSITORY" \
+            '{query: $query, variables: {teamId: $teamId, name: $name}}')
+          REPO_LABEL_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
+            -H "Content-Type: application/json" \
+            -H "Authorization: $LINEAR_API_KEY" \
+            -d "$REPO_LABEL_PAYLOAD")
+          REPO_LABEL_ID=$(echo "$REPO_LABEL_RESPONSE" | jq -r '.data.team.labels.nodes[0].id // empty')
+
+          if [ -z "$REPO_LABEL_ID" ]; then
+            echo "No '$REPOSITORY' label in Linear team — creating it."
+            CREATE_LABEL_MUTATION='mutation($teamId: String!, $name: String!) { issueLabelCreate(input: { teamId: $teamId, name: $name }) { success issueLabel { id } } }'
+            CREATE_LABEL_PAYLOAD=$(jq -n --arg query "$CREATE_LABEL_MUTATION" --arg teamId "$TEAM_UUID" --arg name "$REPOSITORY" \
+              '{query: $query, variables: {teamId: $teamId, name: $name}}')
+            CREATE_LABEL_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
+              -H "Content-Type: application/json" \
+              -H "Authorization: $LINEAR_API_KEY" \
+              -d "$CREATE_LABEL_PAYLOAD")
+            REPO_LABEL_ID=$(echo "$CREATE_LABEL_RESPONSE" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
+            if [ -z "$REPO_LABEL_ID" ]; then
+              echo "::warning::Could not create '$REPOSITORY' label: $(echo "$CREATE_LABEL_RESPONSE" | jq -c '.errors // .')"
+            fi
+          fi
+
           {
             echo "team_uuid=$TEAM_UUID"
             echo "label_id=$LABEL_ID"
+            echo "repo_label_id=$REPO_LABEL_ID"
             echo "state_id=$STATE_ID"
             echo "viewer_id=$VIEWER_ID"
           } >> "$GITHUB_OUTPUT"
@@ -644,16 +671,21 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TEAM_UUID: ${{ steps.match.outputs.team_uuid }}
           LABEL_ID: ${{ steps.match.outputs.label_id }}
+          REPO_LABEL_ID: ${{ steps.match.outputs.repo_label_id }}
           STATE_ID: ${{ steps.match.outputs.state_id }}
           VIEWER_ID: ${{ steps.match.outputs.viewer_id }}
         run: |
           set -uo pipefail
-          # Team UUID, "CVE" label, "Triage" state, and the API key owner's user ID were
-          # already resolved by the "Match existing Linear issues" step and passed in as env.
+          # Team UUID, the "CVE" + repository labels, "Triage" state, and the API key
+          # owner's user ID were already resolved by the "Match existing Linear issues"
+          # step and passed in as env.
           STRUCTURED_OUTPUT=$(cat findings.json)
 
           if [ -z "$LABEL_ID" ]; then
             echo "::warning::Could not find 'CVE' label in Linear team. Creating issues without label."
+          fi
+          if [ -z "$REPO_LABEL_ID" ]; then
+            echo "::warning::Could not resolve '$REPOSITORY' repository label. Creating issues without it."
           fi
           if [ -z "$STATE_ID" ]; then
             echo "::warning::Could not find 'Triage' state in Linear team. Using default state."
@@ -756,8 +788,10 @@ jobs:
               --argjson priority "$PRIORITY" \
               '{teamId: $teamId, title: $title, description: $desc, priority: $priority}')
 
-            if [ -n "$LABEL_ID" ]; then
-              VARIABLES=$(echo "$VARIABLES" | jq --arg lid "$LABEL_ID" '. + {labelIds: [$lid]}')
+            # Attach the "CVE" label and the repository label (dropping any that failed to resolve).
+            LABEL_IDS=$(jq -n --arg cve "$LABEL_ID" --arg repo "$REPO_LABEL_ID" '[$cve, $repo] | map(select(. != ""))')
+            if [ "$(echo "$LABEL_IDS" | jq 'length')" -gt 0 ]; then
+              VARIABLES=$(echo "$VARIABLES" | jq --argjson lids "$LABEL_IDS" '. + {labelIds: $lids}')
             fi
             if [ -n "$STATE_ID" ]; then
               VARIABLES=$(echo "$VARIABLES" | jq --arg sid "$STATE_ID" '. + {stateId: $sid}')


### PR DESCRIPTION
## Summary

Tags each Linear issue created by the vulnerability-triage workflow with a label named after the source repository (e.g. `sourcebot-dev/sourcebot`), in addition to the existing `CVE` label. This makes triaged issues filterable by repo in Linear.

## How

- In the **Match existing Linear issues** step, after resolving the team/`CVE`-label/state/viewer, resolve a team label whose name equals `${{ github.repository }}`. If it doesn't exist yet, create it via `issueLabelCreate` (team-scoped, like the `CVE` label). Expose it as a `repo_label_id` step output.
- In the **Create Linear issues** step, attach both the `CVE` label and the repository label (any that failed to resolve are dropped).

The label is created at most once — subsequent runs find the existing one. Reopened issues are unchanged (they already carry their labels).

## Notes

- The label uses the full `github.repository` (`owner/repo`) to match the `[owner/repo]` title-prefix scoping already used, which keeps it unambiguous across sibling repos (e.g. `sourcebot-dev/sourcebot-helm-chart`). Easy to switch to the short repo name if you'd prefer.
- No CHANGELOG entry — internal CI/security-automation change, not user-facing.

## Testing

Verified the label-array construction in `jq` (both labels present, repo label missing → only `CVE`, both missing → no `labelIds` sent) and that the workflow YAML parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved vulnerability issue tracking workflow to include repository-specific labeling in addition to existing categorization. Enhanced label resolution and assignment logic for better organization of security-related issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->