### PR TITLE
fix(web): enable Next.js version skew protection during rolling deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `protobufjs` to `^7.6.4`. [#1336](https://github.com/sourcebot-dev/sourcebot/pull/1336)
 - Upgraded `tar` to `^7.5.16`. [#1338](https://github.com/sourcebot-dev/sourcebot/pull/1338)
 - Upgraded `esbuild` to `^0.28.1`. [#1342](https://github.com/sourcebot-dev/sourcebot/pull/1342)
+- Enabled Next.js version skew protection to fix "Failed to load chunk" errors during rolling deploys. [#1346](https://github.com/sourcebot-dev/sourcebot/pull/1346)
 
 ## [5.0.3] - 2026-06-17
 

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -5,6 +5,10 @@ import { withSentryConfig } from "@sentry/nextjs";
 const nextConfig = {
     output: "standalone",
 
+    // Version skew protection for rolling deploys.
+    // @see: https://nextjs.org/docs/app/guides/self-hosting#version-skew
+    deploymentId: process.env.NEXT_PUBLIC_BUILD_COMMIT_SHA,
+
     // This is required when using standalone builds.
     // @see: https://env.t3.gg/docs/nextjs#create-your-schema
     transpilePackages: ["@t3-oss/env-core"],


### PR DESCRIPTION
## Problem

During a Sourcebot pod update, users sometimes see an `Unexpected Error` screen with `Failed to load chunk /_next/static/chunks/<hash>.js`. This is Next.js client/server **version skew**: a browser holding an old build's HTML/runtime requests a content-hashed chunk that the newly-rolled pod no longer serves (especially sharp at `replicaCount: 1`, where the old pod is gone entirely after the rollout). The zero-downtime rollout config handles connection-level downtime (502s) but not stale assets already in a user's browser.

## Fix

Enable Next.js [version skew protection](https://nextjs.org/docs/app/guides/self-hosting#version-skew) by setting `deploymentId` in `next.config.mjs`, sourced from `NEXT_PUBLIC_BUILD_COMMIT_SHA` — a per-build, build-time-stable value already plumbed through the `Dockerfile` and `_build.yml` (`github.sha`).

With this set, Next.js:
- stamps static asset URLs with `?dpl=<sha>`, and
- on a deployment-id mismatch during navigation, triggers a full page reload instead of attempting a client-side navigation that fetches missing chunks.

So a user on an old build silently reloads onto the new build instead of hitting the error screen.

## Notes

- Only active in CI-built images (where `NEXT_PUBLIC_BUILD_COMMIT_SHA` is passed); local `pnpm build` leaves it `undefined`, which harmlessly leaves skew protection inactive.
- No effect when redeploying the exact same commit (same id → same chunks → nothing to protect against), which is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed "Failed to load chunk" errors that occurred during rolling deploys by enabling version skew protection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->