### PR TITLE
feat(web): record service ping history and add usage report download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Recorded service ping history locally and added a "Download usage report" button to the offline license settings page, so offline deployments can export their usage and send it to us. [#1348](https://github.com/sourcebot-dev/sourcebot/pull/1348)
+
 ### Fixed
 - Upgraded `@grpc/grpc-js` to `^1.14.4`. [#1315](https://github.com/sourcebot-dev/sourcebot/pull/1315)
 - Upgraded `vite` to `^8.0.16`. [#1313](https://github.com/sourcebot-dev/sourcebot/pull/1313)

--- a/packages/db/prisma/migrations/20260618182127_add_service_ping_event_table/migration.sql
+++ b/packages/db/prisma/migrations/20260618182127_add_service_ping_event_table/migration.sql
@@ -1,0 +1,8 @@
+-- CreateTable
+CREATE TABLE "ServicePingEvent" (
+    "id" TEXT NOT NULL,
+    "payload" JSONB NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "ServicePingEvent_pkey" PRIMARY KEY ("id")
+);

--- a/packages/db/prisma/migrations/20260618210032_add_service_ping_event_table/migration.sql
+++ b/packages/db/prisma/migrations/20260618210032_add_service_ping_event_table/migration.sql
@@ -3,6 +3,10 @@ CREATE TABLE "ServicePingEvent" (
     "id" TEXT NOT NULL,
     "payload" JSONB NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "orgId" INTEGER NOT NULL,
 
     CONSTRAINT "ServicePingEvent_pkey" PRIMARY KEY ("id")
 );
+
+-- AddForeignKey
+ALTER TABLE "ServicePingEvent" ADD CONSTRAINT "ServicePingEvent_orgId_fkey" FOREIGN KEY ("orgId") REFERENCES "Org"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -318,6 +318,7 @@ model Org {
   mcpServers McpServer[]
 
   license License?
+  servicePingEvents ServicePingEvent[]
 }
 
 model License {
@@ -362,6 +363,9 @@ model ServicePingEvent {
   id String @id @default(cuid())
   payload Json
   createdAt DateTime @default(now())
+
+  org   Org @relation(fields: [orgId], references: [id], onDelete: Cascade)
+  orgId Int
 }
 
 enum OrgRole {

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -358,6 +358,12 @@ model License {
   updatedAt         DateTime @updatedAt
 }
 
+model ServicePingEvent {
+  id String @id @default(cuid())
+  payload Json
+  createdAt DateTime @default(now())
+}
+
 enum OrgRole {
   OWNER
   MEMBER

--- a/packages/shared/src/entitlements.ts
+++ b/packages/shared/src/entitlements.ts
@@ -120,10 +120,18 @@ const getValidOnlineLicense = (_license: License | null): License | null => {
     return null;
 }
 
+export const isValidOfflineLicenseActive = (): boolean => {
+    return getValidOfflineLicense() !== null;
+}
+
+export const isValidOnlineLicenseActive = (_license: License | null): boolean => {
+    return getValidOnlineLicense(_license) !== null;
+}
+
 export const isValidLicenseActive = (_license: License | null): boolean => {
     return (
-        getValidOfflineLicense() !== null ||
-        getValidOnlineLicense(_license) !== null
+        isValidOfflineLicenseActive() ||
+        isValidOnlineLicenseActive(_license)
     );
 }
 

--- a/packages/shared/src/index.server.ts
+++ b/packages/shared/src/index.server.ts
@@ -6,6 +6,8 @@ export {
     getEntitlements as _getEntitlements,
     isAnonymousAccessAvailable as _isAnonymousAccessAvailable,
     isValidLicenseActive as _isValidLicenseActive,
+    isValidOfflineLicenseActive,
+    isValidOnlineLicenseActive as _isValidOnlineLicenseActive,
     getSeatCap,
     getOfflineLicenseMetadata,
     STALE_ONLINE_LICENSE_THRESHOLD_MS,

--- a/packages/web/src/app/(app)/settings/license/actions.ts
+++ b/packages/web/src/app/(app)/settings/license/actions.ts
@@ -14,9 +14,10 @@ export interface ServicePingHistoryEntry {
 // Returns the recorded Service Ping history so offline deployments can export
 // it and send it back to us out-of-band (they can't reach Lighthouse directly).
 export const getServicePingHistory = async (): Promise<ServicePingHistoryEntry[] | ServiceError> => sew(() =>
-    withAuth(async ({ role, prisma }) =>
+    withAuth(async ({ org, role, prisma }) =>
         withMinimumOrgRole(role, OrgRole.OWNER, async () => {
             const events = await prisma.servicePingEvent.findMany({
+                where: { orgId: org.id },
                 orderBy: { createdAt: 'asc' },
             });
 

--- a/packages/web/src/app/(app)/settings/license/actions.ts
+++ b/packages/web/src/app/(app)/settings/license/actions.ts
@@ -1,0 +1,29 @@
+'use server';
+
+import { sew } from "@/middleware/sew";
+import { withAuth } from "@/middleware/withAuth";
+import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
+import { OrgRole } from "@sourcebot/db";
+import { ServiceError } from "@/lib/serviceError";
+
+export interface ServicePingHistoryEntry {
+    createdAt: string;
+    payload: unknown;
+}
+
+// Returns the recorded Service Ping history so offline deployments can export
+// it and send it back to us out-of-band (they can't reach Lighthouse directly).
+export const getServicePingHistory = async (): Promise<ServicePingHistoryEntry[] | ServiceError> => sew(() =>
+    withAuth(async ({ role, prisma }) =>
+        withMinimumOrgRole(role, OrgRole.OWNER, async () => {
+            const events = await prisma.servicePingEvent.findMany({
+                orderBy: { createdAt: 'asc' },
+            });
+
+            return events.map((event) => ({
+                createdAt: event.createdAt.toISOString(),
+                payload: event.payload,
+            }));
+        })
+    )
+);

--- a/packages/web/src/app/(app)/settings/license/downloadServicePingHistoryButton.tsx
+++ b/packages/web/src/app/(app)/settings/license/downloadServicePingHistoryButton.tsx
@@ -1,0 +1,65 @@
+'use client';
+
+import { useCallback, useState } from "react";
+import { Download, Loader2 } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { useToast } from "@/components/hooks/use-toast";
+import { isServiceError } from "@/lib/utils";
+import { getServicePingHistory } from "./actions";
+
+export function DownloadServicePingHistoryButton() {
+    const [isLoading, setIsLoading] = useState(false);
+    const { toast } = useToast();
+
+    const handleDownload = useCallback(async () => {
+        setIsLoading(true);
+        try {
+            const result = await getServicePingHistory();
+
+            if (isServiceError(result)) {
+                toast({
+                    description: "Failed to export service ping history. Please try again.",
+                    variant: "destructive",
+                });
+                return;
+            }
+
+            if (result.length === 0) {
+                toast({
+                    description: "No service ping history has been recorded yet.",
+                });
+                return;
+            }
+
+            const blob = new Blob([JSON.stringify(result, null, 2)], {
+                type: "application/json",
+            });
+            const url = URL.createObjectURL(blob);
+            const anchor = document.createElement("a");
+            anchor.href = url;
+            anchor.download = `${new Date().toISOString().slice(0, 10)}-usage-history.json`;
+            document.body.appendChild(anchor);
+            anchor.click();
+            document.body.removeChild(anchor);
+            URL.revokeObjectURL(url);
+        } finally {
+            setIsLoading(false);
+        }
+    }, [toast]);
+
+    return (
+        <Button
+            variant="outline"
+            size="sm"
+            onClick={handleDownload}
+            disabled={isLoading}
+        >
+            {isLoading ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+                <Download className="h-3.5 w-3.5" />
+            )}
+            Download usage report
+        </Button>
+    );
+}

--- a/packages/web/src/app/(app)/settings/license/downloadServicePingHistoryButton.tsx
+++ b/packages/web/src/app/(app)/settings/license/downloadServicePingHistoryButton.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import { useCallback, useState } from "react";
-import { Download, Loader2 } from "lucide-react";
-import { Button } from "@/components/ui/button";
+import { Download } from "lucide-react";
+import { LoadingButton } from "@/components/ui/loading-button";
 import { useToast } from "@/components/hooks/use-toast";
 import { isServiceError } from "@/lib/utils";
 import { getServicePingHistory } from "./actions";
@@ -48,18 +48,14 @@ export function DownloadServicePingHistoryButton() {
     }, [toast]);
 
     return (
-        <Button
+        <LoadingButton
             variant="outline"
             size="sm"
             onClick={handleDownload}
-            disabled={isLoading}
+            loading={isLoading}
         >
-            {isLoading ? (
-                <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-                <Download className="h-3.5 w-3.5" />
-            )}
+            {!isLoading && <Download className="h-3.5 w-3.5" />}
             Download usage report
-        </Button>
+        </LoadingButton>
     );
 }

--- a/packages/web/src/app/(app)/settings/license/offlineLicenseCard.tsx
+++ b/packages/web/src/app/(app)/settings/license/offlineLicenseCard.tsx
@@ -1,6 +1,7 @@
 import type { OfflineLicenseMetadata } from "@sourcebot/shared";
 import { Badge } from "@/components/ui/badge";
 import { SettingsCard } from "../components/settingsCard";
+import { DownloadServicePingHistoryButton } from "./downloadServicePingHistoryButton";
 
 interface OfflineLicenseCardProps {
     license: OfflineLicenseMetadata;
@@ -15,33 +16,46 @@ export function OfflineLicenseCard({ license, isExpired }: OfflineLicenseCardPro
 
     return (
         <SettingsCard>
-            <div className="flex items-center justify-between gap-6">
-                <div className="flex flex-col gap-1">
-                    <div className="flex items-center gap-2">
-                        <p className="font-medium">Enterprise plan</p>
-                        {isExpired && (
-                            <Badge variant="outline" className="border-destructive/30 text-destructive">
-                                Expired
-                            </Badge>
-                        )}
+            <div className="flex flex-col gap-4">
+                <div className="flex items-center justify-between gap-6">
+                    <div className="flex flex-col gap-1">
+                        <div className="flex items-center gap-2">
+                            <p className="font-medium">Enterprise plan</p>
+                            {isExpired && (
+                                <Badge variant="outline" className="border-destructive/30 text-destructive">
+                                    Expired
+                                </Badge>
+                            )}
+                        </div>
+                        <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
+                            <code className="font-mono">{truncatedId}</code>
+                        </div>
                     </div>
-                    <div className="flex items-center gap-2 text-xs text-muted-foreground mt-0.5">
-                        <code className="font-mono">{truncatedId}</code>
+                    <div className="flex items-center gap-12">
+                        {license.seats !== undefined && (
+                            <div className="flex flex-col items-end">
+                                <p className="text-xs text-muted-foreground">Billed seats</p>
+                                <p className="text-sm">{license.seats}</p>
+                            </div>
+                        )}
+                        <div className="flex flex-col items-end">
+                            <p className="text-xs text-muted-foreground">
+                                {isExpired ? "Expired on" : "Expires on"}
+                            </p>
+                            <p className="text-sm">{formatDate(expiryDate)}</p>
+                        </div>
                     </div>
                 </div>
-                <div className="flex items-center gap-12">
-                    {license.seats !== undefined && (
-                        <div className="flex flex-col items-end">
-                            <p className="text-xs text-muted-foreground">Billed seats</p>
-                            <p className="text-sm">{license.seats}</p>
-                        </div>
-                    )}
-                    <div className="flex flex-col items-end">
-                        <p className="text-xs text-muted-foreground">
-                            {isExpired ? "Expired on" : "Expires on"}
-                        </p>
-                        <p className="text-sm">{formatDate(expiryDate)}</p>
-                    </div>
+                <div className="flex items-center justify-between gap-6 border-t border-border pt-4">
+                    <p className="text-xs text-muted-foreground">
+                        Your instance doesn&apos;t report usage automatically. Usage data must be
+                        manually sent to{" "}
+                        <a href="mailto:ar@sourcebot.dev" className="text-primary hover:underline">
+                            ar@sourcebot.dev
+                        </a>
+                        .
+                    </p>
+                    <DownloadServicePingHistoryButton />
                 </div>
             </div>
         </SettingsCard>

--- a/packages/web/src/features/billing/servicePing.ts
+++ b/packages/web/src/features/billing/servicePing.ts
@@ -176,9 +176,7 @@ const inferDeploymentType = (): string => {
 };
 
 const recordServicePingInDB = async (payload: ServicePingRequest) => {
-    // Strip the activation code before persisting. This history is meant to be
-    // exported and sent back to us by offline deployments, so it should not
-    // contain the instance's secret activation code.
+    // Strip the activation code before persisting.
     const { activationCode: _activationCode, ...sanitizedPayload } = payload;
 
     try {

--- a/packages/web/src/features/billing/servicePing.ts
+++ b/packages/web/src/features/billing/servicePing.ts
@@ -83,6 +83,8 @@ export const syncWithLighthouse = async (orgId: number) => {
         ...(activationCode && { activationCode }),
     };
 
+    await recordServicePingInDB(payload);
+
     const response = await client.ping(payload);
     if (isServiceError(response)) {
         logger.error(`Service ping failed:\n ${JSON.stringify(response, null, 2)}`)
@@ -171,4 +173,23 @@ const inferDeploymentType = (): string => {
         return 'docker';
     }
     return 'other';
+};
+
+const recordServicePingInDB = async (payload: ServicePingRequest) => {
+    // Strip the activation code before persisting. This history is meant to be
+    // exported and sent back to us by offline deployments, so it should not
+    // contain the instance's secret activation code.
+    const { activationCode: _activationCode, ...sanitizedPayload } = payload;
+
+    try {
+        await __unsafePrisma.servicePingEvent.create({
+            data: {
+                payload: sanitizedPayload,
+            },
+        });
+    } catch (error) {
+        // Recording the ping is best-effort: a failure here must not prevent
+        // the actual ping from being sent to Lighthouse.
+        logger.error(`Failed to record service ping in database:\n ${error}`);
+    }
 };

--- a/packages/web/src/features/billing/servicePing.ts
+++ b/packages/web/src/features/billing/servicePing.ts
@@ -2,7 +2,13 @@ import { existsSync } from "fs";
 import { SINGLE_TENANT_ORG_ID } from "@/lib/constants";
 import { isServiceError } from "@/lib/utils";
 import { __unsafePrisma } from "@/prisma";
-import { createLogger, decryptActivationCode, env, SOURCEBOT_VERSION } from "@sourcebot/shared";
+import {
+    createLogger,
+    decryptActivationCode,
+    env,
+    SOURCEBOT_VERSION,
+    isValidOfflineLicenseActive
+} from "@sourcebot/shared";
 import { client } from "./client";
 import { ServicePingRequest } from "./types";
 import { ServiceErrorException } from "@/lib/serviceError";
@@ -83,7 +89,12 @@ export const syncWithLighthouse = async (orgId: number) => {
         ...(activationCode && { activationCode }),
     };
 
-    await recordServicePingInDB(payload);
+    await recordServicePingInDB(orgId, payload);
+
+    if (isValidOfflineLicenseActive()) {
+        logger.debug('Skipping service ping: active offline license detected.');
+        return;
+    }
 
     const response = await client.ping(payload);
     if (isServiceError(response)) {
@@ -175,13 +186,14 @@ const inferDeploymentType = (): string => {
     return 'other';
 };
 
-const recordServicePingInDB = async (payload: ServicePingRequest) => {
+const recordServicePingInDB = async (orgId: number, payload: ServicePingRequest) => {
     // Strip the activation code before persisting.
     const { activationCode: _activationCode, ...sanitizedPayload } = payload;
 
     try {
         await __unsafePrisma.servicePingEvent.create({
             data: {
+                orgId,
                 payload: sanitizedPayload,
             },
         });


### PR DESCRIPTION
## Overview

Offline / air-gapped deployments can't report usage to Lighthouse automatically. This change records each service ping locally so those deployments can download their usage history and send it to us out-of-band.

## Changes

- **DB**: New `ServicePingEvent` table (`id`, `payload` JSON, `createdAt`) + migration.
- **Recording**: `syncWithLighthouse` now persists each ping (via `recordServicePingInDB`) before sending it to Lighthouse, so the history is captured even when the outbound ping fails (as it always will on air-gapped instances). The **activation code is stripped** before persisting, and recording is best-effort (wrapped in try/catch + logging) so a DB error never blocks the real ping.
- **Export UI**: A "Download usage report" button on the offline license settings card (`Settings → License`), backed by an `OWNER`-gated server action that returns the recorded events. Downloads as `<date>-usage-history.json`.
- **Copy**: The offline license card explains that the instance doesn't report usage automatically and that usage must be manually sent to `ar@sourcebot.dev`.

<img width="741" height="184" alt="image" src="https://github.com/user-attachments/assets/78fe71f9-7f6b-4c0c-be59-2eba92cce1ee" />


## Notes

- The export button only renders for offline licenses, but recording runs on all deployments (one tiny row/day, negligible).
- No retention/pruning yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Offline license settings page now includes a "Download usage report" button to export usage data as JSON files.
  * Service ping history is now recorded locally for offline deployments to support usage tracking.

* **Refactor**
  * Improved license validation helper functions for better code organization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->