### PR TITLE
fix: add pcre2 and libyaml to macos install script

### DIFF
--- a/install-ctags-macos.sh
+++ b/install-ctags-macos.sh
@@ -23,7 +23,7 @@ if ! command -v brew >/dev/null 2>&1; then
   exit 1
 fi
 
-brew install autoconf automake pkg-config jansson
+brew install autoconf automake pkg-config jansson pcre2 libyaml
 
 curl --retry 5 "https://codeload.github.com/universal-ctags/ctags/tar.gz/$CTAGS_VERSION" | tar xz -C /tmp
 cd /tmp/$CTAGS_ARCHIVE_TOP_LEVEL_DIR


### PR DESCRIPTION
Fixes #1359.

This install script failed for me the first time I think because I had old x86_64 installs of these dependencies. Installing ARM versions fixed the issue.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated macOS installer script to include additional Homebrew build dependencies for enhanced compatibility and stability during installation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->