### PR TITLE
fix(web): send anonymous PostHog events as personless

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added per-step token cost tracking and estimated tool call token usage to Ask Sourcebot chat history. [#1353](https://github.com/sourcebot-dev/sourcebot/pull/1353)
 
+### Fixed
+- Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)
+
 ## [5.0.4] - 2026-06-18
 
 ### Changed

--- a/packages/web/src/features/chat/llm.server.ts
+++ b/packages/web/src/features/chat/llm.server.ts
@@ -310,12 +310,15 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
     })();
 
     const posthog = await createPostHogClient();
-    const distinctId = await tryGetPostHogDistinctId();
+    const { distinctId } = await tryGetPostHogDistinctId();
 
     // Only enable posthog LLM analytics for the ask GH experiment.
     const model = env.EXPERIMENT_ASK_GH_ENABLED === 'true' ?
         withTracing(_model, posthog, {
-            posthogDistinctId: distinctId,
+            // @note: Key anonymous events to the install id so they
+            // collapse to a single identity instead of a brand-new one
+            // on every call.
+            posthogDistinctId: distinctId ?? env.SOURCEBOT_INSTALL_ID,
         }) :
         _model;
 

--- a/packages/web/src/lib/posthog.ts
+++ b/packages/web/src/lib/posthog.ts
@@ -14,6 +14,7 @@ const logger = createLogger('posthog');
  */
 export type PostHogCookie = {
     distinct_id: string;
+    $user_state?: 'anonymous' | 'identified';
 }
 
 const isPostHogCookie = (cookie: unknown): cookie is PostHogCookie => {
@@ -51,22 +52,33 @@ const getPostHogCookie = (cookieStore: Pick<RequestCookies, 'get'>): PostHogCook
 }
 
 /**
- * Attempts to retrieve the distinct id of the current user.
+ * Attempts to retrieve the distinct id of the current user, along with whether
+ * that id corresponds to an *identified* user (as opposed to an anonymous one).
  */
-export const tryGetPostHogDistinctId = async () => {
+export const tryGetPostHogDistinctId = async (): Promise<{
+    distinctId: string | undefined;
+    isIdentified: boolean;
+}> => {
     // First, attempt to retrieve the distinct id from the PostHog cookie
     // (set by the client-side PostHog SDK). This preserves identity
     // continuity between client-side and server-side events.
     const cookieStore = await cookies();
     const cookie = getPostHogCookie(cookieStore);
     if (cookie) {
-        return cookie.distinct_id;
+        return {
+            distinctId: cookie.distinct_id,
+            isIdentified: cookie.$user_state === 'identified',
+        };
     }
 
     // Fall back to the authenticated user's ID. This covers all auth
     // methods: session cookies, OAuth Bearer tokens, and API keys.
     const authResult = await getAuthenticatedUser();
-    return authResult?.user.id;
+    if (authResult?.user.id) {
+        return { distinctId: authResult.user.id, isIdentified: true };
+    }
+
+    return { distinctId: undefined, isIdentified: false };
 }
 
 export const createPostHogClient = async () => {
@@ -85,7 +97,7 @@ export async function captureEvent<E extends PosthogEvent>(event: E, properties:
             return;
         }
 
-        const distinctId = await tryGetPostHogDistinctId();
+        const { distinctId, isIdentified } = await tryGetPostHogDistinctId();
         const posthog = await createPostHogClient();
 
         const headersList = await headers();
@@ -98,8 +110,18 @@ export async function captureEvent<E extends PosthogEvent>(event: E, properties:
                 sourcebot_version: SOURCEBOT_VERSION,
                 install_id: env.SOURCEBOT_INSTALL_ID,
                 $host: host,
+                // Mirror the client's `identified_only` setting: only identified
+                // users get a person profile. Anonymous requests (logged-out
+                // visitors and unauthenticated API calls) are sent as personless
+                // events so we don't create a person profile per request and
+                // inflate person counts/billing.
+                // @see: https://posthog.com/handbook/engineering/person-processing#personless-mode-anonymous-events
+                ...(isIdentified ? {} : { $process_person_profile: false }),
             },
-            distinctId,
+            // @note: Key anonymous events to the install id so they
+            // collapse to a single identity instead of a brand-new one
+            // on every call.
+            distinctId: distinctId ?? env.SOURCEBOT_INSTALL_ID,
             groups: { company: env.SOURCEBOT_INSTALL_ID },
         });
     } catch (error) {


### PR DESCRIPTION
## Problem

In `posthog.ts`, unauthenticated server-side captures shipped with an empty `distinctId`. PostHog treated each such request as a new person, inflating person counts and billing.

## Fix

`tryGetPostHogDistinctId` now resolves identity by mirroring the client's `identified_only` contract:

- **Cookie present** → use its `distinct_id`; identified iff `$user_state === 'identified'`.
- **No cookie, authenticated** → use the user id (identified).
- **No cookie, unauthenticated** → key the event to the install id.

Non-identified events are sent personless (`$process_person_profile: false`), so logged-out visitors and anonymous API calls no longer create a person profile per request. Identified users are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Anonymous user events are now processed as personless, preventing unauthenticated requests from inflating analytics person counts and ensuring more accurate user metrics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->