### PR TITLE
feat: add Requesty as an OpenAI-compatible chat model provider

### DIFF
--- a/docs/docs/configuration/language-model-providers.mdx
+++ b/docs/docs/configuration/language-model-providers.mdx
@@ -342,6 +342,27 @@ The OpenAI compatible provider allows you to use any model that is compatible wi
 }
 ```
 
+### Requesty
+
+[Requesty](https://requesty.ai) is an OpenAI-compatible LLM gateway. Models are referenced in `provider/model` format (e.g. `openai/gpt-4o-mini`). See the [Requesty docs](https://docs.requesty.ai).
+
+```json wrap icon="code" Example config with Requesty provider
+{
+    "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/v3/index.json",
+    "models": [
+        {
+            "provider": "requesty",
+            "model": "openai/gpt-4o-mini",
+            "displayName": "OPTIONAL_DISPLAY_NAME",
+            "token": {
+                "env": "REQUESTY_API_KEY"
+            },
+            "baseUrl": "OPTIONAL_BASE_URL"
+        }
+    ] 
+}
+```
+
 ### xAI
 
 [Vercel AI SDK xAI Docs](https://ai-sdk.dev/providers/ai-sdk-providers/xai)

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -3143,6 +3143,116 @@
             ],
             "additionalProperties": false
           },
+          "RequestyLanguageModel": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "const": "requesty",
+                "description": "Requesty Configuration"
+              },
+              "model": {
+                "type": "string",
+                "description": "The name of the language model in `provider/model` format.",
+                "examples": [
+                  "openai/gpt-4o-mini"
+                ]
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Optional display name."
+              },
+              "token": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "env": {
+                        "type": "string",
+                        "description": "The name of the environment variable that contains the token."
+                      }
+                    },
+                    "required": [
+                      "env"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "googleCloudSecret": {
+                        "type": "string",
+                        "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                      }
+                    },
+                    "required": [
+                      "googleCloudSecret"
+                    ],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+              },
+              "baseUrl": {
+                "type": "string",
+                "format": "url",
+                "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+                "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "googleCloudSecret": {
+                                "type": "string",
+                                "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                              }
+                            },
+                            "required": [
+                              "googleCloudSecret"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "provider",
+              "model"
+            ],
+            "additionalProperties": false
+          },
           "XaiLanguageModel": {
             "type": "object",
             "properties": {
@@ -4653,6 +4763,116 @@
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "googleCloudSecret": {
+                                "type": "string",
+                                "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                              }
+                            },
+                            "required": [
+                              "googleCloudSecret"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "provider",
+              "model"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "const": "requesty",
+                "description": "Requesty Configuration"
+              },
+              "model": {
+                "type": "string",
+                "description": "The name of the language model in `provider/model` format.",
+                "examples": [
+                  "openai/gpt-4o-mini"
+                ]
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Optional display name."
+              },
+              "token": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "env": {
+                        "type": "string",
+                        "description": "The name of the environment variable that contains the token."
+                      }
+                    },
+                    "required": [
+                      "env"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "googleCloudSecret": {
+                        "type": "string",
+                        "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                      }
+                    },
+                    "required": [
+                      "googleCloudSecret"
+                    ],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+              },
+              "baseUrl": {
+                "type": "string",
+                "format": "url",
+                "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+                "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
               },
               "temperature": {
                 "type": "number",

--- a/docs/snippets/schemas/v3/languageModel.schema.mdx
+++ b/docs/snippets/schemas/v3/languageModel.schema.mdx
@@ -1457,6 +1457,116 @@
       ],
       "additionalProperties": false
     },
+    "RequestyLanguageModel": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "const": "requesty",
+          "description": "Requesty Configuration"
+        },
+        "model": {
+          "type": "string",
+          "description": "The name of the language model in `provider/model` format.",
+          "examples": [
+            "openai/gpt-4o-mini"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional display name."
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "url",
+          "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+          "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "googleCloudSecret": {
+                          "type": "string",
+                          "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                        }
+                      },
+                      "required": [
+                        "googleCloudSecret"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "provider",
+        "model"
+      ],
+      "additionalProperties": false
+    },
     "XaiLanguageModel": {
       "type": "object",
       "properties": {
@@ -2967,6 +3077,116 @@
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "googleCloudSecret": {
+                          "type": "string",
+                          "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                        }
+                      },
+                      "required": [
+                        "googleCloudSecret"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "provider",
+        "model"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "const": "requesty",
+          "description": "Requesty Configuration"
+        },
+        "model": {
+          "type": "string",
+          "description": "The name of the language model in `provider/model` format.",
+          "examples": [
+            "openai/gpt-4o-mini"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional display name."
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "url",
+          "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+          "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
         },
         "temperature": {
           "type": "number",

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -3142,6 +3142,116 @@ const schema = {
             ],
             "additionalProperties": false
           },
+          "RequestyLanguageModel": {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "const": "requesty",
+                "description": "Requesty Configuration"
+              },
+              "model": {
+                "type": "string",
+                "description": "The name of the language model in `provider/model` format.",
+                "examples": [
+                  "openai/gpt-4o-mini"
+                ]
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Optional display name."
+              },
+              "token": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "env": {
+                        "type": "string",
+                        "description": "The name of the environment variable that contains the token."
+                      }
+                    },
+                    "required": [
+                      "env"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "googleCloudSecret": {
+                        "type": "string",
+                        "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                      }
+                    },
+                    "required": [
+                      "googleCloudSecret"
+                    ],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+              },
+              "baseUrl": {
+                "type": "string",
+                "format": "url",
+                "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+                "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "googleCloudSecret": {
+                                "type": "string",
+                                "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                              }
+                            },
+                            "required": [
+                              "googleCloudSecret"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "provider",
+              "model"
+            ],
+            "additionalProperties": false
+          },
           "XaiLanguageModel": {
             "type": "object",
             "properties": {
@@ -4652,6 +4762,116 @@ const schema = {
                 "format": "url",
                 "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
                 "description": "Optional base URL."
+              },
+              "temperature": {
+                "type": "number",
+                "description": "Optional temperature setting to use with the model."
+              },
+              "headers": {
+                "type": "object",
+                "description": "Optional headers to use with the model.",
+                "patternProperties": {
+                  "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+                    "anyOf": [
+                      {
+                        "type": "string"
+                      },
+                      {
+                        "anyOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "env": {
+                                "type": "string",
+                                "description": "The name of the environment variable that contains the token."
+                              }
+                            },
+                            "required": [
+                              "env"
+                            ],
+                            "additionalProperties": false
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "googleCloudSecret": {
+                                "type": "string",
+                                "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                              }
+                            },
+                            "required": [
+                              "googleCloudSecret"
+                            ],
+                            "additionalProperties": false
+                          }
+                        ]
+                      }
+                    ]
+                  }
+                },
+                "additionalProperties": false
+              }
+            },
+            "required": [
+              "provider",
+              "model"
+            ],
+            "additionalProperties": false
+          },
+          {
+            "type": "object",
+            "properties": {
+              "provider": {
+                "const": "requesty",
+                "description": "Requesty Configuration"
+              },
+              "model": {
+                "type": "string",
+                "description": "The name of the language model in `provider/model` format.",
+                "examples": [
+                  "openai/gpt-4o-mini"
+                ]
+              },
+              "displayName": {
+                "type": "string",
+                "description": "Optional display name."
+              },
+              "token": {
+                "anyOf": [
+                  {
+                    "type": "object",
+                    "properties": {
+                      "env": {
+                        "type": "string",
+                        "description": "The name of the environment variable that contains the token."
+                      }
+                    },
+                    "required": [
+                      "env"
+                    ],
+                    "additionalProperties": false
+                  },
+                  {
+                    "type": "object",
+                    "properties": {
+                      "googleCloudSecret": {
+                        "type": "string",
+                        "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                      }
+                    },
+                    "required": [
+                      "googleCloudSecret"
+                    ],
+                    "additionalProperties": false
+                  }
+                ],
+                "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+              },
+              "baseUrl": {
+                "type": "string",
+                "format": "url",
+                "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+                "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
               },
               "temperature": {
                 "type": "number",

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -24,6 +24,7 @@ export type LanguageModel =
   | OpenAILanguageModel
   | OpenAICompatibleLanguageModel
   | OpenRouterLanguageModel
+  | RequestyLanguageModel
   | XaiLanguageModel;
 export type AppConfig = GitHubAppConfig;
 /**
@@ -1272,6 +1273,45 @@ export interface OpenRouterLanguageModel {
       };
   /**
    * Optional base URL.
+   */
+  baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
+  headers?: LanguageModelHeaders;
+}
+export interface RequestyLanguageModel {
+  /**
+   * Requesty Configuration
+   */
+  provider: "requesty";
+  /**
+   * The name of the language model in `provider/model` format.
+   */
+  model: string;
+  /**
+   * Optional display name.
+   */
+  displayName?: string;
+  /**
+   * Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable.
+   */
+  token?:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  /**
+   * Optional base URL. Defaults to `https://router.requesty.ai/v1`.
    */
   baseUrl?: string;
   /**

--- a/packages/schemas/src/v3/languageModel.schema.ts
+++ b/packages/schemas/src/v3/languageModel.schema.ts
@@ -1456,6 +1456,116 @@ const schema = {
       ],
       "additionalProperties": false
     },
+    "RequestyLanguageModel": {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "const": "requesty",
+          "description": "Requesty Configuration"
+        },
+        "model": {
+          "type": "string",
+          "description": "The name of the language model in `provider/model` format.",
+          "examples": [
+            "openai/gpt-4o-mini"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional display name."
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "url",
+          "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+          "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "googleCloudSecret": {
+                          "type": "string",
+                          "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                        }
+                      },
+                      "required": [
+                        "googleCloudSecret"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "provider",
+        "model"
+      ],
+      "additionalProperties": false
+    },
     "XaiLanguageModel": {
       "type": "object",
       "properties": {
@@ -2966,6 +3076,116 @@ const schema = {
           "format": "url",
           "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
           "description": "Optional base URL."
+        },
+        "temperature": {
+          "type": "number",
+          "description": "Optional temperature setting to use with the model."
+        },
+        "headers": {
+          "type": "object",
+          "description": "Optional headers to use with the model.",
+          "patternProperties": {
+            "^[!#$%&'*+\\-.^_`|~0-9A-Za-z]+$": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "anyOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "env": {
+                          "type": "string",
+                          "description": "The name of the environment variable that contains the token."
+                        }
+                      },
+                      "required": [
+                        "env"
+                      ],
+                      "additionalProperties": false
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "googleCloudSecret": {
+                          "type": "string",
+                          "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                        }
+                      },
+                      "required": [
+                        "googleCloudSecret"
+                      ],
+                      "additionalProperties": false
+                    }
+                  ]
+                }
+              ]
+            }
+          },
+          "additionalProperties": false
+        }
+      },
+      "required": [
+        "provider",
+        "model"
+      ],
+      "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "properties": {
+        "provider": {
+          "const": "requesty",
+          "description": "Requesty Configuration"
+        },
+        "model": {
+          "type": "string",
+          "description": "The name of the language model in `provider/model` format.",
+          "examples": [
+            "openai/gpt-4o-mini"
+          ]
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional display name."
+        },
+        "token": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ],
+          "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+        },
+        "baseUrl": {
+          "type": "string",
+          "format": "url",
+          "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+          "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
         },
         "temperature": {
           "type": "number",

--- a/packages/schemas/src/v3/languageModel.type.ts
+++ b/packages/schemas/src/v3/languageModel.type.ts
@@ -12,6 +12,7 @@ export type LanguageModel =
   | OpenAILanguageModel
   | OpenAICompatibleLanguageModel
   | OpenRouterLanguageModel
+  | RequestyLanguageModel
   | XaiLanguageModel;
 
 export interface AmazonBedrockLanguageModel {
@@ -598,6 +599,45 @@ export interface OpenRouterLanguageModel {
       };
   /**
    * Optional base URL.
+   */
+  baseUrl?: string;
+  /**
+   * Optional temperature setting to use with the model.
+   */
+  temperature?: number;
+  headers?: LanguageModelHeaders;
+}
+export interface RequestyLanguageModel {
+  /**
+   * Requesty Configuration
+   */
+  provider: "requesty";
+  /**
+   * The name of the language model in `provider/model` format.
+   */
+  model: string;
+  /**
+   * Optional display name.
+   */
+  displayName?: string;
+  /**
+   * Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable.
+   */
+  token?:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  /**
+   * Optional base URL. Defaults to `https://router.requesty.ai/v1`.
    */
   baseUrl?: string;
   /**

--- a/packages/setupWizard/src/models.ts
+++ b/packages/setupWizard/src/models.ts
@@ -20,6 +20,7 @@ export const PROVIDER_ENV_KEYS: Record<string, string> = {
     'mistral': 'MISTRAL_API_KEY',
     'xai': 'XAI_API_KEY',
     'openrouter': 'OPENROUTER_API_KEY',
+    'requesty': 'REQUESTY_API_KEY',
     'openai-compatible': 'OPENAI_COMPATIBLE_API_KEY',
     'azure': 'AZURE_OPENAI_API_KEY',
 };
@@ -172,7 +173,8 @@ async function collectModelConfig(
         case 'deepseek':
         case 'mistral':
         case 'xai':
-        case 'openrouter': {
+        case 'openrouter':
+        case 'requesty': {
             const envKey = await ensureApiKey(provider, env);
             return { provider, model, token: { env: envKey } } satisfies LanguageModel;
         }
@@ -337,6 +339,7 @@ export async function collectModels(): Promise<{ models: LanguageModel[]; env: E
                 { value: 'deepseek', name: 'DeepSeek' },
                 { value: 'mistral', name: 'Mistral' },
                 { value: 'openrouter', name: 'OpenRouter' },
+                { value: 'requesty', name: 'Requesty' },
                 { value: 'xai', name: 'xAI', description: 'Grok' },
             ],
         });

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -295,6 +295,8 @@ const options = {
 
         OPENROUTER_API_KEY: z.string().optional(),
 
+        REQUESTY_API_KEY: z.string().optional(),
+
         XAI_API_KEY: z.string().optional(),
 
         MISTRAL_API_KEY: z.string().optional(),

--- a/packages/web/src/features/chat/components/chatBox/modelProviderLogo.tsx
+++ b/packages/web/src/features/chat/components/chatBox/modelProviderLogo.tsx
@@ -78,6 +78,11 @@ export const ModelProviderLogo = ({
                     Icon: Box,
                     className: 'text-muted-foreground'
                 };
+            case 'requesty':
+                return {
+                    Icon: Box,
+                    className: 'text-muted-foreground'
+                };
         }
     }, [provider]);
 

--- a/packages/web/src/features/chat/llm.server.ts
+++ b/packages/web/src/features/chat/llm.server.ts
@@ -291,6 +291,22 @@ export const getAISDKLanguageModelAndOptions = async (config: LanguageModel): Pr
                     model: openrouter(modelId),
                 };
             }
+            case 'requesty': {
+                const requesty = createOpenAICompatible({
+                    baseURL: config.baseUrl ?? 'https://router.requesty.ai/v1',
+                    name: config.displayName ?? 'requesty',
+                    apiKey: config.token
+                        ? await getTokenFromConfig(config.token)
+                        : env.REQUESTY_API_KEY,
+                    headers: config.headers
+                        ? await extractLanguageModelKeyValuePairs(config.headers)
+                        : undefined,
+                });
+
+                return {
+                    model: requesty.chatModel(modelId),
+                };
+            }
             case 'xai': {
                 const xai = createXai({
                     baseURL: config.baseUrl,

--- a/packages/web/src/features/chat/types.ts
+++ b/packages/web/src/features/chat/types.ts
@@ -199,6 +199,7 @@ export const languageModelProviders = [
     "openai",
     "openai-compatible",
     "openrouter",
+    "requesty",
     "xai",
 ] as const satisfies readonly LanguageModelProvider[];
 

--- a/schemas/v3/languageModel.json
+++ b/schemas/v3/languageModel.json
@@ -585,6 +585,48 @@
             ],
             "additionalProperties": false
         },
+        "RequestyLanguageModel": {
+            "type": "object",
+            "properties": {
+                "provider": {
+                    "const": "requesty",
+                    "description": "Requesty Configuration"
+                },
+                "model": {
+                    "type": "string",
+                    "description": "The name of the language model in `provider/model` format.",
+                    "examples": [
+                        "openai/gpt-4o-mini"
+                    ]
+                },
+                "displayName": {
+                    "type": "string",
+                    "description": "Optional display name."
+                },
+                "token": {
+                    "$ref": "./shared.json#/definitions/Token",
+                    "description": "Optional API key to use with the model. Defaults to the `REQUESTY_API_KEY` environment variable."
+                },
+                "baseUrl": {
+                    "type": "string",
+                    "format": "url",
+                    "pattern": "^https?:\\/\\/[^\\s/$.?#].[^\\s]*$",
+                    "description": "Optional base URL. Defaults to `https://router.requesty.ai/v1`."
+                },
+                "temperature": {
+                    "type": "number",
+                    "description": "Optional temperature setting to use with the model."
+                },
+                "headers": {
+                    "$ref": "./shared.json#/definitions/LanguageModelHeaders"
+                }
+            },
+            "required": [
+                "provider",
+                "model"
+            ],
+            "additionalProperties": false
+        },
         "XaiLanguageModel": {
             "type": "object",
             "properties": {
@@ -662,6 +704,9 @@
         },
         {
             "$ref": "#/definitions/OpenRouterLanguageModel"
+        },
+        {
+            "$ref": "#/definitions/RequestyLanguageModel"
         },
         {
             "$ref": "#/definitions/XaiLanguageModel"


### PR DESCRIPTION
Adds **Requesty** as an OpenAI-compatible chat model provider, mirroring the existing **OpenRouter** provider.

Requesty ([requesty.ai](https://requesty.ai)) is an OpenAI-compatible LLM gateway — one API across many models, using the same `provider/model` naming as OpenRouter (base `https://router.requesty.ai/v1`, `REQUESTY_API_KEY`). Since there's no Requesty-specific AI SDK package, it routes through `@ai-sdk/openai-compatible` (already a dependency).

## Changes

- `packages/web/src/features/chat/llm.server.ts` — `case 'requesty'` building the model via `createOpenAICompatible` (default base `https://router.requesty.ai/v1`, overridable via `config.baseUrl`; key from `config.token ?? env.REQUESTY_API_KEY`; headers mirroring openrouter).
- `packages/schemas/src/v3/languageModel.schema.ts` — `RequestyLanguageModel` zod definition mirroring `OpenRouterLanguageModel`; regenerated `languageModel.json` + types via `yarn generate` (the diff is purely the Requesty addition).
- `packages/shared/src/env.server.ts` — `REQUESTY_API_KEY` optional env.
- `packages/web/src/features/chat/types.ts` — provider type.
- `packages/web/src/features/chat/components/chatBox/modelProviderLogo.tsx` — `case 'requesty'` (falls back to default; no asset fabricated).
- `packages/setupWizard/src/models.ts` — wizard entry.
- `docs/docs/configuration/language-model-providers.mdx` + generated schema snippets — Requesty section in the existing per-provider docs table.

## Testing

- `tsc --noEmit` on `@sourcebot/schemas` → 0 errors; the edited web files (llm.server, types) → no new errors (remaining errors are pre-existing `@/public/*.svg`/`*.png` module-decl + a test-prop issue, present for all providers).
- `yarn generate` reproduces the committed schema json (zod source and generated json are consistent).
- Verified live: `POST https://router.requesty.ai/v1/chat/completions` with `model: openai/gpt-4o-mini` → HTTP 200 with a real completion.

Docs: https://docs.requesty.ai • Keys: https://app.requesty.ai/api-keys

I work at Requesty. This mirrors the existing OpenRouter provider as closely as possible. Happy to adjust or close it if it's not a fit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the Requesty language model provider across setup, chat, and schema validation.
  * Requesty can now be selected as a provider and configured with a model name, API key, optional base URL, headers, and temperature.
  * Added UI support for displaying a Requesty provider icon.

* **Documentation**
  * Updated configuration docs with Requesty setup details and an example configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->