### PR TITLE
fix(backend): pass zoekt index args without shell

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)
 - [EE] Fixed Ask Sourcebot mermaid diagrams overflowing their container by contain-fitting them to both width and height, and made revealing a diagram from the answer jump it into view instantly to avoid over/undershooting. [#1373](https://github.com/sourcebot-dev/sourcebot/pull/1373)
+- Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/backend/src/zoekt.test.ts
+++ b/packages/backend/src/zoekt.test.ts
@@ -1,0 +1,70 @@
+import type { Repo } from "@sourcebot/db";
+import { execFile } from "child_process";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+import type { Settings } from "./types.js";
+import { indexGitRepository } from "./zoekt.js";
+
+vi.mock("child_process", () => ({
+    execFile: vi.fn((_file, _args, _options, callback) => {
+        callback(null, "", "");
+    }),
+}));
+
+vi.mock("@sourcebot/shared", () => ({
+    createLogger: vi.fn(() => ({
+        debug: vi.fn(),
+        warn: vi.fn(),
+    })),
+    env: {},
+    getRepoPath: vi.fn(() => ({
+        path: "/tmp/repo.git",
+    })),
+}));
+
+vi.mock("./constants.js", () => ({
+    INDEX_CACHE_DIR: "/tmp/index",
+}));
+
+vi.mock("./utils.js", () => ({
+    getShardPrefix: vi.fn(() => "1_2"),
+}));
+
+describe("indexGitRepository", () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test("preserves revision names with punctuation", async () => {
+        const repo = {
+            id: 2,
+            orgId: 1,
+        } as Repo;
+        const settings = {
+            maxTrigramCount: 100,
+            maxFileSize: 200,
+        } as Settings;
+        const payloadBranch = 'refs/heads/release";metadata${IFS}v1;"x';
+
+        await indexGitRepository(repo, settings, [
+            "refs/heads/main",
+            payloadBranch,
+        ]);
+
+        expect(execFile).toHaveBeenCalledWith(
+            "zoekt-git-index",
+            [
+                "-allow_missing_branches",
+                "-index", "/tmp/index",
+                "-max_trigram_count", "100",
+                "-file_limit", "200",
+                "-branches", `refs/heads/main,${payloadBranch}`,
+                "-tenant_id", "1",
+                "-repo_id", "2",
+                "-shard_prefix_override", "1_2",
+                "/tmp/repo.git",
+            ],
+            {},
+            expect.any(Function),
+        );
+    });
+});

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -1,6 +1,6 @@
 import { Repo } from "@sourcebot/db";
 import { createLogger, env, getRepoPath } from "@sourcebot/shared";
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { readdir, rm } from "fs/promises";
 import { INDEX_CACHE_DIR } from "./constants.js";
 import { Settings } from "./types.js";
@@ -14,22 +14,21 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, revisio
 
     const largeFileGlobPatterns = env.ALWAYS_INDEX_FILE_PATTERNS?.split(',').map(pattern => pattern.trim()) ?? [];
 
-    const command = [
-        'zoekt-git-index',
+    const args = [
         '-allow_missing_branches',
-        `-index ${INDEX_CACHE_DIR}`,
-        `-max_trigram_count ${settings.maxTrigramCount}`,
-        `-file_limit ${settings.maxFileSize}`,
-        `-branches "${revisions.join(',')}"`,
-        `-tenant_id ${repo.orgId}`,
-        `-repo_id ${repo.id}`,
-        `-shard_prefix_override ${shardPrefix}`,
-        ...largeFileGlobPatterns.map((pattern) => `-large_file "${pattern}"`),
+        '-index', INDEX_CACHE_DIR,
+        '-max_trigram_count', settings.maxTrigramCount.toString(),
+        '-file_limit', settings.maxFileSize.toString(),
+        '-branches', revisions.join(','),
+        '-tenant_id', repo.orgId.toString(),
+        '-repo_id', repo.id.toString(),
+        '-shard_prefix_override', shardPrefix,
+        ...largeFileGlobPatterns.flatMap((pattern) => ['-large_file', pattern]),
         repoPath
-    ].join(' ');
+    ];
 
     return new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
-        exec(command, { signal }, (error, stdout, stderr) => {
+        execFile('zoekt-git-index', args, { signal }, (error, stdout, stderr) => {
             if (error) {
                 reject(error);
                 return;


### PR DESCRIPTION
Fixes SOU-1462

## Summary
- Pass zoekt index parameters via argv instead of a composed command string.
- Add backend coverage for revision names with punctuation.

## Tests
- yarn workspace @sourcebot/backend test
- yarn workspace @sourcebot/backend build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Zoekt indexing so revision names with punctuation and special characters are preserved correctly.
  * Improved how indexing parameters are passed to avoid issues caused by shell command parsing.

* **Tests**
  * Added coverage for Zoekt indexing to verify the expected arguments are sent during repository indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->