### PR TITLE
feat: detect and surface ctags indexing failures

### DIFF
--- a/packages/backend/src/repoIndexManager.ts
+++ b/packages/backend/src/repoIndexManager.ts
@@ -330,14 +330,15 @@ export class RepoIndexManager {
         this.promClient.activeRepoIndexJobs.inc({ repo: job.data.repoName, type: jobTypeLabel });
 
         if (jobType === RepoIndexingJobType.INDEX) {
-            const revisions = await this.indexRepository(repo, logger, signal);
+            const { revisions, ctagsWarning } = await this.indexRepository(repo, logger, signal);
 
             await this.db.repoIndexingJob.update({
                 where: { id },
                 data: {
                     metadata: {
                         indexedRevisions: revisions,
-                    } satisfies RepoIndexingJobMetadata,
+                        ...(ctagsWarning && { ctagsWarning }),
+                    },
                 },
             });
         } else if (jobType === RepoIndexingJobType.CLEANUP) {
@@ -511,10 +512,15 @@ export class RepoIndexManager {
         }
 
         logger.debug(`Indexing ${repo.name} (id: ${repo.id})...`);
+        let ctagsWarning: string | undefined;
         try {
-            const { durationMs } = await measure(() => indexGitRepository(repo, this.settings, revisions, signal));
+            const { data, durationMs } = await measure(() => indexGitRepository(repo, this.settings, revisions, signal));
+            ctagsWarning = data.ctagsWarning;
             const indexDuration_s = durationMs / 1000;
             logger.debug(`Indexed ${repo.name} (id: ${repo.id}) in ${indexDuration_s}s`);
+            if (ctagsWarning) {
+                logger.warn(`Repo ${repo.name} (id: ${repo.id}) has symbol indexing issues: ${ctagsWarning}`);
+            }
         } catch (error) {
             // Clean up any temporary shard files left behind by the failed indexing operation.
             // Zoekt creates .tmp files during indexing which can accumulate if indexing fails repeatedly.
@@ -523,7 +529,7 @@ export class RepoIndexManager {
             throw error;
         }
 
-        return revisions;
+        return { revisions, ctagsWarning };
     }
 
     private async cleanupRepository(repo: Repo, logger: Logger) {

--- a/packages/backend/src/zoekt.ts
+++ b/packages/backend/src/zoekt.ts
@@ -8,6 +8,47 @@ import { getShardPrefix } from "./utils.js";
 
 const logger = createLogger('zoekt');
 
+// Patterns that indicate ctags/symbol indexing failure in zoekt output
+const CTAGS_ERROR_PATTERNS = [
+    /illegal option/i,
+    /file already closed/i,
+    /ctags.*not found/i,
+    /ctags.*error/i,
+    /universal:ctags.*error/i,
+    /scip:.*error/i,
+];
+
+/**
+ * Detect ctags/symbol indexing failures from zoekt stderr output.
+ * Returns a warning message if ctags failed, or undefined if symbol indexing succeeded.
+ */
+export const detectCtagsFailure = (stderr: string): string | undefined => {
+    const lines = stderr.split('\n').filter(line => line.trim());
+
+    // Check for ctags error patterns
+    const hasCtagsError = lines.some(line =>
+        CTAGS_ERROR_PATTERNS.some(pattern => pattern.test(line))
+    );
+
+    // Check for symbols=0 in the statistics line (indicates no symbols were indexed)
+    const statsLine = lines.find(line => /symbol analysis finished.*symbols=0/.test(line));
+    const hasZeroSymbols = statsLine !== undefined;
+
+    if (hasCtagsError && hasZeroSymbols) {
+        return `ctags symbol indexing failed: ctags reported errors and 0 symbols were indexed. ` +
+            `Symbol search (sym:*) will return no results. ` +
+            `Check that CTAGS_COMMAND points to a Universal Ctags binary.`;
+    }
+
+    if (hasCtagsError) {
+        return `ctags reported errors during symbol indexing. ` +
+            `Symbol search results may be incomplete. ` +
+            `Check that CTAGS_COMMAND points to a Universal Ctags binary.`;
+    }
+
+    return undefined;
+};
+
 export const indexGitRepository = async (repo: Repo, settings: Settings, revisions: string[], signal?: AbortSignal) => {
     const { path: repoPath } = getRepoPath(repo);
     const shardPrefix = getShardPrefix(repo.orgId, repo.id);
@@ -27,7 +68,7 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, revisio
         repoPath
     ];
 
-    return new Promise<{ stdout: string, stderr: string }>((resolve, reject) => {
+    return new Promise<{ stdout: string, stderr: string; ctagsWarning?: string }>((resolve, reject) => {
         execFile('zoekt-git-index', args, { signal }, (error, stdout, stderr) => {
             if (error) {
                 reject(error);
@@ -45,9 +86,16 @@ export const indexGitRepository = async (repo: Repo, settings: Settings, revisio
                 });
             }
 
+            // Detect ctags/symbol indexing failures
+            const ctagsWarning = detectCtagsFailure(stderr ?? '');
+            if (ctagsWarning) {
+                logger.warn(`[${repo.name}] ${ctagsWarning}`);
+            }
+
             resolve({
                 stdout,
-                stderr
+                stderr,
+                ctagsWarning,
             });
         })
     });


### PR DESCRIPTION
## Summary

When `zoekt-git-index` runs with a misconfigured `CTAGS_COMMAND`, ctags fails silently — the process exits with code 0 but `symbols=0` are indexed. The UI shows "completed" but symbol search (`sym:*`) returns no results.

This PR adds detection and logging of ctags failures so they are no longer invisible.

Closes #1361

## Changes

| File | Description |
|------|-------------|
| `packages/backend/src/zoekt.ts` | Add `detectCtagsFailure()` — parses stderr for ctags error patterns combined with `symbols=0` in statistics |
| `packages/backend/src/repoIndexManager.ts` | Store `ctagsWarning` in job metadata when detected; log clear warning |

## Detection logic

`detectCtagsFailure()` checks stderr for two conditions:

1. **ctags error patterns**: `illegal option`, `file already closed`, `ctags not found`, `ctags error`, `universal:ctags error`, `scip: error`
2. **Zero symbols**: `symbol analysis finished.*symbols=0` in the statistics line

When both conditions are met, a warning message is returned and stored in the job metadata for UI consumption.

## Example log output

```
[repo-index-manager:job:abc123] Repo my-app (id: 42) has symbol indexing issues: ctags symbol indexing failed: ctags reported errors and 0 symbols were indexed. Symbol search (sym:*) will return no results. Check that CTAGS_COMMAND points to a Universal Ctags binary.
```

## Follow-up

A future PR can surface the `ctagsWarning` from job metadata in the UI (e.g., a warning badge on the repo card when symbol indexing degraded).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository indexing so warning messages from symbol/ctags processing are now detected and reported.
  * Indexing jobs now retain additional indexing details, helping surface partial indexing issues more reliably.
  * When indexing warnings occur, they are logged and stored for later review instead of being dropped.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->