### PR TITLE
fix(web): encode search landing example links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)
 - [EE] Fixed Ask Sourcebot mermaid diagrams overflowing their container by contain-fitting them to both width and height, and made revealing a diagram from the answer jump it into view instantly to avoid over/undershooting. [#1373](https://github.com/sourcebot-dev/sourcebot/pull/1373)
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
+- Fixed search landing example links corrupting queries that contain reserved URL characters. [#1391](https://github.com/sourcebot-dev/sourcebot/pull/1391)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/src/app/(app)/search/components/searchLandingPage.test.ts
+++ b/packages/web/src/app/(app)/search/components/searchLandingPage.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, test } from 'vitest';
+import { buildQueryExampleHref } from './searchLandingPageUtils';
+
+describe('buildQueryExampleHref', () => {
+    test('encodes reserved query characters in example links', () => {
+        const href = buildQueryExampleHref({
+            query: 'foo & bar#baz%qux',
+        });
+
+        const url = new URL(href, 'https://sourcebot.local');
+
+        expect(url.pathname).toBe('/search');
+        expect(url.searchParams.get('query')).toBe('foo & bar#baz%qux');
+    });
+
+    test('preserves the case sensitivity flag when enabled', () => {
+        const href = buildQueryExampleHref({
+            query: 'TODO',
+            isCaseSensitivityEnabled: true,
+        });
+
+        const url = new URL(href, 'https://sourcebot.local');
+
+        expect(url.searchParams.get('query')).toBe('TODO');
+        expect(url.searchParams.get('isCaseSensitivityEnabled')).toBe('true');
+    });
+});

--- a/packages/web/src/app/(app)/search/components/searchLandingPage.tsx
+++ b/packages/web/src/app/(app)/search/components/searchLandingPage.tsx
@@ -8,6 +8,7 @@ import { SearchModeSelector } from "../../components/searchModeSelector"
 import { getRepos, getReposStats } from "@/actions"
 import { ServiceErrorException } from "@/lib/serviceError"
 import { isServiceError } from "@/lib/utils"
+import { buildQueryExampleHref } from "./searchLandingPageUtils"
 
 export interface SearchLandingPageProps {
     isSearchAssistSupported: boolean;
@@ -157,7 +158,7 @@ const QueryExplanation = ({ children }: { children: React.ReactNode }) => {
 const Query = ({ query, children, isCaseSensitivityEnabled = false }: { query: string, children: React.ReactNode, isCaseSensitivityEnabled?: boolean }) => {
     return (
         <Link
-            href={`/search?query=${query}${isCaseSensitivityEnabled ? "&isCaseSensitivityEnabled=true" : ""}`}
+            href={buildQueryExampleHref({ query, isCaseSensitivityEnabled })}
             className="cursor-pointer hover:underline"
         >
             {children}

--- a/packages/web/src/app/(app)/search/components/searchLandingPageUtils.ts
+++ b/packages/web/src/app/(app)/search/components/searchLandingPageUtils.ts
@@ -1,0 +1,17 @@
+export const buildQueryExampleHref = ({
+    query,
+    isCaseSensitivityEnabled = false,
+}: {
+    query: string;
+    isCaseSensitivityEnabled?: boolean;
+}) => {
+    const searchParams = new URLSearchParams({
+        query,
+    });
+
+    if (isCaseSensitivityEnabled) {
+        searchParams.set("isCaseSensitivityEnabled", "true");
+    }
+
+    return `/search?${searchParams.toString()}`;
+}


### PR DESCRIPTION
Fixes #1386

## Problem
Search landing example links interpolated the raw query value into `href`, so reserved URL characters could corrupt the `query` parameter.

## Root cause
The example link builder used string concatenation instead of structured search params.

## Solution
Build example hrefs with `URLSearchParams` and cover reserved characters plus the case-sensitivity flag with a focused test.

## Tests
- `node .yarn/releases/yarn-4.7.0.cjs workspace @sourcebot/web test src/app/(app)/search/components/searchLandingPage.test.ts`
- `node .yarn/releases/yarn-4.7.0.cjs workspace @sourcebot/web exec eslint src/app/(app)/search/components/searchLandingPage.tsx src/app/(app)/search/components/searchLandingPageUtils.ts src/app/(app)/search/components/searchLandingPage.test.ts`

## Risk
Low. Existing example link behavior is preserved for current examples while making future/reserved-character examples safe.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed search landing example links to generate valid URLs when the example query contains reserved URL characters.
  * Ensured the search path is preserved and the case-sensitivity setting remains correctly applied when enabled.
* **Tests**
  * Added automated coverage to verify search example link URL formatting, including correct encoding and conditional query parameters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->