### PR TITLE
feat(web): pin+flag Ask citations to a resolved commit SHA

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [EE] Improved Ask Sourcebot prompt caching by splitting static and dynamic prompt sections and advancing cache breakpoints after every agent step instead of only after each message. [#1366](https://github.com/sourcebot-dev/sourcebot/pull/1366)
 - Refactored Ask Sourcebot user message text extraction into a shared helper that robustly handles non-text message parts. [#1371](https://github.com/sourcebot-dev/sourcebot/pull/1371)
+- [EE] Pinned Ask Sourcebot file citations to the commit they were sourced at so their content and line ranges stay aligned with the code as it was when the answer was generated. [#1397](https://github.com/sourcebot-dev/sourcebot/pull/1397)
 
 ### Added
 - Added per-step token cost tracking and estimated tool call token usage to Ask Sourcebot chat history. [#1353](https://github.com/sourcebot-dev/sourcebot/pull/1353)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added mermaid diagram rendering to Ask Sourcebot answers, with pan/zoom, copy/export, in-thread deep links, and an interleaved right-panel view. [#1369](https://github.com/sourcebot-dev/sourcebot/pull/1369)
 - [EE] Added a context-window usage gauge to the Ask Sourcebot chat details, showing how much of the selected model's context window each turn occupies. Window sizes are resolved from the models.dev catalog. [#1370](https://github.com/sourcebot-dev/sourcebot/pull/1370)
 - Added language model input-modality and document capability resolution, automatically resolved from the models.dev catalog (falls back to text-only for uncatalogued/self-hosted models). [#1372](https://github.com/sourcebot-dev/sourcebot/pull/1372)
+- [EE] Added a staleness hint to Ask Sourcebot file citations that flags when the cited file has changed since the answer was generated, with a link to the latest version. [#1399](https://github.com/sourcebot-dev/sourcebot/pull/1399)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -381,6 +381,9 @@
                 },
                 "webUrl": {
                   "type": "string"
+                },
+                "indexedCommitHash": {
+                  "type": "string"
                 }
               },
               "required": [
@@ -575,6 +578,9 @@
             "type": "string"
           },
           "externalWebUrl": {
+            "type": "string"
+          },
+          "commitSha": {
             "type": "string"
           }
         },
@@ -930,6 +936,9 @@
                   "type": "string"
                 },
                 "webUrl": {
+                  "type": "string"
+                },
+                "indexedCommitHash": {
                   "type": "string"
                 }
               },

--- a/packages/web/src/actions.ts
+++ b/packages/web/src/actions.ts
@@ -372,6 +372,7 @@ export const getRepoInfoByName = async (repoName: string) => sew(() =>
             externalWebUrl: repo.webUrl ?? undefined,
             imageUrl: repo.imageUrl ?? undefined,
             indexedAt: repo.indexedAt ?? undefined,
+            indexedCommitHash: repo.indexedCommitHash ?? undefined,
         }
     }));
 

--- a/packages/web/src/app/api/(client)/client.ts
+++ b/packages/web/src/app/api/(client)/client.ts
@@ -20,6 +20,8 @@ import {
     GetTreeResponse,
     FileSourceRequest,
     FileSourceResponse,
+    FileFreshnessRequest,
+    FileFreshnessResponse,
     ListCommitsQueryParams,
     ListCommitsResponse,
 } from "@/features/git";
@@ -66,6 +68,22 @@ export const getFileSource = async (queryParams: FileSourceRequest): Promise<Fil
     }).then(response => response.json());
 
     return result as FileSourceResponse | ServiceError;
+}
+
+export const getFileFreshness = async (queryParams: FileFreshnessRequest): Promise<FileFreshnessResponse | ServiceError> => {
+    const url = new URL("/api/source/freshness", window.location.origin);
+    for (const [key, value] of Object.entries(queryParams)) {
+        url.searchParams.set(key, value.toString());
+    }
+
+    const result = await fetch(url, {
+        method: "GET",
+        headers: {
+            "X-Sourcebot-Client-Source": "sourcebot-web-client",
+        }
+    }).then(response => response.json());
+
+    return result as FileFreshnessResponse | ServiceError;
 }
 
 export const listRepos = async (queryParams: ListReposQueryParams): Promise<ListReposResponse | ServiceError> => {

--- a/packages/web/src/app/api/(server)/source/freshness/route.ts
+++ b/packages/web/src/app/api/(server)/source/freshness/route.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { getFileFreshness } from '@/features/git';
+import { fileFreshnessRequestSchema } from '@/features/git/schemas';
+import { apiHandler } from "@/lib/apiHandler";
+import { queryParamsSchemaValidationError, serviceErrorResponse } from "@/lib/serviceError";
+import { isServiceError } from "@/lib/utils";
+import { NextRequest } from "next/server";
+
+// eslint-disable-next-line authz/require-auth-wrapper -- delegates to getFileFreshness() which calls withOptionalAuth
+export const GET = apiHandler(async (request: NextRequest) => {
+    const rawParams = Object.fromEntries(
+        Object.keys(fileFreshnessRequestSchema.shape).map(key => [
+            key,
+            request.nextUrl.searchParams.get(key) ?? undefined
+        ])
+    );
+    const parsed = fileFreshnessRequestSchema.safeParse(rawParams);
+
+    if (!parsed.success) {
+        return serviceErrorResponse(
+            queryParamsSchemaValidationError(parsed.error)
+        );
+    }
+
+    const { repo, path, sinceSha } = parsed.data;
+    const response = await getFileFreshness({ repo, path, sinceSha });
+
+    if (isServiceError(response)) {
+        return serviceErrorResponse(response);
+    }
+
+    return Response.json(response);
+});

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItem.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItem.tsx
@@ -8,16 +8,95 @@ import { useCodeMirrorLanguageExtension } from "@/hooks/useCodeMirrorLanguageExt
 import { useCodeMirrorTheme } from "@/hooks/useCodeMirrorTheme";
 import { useExtensionWithDependency } from "@/hooks/useExtensionWithDependency";
 import { useKeymapExtension } from "@/hooks/useKeymapExtension";
-import { cn } from "@/lib/utils";
+import { cn, truncateSha } from "@/lib/utils";
+import { getBrowsePath } from "@/app/(app)/browse/hooks/utils";
 import { EditorView } from '@codemirror/view';
 import { CodeHostType } from "@sourcebot/db";
 import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import isEqual from "fast-deep-equal/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, History } from "lucide-react";
+import Link from "next/link";
 import { forwardRef, memo, Ref, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FileReference } from "@/features/chat/types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { createCodeFoldingExtension } from "./codeFoldingExtension";
 import { createReferencesHighlightExtension, setHoveredIdEffect, setSelectedIdEffect } from "./referencesHighlightExtension";
+
+export type FileFreshnessStatus = 'fresh' | 'changed' | 'removed' | 'pinned_unavailable';
+
+const FreshnessBadge = ({
+    status,
+    pinnedSha,
+    currentSha,
+    repoName,
+    path,
+}: {
+    status: FileFreshnessStatus;
+    pinnedSha?: string;
+    currentSha?: string;
+    repoName: string;
+    path: string;
+}) => {
+    if (status === 'fresh') {
+        return null;
+    }
+
+    const shortPinned = pinnedSha ? truncateSha(pinnedSha) : undefined;
+
+    const { label, tooltip, className } = (() => {
+        switch (status) {
+            case 'changed':
+                return {
+                    label: 'Changed since',
+                    tooltip: `Shown as of ${shortPinned ?? 'the cited commit'}. This file has changed since this answer was generated.`,
+                    className: 'text-amber-600 dark:text-amber-500',
+                };
+            case 'removed':
+                return {
+                    label: 'Removed since',
+                    tooltip: `Shown as of ${shortPinned ?? 'the cited commit'}. This file no longer exists at the latest revision.`,
+                    className: 'text-destructive',
+                };
+            case 'pinned_unavailable':
+                return {
+                    label: 'Showing latest',
+                    tooltip: `The cited commit ${shortPinned ? `(${shortPinned}) ` : ''}is no longer available, so the latest version is shown.`,
+                    className: 'text-muted-foreground',
+                };
+        }
+    })();
+
+    return (
+        <div className="flex shrink-0 items-center gap-1.5">
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span className={cn('flex items-center gap-1 text-xs font-medium', className)}>
+                        <History className="h-3 w-3" />
+                        {label}
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                    {tooltip}
+                </TooltipContent>
+            </Tooltip>
+            {status === 'changed' && currentSha && (
+                <Link
+                    href={getBrowsePath({
+                        repoName,
+                        revisionName: currentSha,
+                        path,
+                        pathType: 'blob',
+                    })}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-muted-foreground underline hover:text-foreground"
+                >
+                    View latest
+                </Link>
+            )}
+        </div>
+    );
+};
 
 const CODEMIRROR_BASIC_SETUP = {
     highlightActiveLine: false,
@@ -37,6 +116,14 @@ interface ReferencedFileSourceListItemProps {
     repoWebUrl?: string;
     fileName: string;
     references: FileReference[];
+    // The pinned commit the file content is shown at (short-displayed in the
+    // staleness hint). Undefined for un-pinned (pre-pinning) sources.
+    pinnedSha?: string;
+    // Result of comparing the pinned commit against the current tip. Undefined
+    // while loading or for un-pinned sources.
+    freshnessStatus?: FileFreshnessStatus;
+    // The current default-branch commit, used to link to the latest version.
+    currentSha?: string;
     selectedReference?: FileReference;
     hoveredReference?: FileReference;
     onSelectedReferenceChanged: (reference?: FileReference) => void;
@@ -56,6 +143,9 @@ const ReferencedFileSourceListItemComponent = ({
     repoWebUrl,
     fileName,
     references,
+    pinnedSha,
+    freshnessStatus,
+    currentSha,
     selectedReference,
     hoveredReference,
     onSelectedReferenceChanged,
@@ -145,6 +235,15 @@ const ReferencedFileSourceListItemComponent = ({
                     revisionName={revision === 'HEAD' ? undefined : revision}
                     repoNameClassName="font-normal text-muted-foreground text-sm"
                 />
+                {freshnessStatus && (
+                    <FreshnessBadge
+                        status={freshnessStatus}
+                        pinnedSha={pinnedSha}
+                        currentSha={currentSha}
+                        repoName={repoName}
+                        path={fileName}
+                    />
+                )}
             </div>
 
             {/* Code container */}

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -43,12 +43,26 @@ const ReferencedFileSourceListItemContainerComponent = ({
     const fetchRef = fileSource.commitSha ?? fileSource.revision;
 
     const { data, isLoading, isError, error } = useQuery({
-        queryKey: ['fileSource', fileSource.path, fileSource.repo, fetchRef],
-        queryFn: () => unwrapServiceError(getFileSource({
-            path: fileSource.path,
-            repo: fileSource.repo,
-            ref: fetchRef,
-        })),
+        queryKey: ['fileSource', fileSource.path, fileSource.repo, fetchRef, fileSource.revision],
+        queryFn: async () => {
+            const pinned = await getFileSource({
+                path: fileSource.path,
+                repo: fileSource.repo,
+                ref: fetchRef,
+            });
+
+            // The pinned commit can disappear (e.g. a force-push + GC prunes it).
+            // Fall back once to the symbolic ref so the file still renders.
+            if (isServiceError(pinned) && fetchRef !== fileSource.revision) {
+                return unwrapServiceError(getFileSource({
+                    path: fileSource.path,
+                    repo: fileSource.repo,
+                    ref: fileSource.revision,
+                }));
+            }
+
+            return unwrapServiceError(Promise.resolve(pinned));
+        },
         staleTime: Infinity,
     });
 

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -4,6 +4,7 @@ import { getFileSource } from "@/app/api/(client)/client";
 import { VscodeFileIcon } from "@/app/components/vscodeFileIcon";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isServiceError, unwrapServiceError } from "@/lib/utils";
+import { ErrorCode } from "@/lib/errorCodes";
 import { useQuery } from "@tanstack/react-query";
 import { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import { memo, useCallback } from "react";
@@ -51,9 +52,15 @@ const ReferencedFileSourceListItemContainerComponent = ({
                 ref: fetchRef,
             });
 
-            // The pinned commit can disappear (e.g. a force-push + GC prunes it).
-            // Fall back once to the symbolic ref so the file still renders.
-            if (isServiceError(pinned) && fetchRef !== fileSource.revision) {
+            // The pinned commit can disappear (e.g. a force-push + GC prunes it),
+            // which surfaces as an unresolvable git ref. Only that case falls
+            // back to the symbolic ref; other errors (repo/path/access) are
+            // surfaced as-is so we don't silently render the wrong revision.
+            if (
+                isServiceError(pinned) &&
+                pinned.errorCode === ErrorCode.INVALID_GIT_REF &&
+                fetchRef !== fileSource.revision
+            ) {
                 return unwrapServiceError(getFileSource({
                     path: fileSource.path,
                     repo: fileSource.repo,

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -38,12 +38,16 @@ const ReferencedFileSourceListItemContainerComponent = ({
 }: ReferencedFileSourceListItemContainerProps) => {
     const fileName = fileSource.path.split('/').pop() ?? fileSource.path;
 
+    // Prefer the pinned commit SHA so the file renders as it was when answered,
+    // with line ranges still aligned. Falls back to the symbolic ref.
+    const fetchRef = fileSource.commitSha ?? fileSource.revision;
+
     const { data, isLoading, isError, error } = useQuery({
-        queryKey: ['fileSource', fileSource.path, fileSource.repo, fileSource.revision],
+        queryKey: ['fileSource', fileSource.path, fileSource.repo, fetchRef],
         queryFn: () => unwrapServiceError(getFileSource({
             path: fileSource.path,
             repo: fileSource.repo,
-            ref: fileSource.revision,
+            ref: fetchRef,
         })),
         staleTime: Infinity,
     });

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getFileSource } from "@/app/api/(client)/client";
+import { getFileFreshness, getFileSource } from "@/app/api/(client)/client";
 import { VscodeFileIcon } from "@/app/components/vscodeFileIcon";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isServiceError, unwrapServiceError } from "@/lib/utils";
@@ -72,6 +72,19 @@ const ReferencedFileSourceListItemContainerComponent = ({
         staleTime: Infinity,
     });
 
+    // Whether the cited file has changed since the pinned commit. Only checked
+    // for pinned sources; older un-pinned sources have nothing to compare.
+    const { data: freshness } = useQuery({
+        queryKey: ['fileFreshness', fileSource.repo, fileSource.path, fileSource.commitSha],
+        queryFn: () => unwrapServiceError(getFileFreshness({
+            repo: fileSource.repo,
+            path: fileSource.path,
+            sinceSha: fileSource.commitSha!,
+        })),
+        enabled: !!fileSource.commitSha,
+        staleTime: 5 * 60 * 1000,
+    });
+
     const handleRef = useCallback((ref: ReactCodeMirrorRef | null) => {
         onEditorRef(fileId, ref);
     }, [fileId, onEditorRef]);
@@ -118,6 +131,9 @@ const ReferencedFileSourceListItemContainerComponent = ({
             repoWebUrl={data.repoExternalWebUrl}
             fileName={data.path}
             references={references}
+            pinnedSha={fileSource.commitSha}
+            freshnessStatus={freshness?.status}
+            currentSha={freshness?.currentSha}
             ref={handleRef}
             onSelectedReferenceChanged={onSelectedReferenceChanged}
             onHoveredReferenceChanged={onHoveredReferenceChanged}

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -52,10 +52,9 @@ const ReferencedFileSourceListItemContainerComponent = ({
                 ref: fetchRef,
             });
 
-            // The pinned commit can disappear (e.g. a force-push + GC prunes it),
-            // which surfaces as an unresolvable git ref. Only that case falls
-            // back to the symbolic ref; other errors (repo/path/access) are
-            // surfaced as-is so we don't silently render the wrong revision.
+            // A gone pinned commit (e.g. force-push + GC) surfaces as an
+            // unresolvable ref. Only then fall back to the symbolic ref; other
+            // errors are surfaced as-is rather than silently showing latest.
             if (
                 isServiceError(pinned) &&
                 pinned.errorCode === ErrorCode.INVALID_GIT_REF &&

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -443,8 +443,12 @@ export const getLanguageModelKey = (model: Pick<LanguageModelInfo, 'provider' | 
  * Given a file reference and a list of file sources, attempts to resolve the file source that the reference points to.
  */
 export const tryResolveFileReference = (reference: FileReference, sources: FileSource[]): FileSource | undefined => {
-    return sources.find(
+    const matches = sources.filter(
         (source) => source.repo.endsWith(reference.repo) &&
             source.path.endsWith(reference.path)
     );
+    // The same file can be sourced by multiple tools in one turn (e.g. an
+    // unpinned `list_tree` listing plus a pinned `read_file`). Prefer a pinned
+    // source so citations resolve to the commit the content was read at.
+    return matches.find((source) => source.commitSha) ?? matches[0];
 };

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -287,10 +287,11 @@ export const convertLLMOutputToPortableMarkdown = (text: string, baseUrl: string
                 end: { lineNumber: parseInt(endLine || startLine) },
             } : undefined;
 
-            // Construct full browse URL
+            // Prefer the pinned commit SHA so copied links resolve to the code
+            // as it was when answered; fall back to the symbolic ref.
             const browsePath = getBrowsePath({
                 repoName: repo,
-                revisionName: source.revision,
+                revisionName: source.commitSha ?? source.revision,
                 path: fileName,
                 pathType: 'blob',
                 highlightRange,

--- a/packages/web/src/features/git/getFileFreshnessApi.test.ts
+++ b/packages/web/src/features/git/getFileFreshnessApi.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSimpleGit = vi.hoisted(() => vi.fn());
+
+vi.mock('simple-git', () => ({
+    default: mockSimpleGit,
+    simpleGit: mockSimpleGit,
+}));
+vi.mock('@sourcebot/shared', () => ({
+    getRepoPath: (repo: { id: number }) => ({ path: `/mock/repos/${repo.id}` }),
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@/middleware/sew', () => ({
+    sew: async <T>(fn: () => Promise<T> | T): Promise<T> => {
+        try {
+            return await fn();
+        } catch (error) {
+            return {
+                errorCode: 'UNEXPECTED_ERROR',
+                message: error instanceof Error ? error.message : String(error),
+            } as T;
+        }
+    },
+}));
+vi.mock('@/middleware/withAuth', () => ({
+    // Invoke the callback with a minimal auth context.
+    withOptionalAuth: (fn: (ctx: { org: unknown; prisma: unknown }) => unknown) =>
+        fn({ org: MOCK_ORG, prisma: mockPrisma }),
+}));
+
+import { getFileFreshness } from './getFileFreshnessApi';
+
+const MOCK_ORG = { id: 1, name: 'test-org' } as never;
+
+const MOCK_REPO = {
+    id: 123,
+    name: 'github.com/owner/repo',
+    orgId: 1,
+    defaultBranch: 'main',
+};
+
+const mockGitRaw = vi.fn();
+const mockCwd = vi.fn();
+const mockFindFirst = vi.fn();
+const mockPrisma = { repo: { findFirst: (...args: unknown[]) => mockFindFirst(...args) } } as never;
+
+const PATH = 'src/index.ts';
+
+describe('getFileFreshness', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCwd.mockReturnValue({ raw: mockGitRaw });
+        mockSimpleGit.mockReturnValue({ cwd: mockCwd });
+        mockFindFirst.mockResolvedValue(MOCK_REPO);
+    });
+
+    it('returns NOT_FOUND when the repo is absent', async () => {
+        mockFindFirst.mockResolvedValue(null);
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'abc' });
+        expect(result).toMatchObject({ errorCode: 'NOT_FOUND' });
+    });
+
+    it('returns FILE_NOT_FOUND for path traversal', async () => {
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: 'src/../../etc/passwd', sinceSha: 'abc' });
+        expect(result).toMatchObject({ errorCode: 'FILE_NOT_FOUND' });
+    });
+
+    it('returns INVALID_GIT_REF for refs starting with "-"', async () => {
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: '--evil' });
+        expect(result).toMatchObject({ errorCode: 'INVALID_GIT_REF' });
+    });
+
+    it('is fresh (fast path) when the pinned commit equals the current tip', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            throw new Error('should not reach blob comparison');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'currentsha' });
+        expect(result).toMatchObject({ status: 'fresh', currentSha: 'currentsha' });
+    });
+
+    it('is fresh when the blob is identical at both commits', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'sameblob\n';
+            if (args[1] === `currentsha:${PATH}`) return 'sameblob\n';
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'fresh', currentSha: 'currentsha' });
+    });
+
+    it('is changed when the blob differs', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'oldblob\n';
+            if (args[1] === `currentsha:${PATH}`) return 'newblob\n';
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'changed', currentSha: 'currentsha' });
+    });
+
+    it('is removed when the path is absent at the current tip', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'oldblob\n';
+            if (args[1] === `currentsha:${PATH}`) throw new Error('does not exist');
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'removed', currentSha: 'currentsha' });
+    });
+
+    it('is pinned_unavailable when the pinned commit is gone', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `gonepin:${PATH}`) throw new Error('bad revision');
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'gonepin' });
+        expect(result).toMatchObject({ status: 'pinned_unavailable', currentSha: 'currentsha' });
+    });
+
+    it('returns UNEXPECTED_ERROR when resolving the current tip fails', async () => {
+        mockGitRaw.mockRejectedValueOnce(new Error('I/O error'));
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ errorCode: 'UNEXPECTED_ERROR' });
+    });
+});

--- a/packages/web/src/features/git/getFileFreshnessApi.ts
+++ b/packages/web/src/features/git/getFileFreshnessApi.ts
@@ -1,0 +1,85 @@
+import { sew } from "@/middleware/sew";
+import { fileNotFound, invalidGitRef, notFound, ServiceError, unexpectedError } from '@/lib/serviceError';
+import { withOptionalAuth } from '@/middleware/withAuth';
+import { getRepoPath } from '@sourcebot/shared';
+import simpleGit from 'simple-git';
+import type z from 'zod';
+import { isGitRefValid, isPathValid } from './utils';
+import { fileFreshnessRequestSchema, fileFreshnessResponseSchema } from './schemas';
+
+export { fileFreshnessRequestSchema, fileFreshnessResponseSchema } from './schemas';
+export type FileFreshnessRequest = z.infer<typeof fileFreshnessRequestSchema>;
+export type FileFreshnessResponse = z.infer<typeof fileFreshnessResponseSchema>;
+
+// Resolves the blob OID of `path` at a ref, or undefined if it can't be
+// resolved (ref or path absent at that ref).
+const resolveBlobOid = async (
+    git: ReturnType<typeof simpleGit>,
+    ref: string,
+    path: string,
+): Promise<string | undefined> => {
+    try {
+        return (await git.raw(['rev-parse', `${ref}:${path}`])).trim();
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Compares a citation's pinned commit against the repo's current default-branch
+ * tip to determine whether the cited file has changed since the answer was
+ * generated. File-level (blob identity), not line-level. Best-effort: a pinned
+ * commit that no longer exists (e.g. force-push + GC) yields `pinned_unavailable`.
+ */
+export const getFileFreshness = async (
+    { repo: repoName, path: filePath, sinceSha }: FileFreshnessRequest,
+): Promise<FileFreshnessResponse | ServiceError> => sew(() =>
+    withOptionalAuth(async ({ org, prisma }) => {
+        const repo = await prisma.repo.findFirst({
+            where: { name: repoName, orgId: org.id },
+        });
+        if (!repo) {
+            return notFound(`Repository "${repoName}" not found.`);
+        }
+
+        if (!isPathValid(filePath)) {
+            return fileNotFound(filePath, repoName);
+        }
+
+        if (!isGitRefValid(sinceSha)) {
+            return invalidGitRef(sinceSha);
+        }
+
+        const { path: repoPath } = getRepoPath(repo);
+        const git = simpleGit().cwd(repoPath);
+        const currentRef = repo.defaultBranch ?? 'HEAD';
+
+        let currentSha: string;
+        try {
+            currentSha = (await git.raw(['rev-parse', `${currentRef}^{commit}`])).trim();
+        } catch (error) {
+            return unexpectedError(error instanceof Error ? error.message : String(error));
+        }
+
+        // Nothing has advanced since the pin: definitively fresh, no blob work.
+        if (sinceSha === currentSha) {
+            return { status: 'fresh', currentSha };
+        }
+
+        const pinnedBlob = await resolveBlobOid(git, sinceSha, filePath);
+        if (pinnedBlob === undefined) {
+            // The pinned commit (or the path within it) is gone.
+            return { status: 'pinned_unavailable', currentSha };
+        }
+
+        const currentBlob = await resolveBlobOid(git, currentSha, filePath);
+        if (currentBlob === undefined) {
+            return { status: 'removed', currentSha };
+        }
+
+        return {
+            status: pinnedBlob === currentBlob ? 'fresh' : 'changed',
+            currentSha,
+        };
+    }),
+);

--- a/packages/web/src/features/git/getFileSourceApi.test.ts
+++ b/packages/web/src/features/git/getFileSourceApi.test.ts
@@ -92,9 +92,7 @@ describe('getFileSourceForRepo', () => {
         mockSimpleGit.mockReturnValue({ cwd: mockCwd });
         mockFindFirst.mockResolvedValue(MOCK_REPO);
 
-        // Default: ref resolves to a concrete sha, file show succeeds, and
-        // .gitattributes is absent. The SUT resolves the ref first (rev-parse),
-        // then reads content + .gitattributes at the resolved sha.
+        // ref resolves to a sha, file show succeeds, .gitattributes is absent.
         mockGitRaw.mockImplementation(async (args: string[]) => {
             if (args[0] === 'rev-parse') {
                 return 'resolvedsha\n';
@@ -203,7 +201,7 @@ describe('getFileSourceForRepo', () => {
             // pr_payload.head_sha as ref, but the bare clone hasn't fetched it yet.
             mockGitRaw.mockRejectedValue(
                 new Error("fatal: ambiguous argument 'deadbeef': unknown revision or path not in the working tree"),
-            ); // rejects rev-parse (swallowed) and the show, which drives the result
+            );
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo', ref: 'deadbeef' },

--- a/packages/web/src/features/git/getFileSourceApi.test.ts
+++ b/packages/web/src/features/git/getFileSourceApi.test.ts
@@ -92,8 +92,13 @@ describe('getFileSourceForRepo', () => {
         mockSimpleGit.mockReturnValue({ cwd: mockCwd });
         mockFindFirst.mockResolvedValue(MOCK_REPO);
 
-        // Default: file show succeeds; .gitattributes not present
+        // Default: ref resolves to a concrete sha, file show succeeds, and
+        // .gitattributes is absent. The SUT resolves the ref first (rev-parse),
+        // then reads content + .gitattributes at the resolved sha.
         mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[0] === 'rev-parse') {
+                return 'resolvedsha\n';
+            }
             if (args[1]?.endsWith('.gitattributes')) {
                 throw new Error('does not exist in HEAD');
             }
@@ -170,7 +175,7 @@ describe('getFileSourceForRepo', () => {
 
     describe('git error handling', () => {
         it('returns FILE_NOT_FOUND when git reports the file does not exist', async () => {
-            mockGitRaw.mockRejectedValueOnce(
+            mockGitRaw.mockRejectedValue(
                 new Error("fatal: path 'src/missing.ts' does not exist in 'main'"),
             );
 
@@ -183,7 +188,7 @@ describe('getFileSourceForRepo', () => {
         });
 
         it('returns FILE_NOT_FOUND for "fatal: path" errors', async () => {
-            mockGitRaw.mockRejectedValueOnce(new Error('fatal: path not found'));
+            mockGitRaw.mockRejectedValue(new Error('fatal: path not found'));
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo' },
@@ -196,9 +201,9 @@ describe('getFileSourceForRepo', () => {
         it('returns INVALID_GIT_REF with an unresolved-ref message when head_sha has not been fetched ("unknown revision")', async () => {
             // This is the scenario from the v4.16.14 regression: the review agent passes
             // pr_payload.head_sha as ref, but the bare clone hasn't fetched it yet.
-            mockGitRaw.mockRejectedValueOnce(
+            mockGitRaw.mockRejectedValue(
                 new Error("fatal: ambiguous argument 'deadbeef': unknown revision or path not in the working tree"),
-            );
+            ); // rejects rev-parse (swallowed) and the show, which drives the result
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo', ref: 'deadbeef' },
@@ -212,7 +217,7 @@ describe('getFileSourceForRepo', () => {
         });
 
         it('returns INVALID_GIT_REF with an unresolved-ref message for "bad revision" errors', async () => {
-            mockGitRaw.mockRejectedValueOnce(new Error('fatal: bad revision'));
+            mockGitRaw.mockRejectedValue(new Error('fatal: bad revision'));
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo', ref: 'nonexistent' },
@@ -226,7 +231,7 @@ describe('getFileSourceForRepo', () => {
         });
 
         it('returns INVALID_GIT_REF with an unresolved-ref message for "invalid object name" errors', async () => {
-            mockGitRaw.mockRejectedValueOnce(new Error('fatal: invalid object name HEAD'));
+            mockGitRaw.mockRejectedValue(new Error('fatal: invalid object name HEAD'));
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo' },
@@ -243,7 +248,7 @@ describe('getFileSourceForRepo', () => {
             // Before the fix, getFileSourceForRepo re-threw unknown errors.
             // Outside sew(), this caused a fatal Next.js task-runner exception.
             // After the fix, all errors are returned as ServiceError.
-            mockGitRaw.mockRejectedValueOnce(new Error('I/O error: device busy'));
+            mockGitRaw.mockRejectedValue(new Error('I/O error: device busy'));
 
             const result = await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo' },
@@ -254,7 +259,7 @@ describe('getFileSourceForRepo', () => {
         });
 
         it('never rejects its returned promise for unrecognised git errors', async () => {
-            mockGitRaw.mockRejectedValueOnce(new Error('transient I/O error'));
+            mockGitRaw.mockRejectedValue(new Error('transient I/O error'));
 
             await expect(
                 getFileSourceForRepo(
@@ -280,13 +285,16 @@ describe('getFileSourceForRepo', () => {
             });
         });
 
-        it('uses the provided ref for the git show command', async () => {
+        it('resolves the provided ref to a commit, then reads content at it', async () => {
             await getFileSourceForRepo(
                 { path: 'src/index.ts', repo: 'github.com/owner/repo', ref: 'abc123sha' },
                 { org: MOCK_ORG, prisma: mockPrisma },
             );
 
-            expect(mockGitRaw).toHaveBeenCalledWith(['show', 'abc123sha:src/index.ts']);
+            // The provided ref is resolved up front...
+            expect(mockGitRaw).toHaveBeenCalledWith(['rev-parse', 'abc123sha^{commit}']);
+            // ...and content is read at the resolved sha, not the symbolic ref.
+            expect(mockGitRaw).toHaveBeenCalledWith(['show', 'resolvedsha:src/index.ts']);
         });
 
         it('falls back to defaultBranch when ref is omitted', async () => {
@@ -295,7 +303,7 @@ describe('getFileSourceForRepo', () => {
                 { org: MOCK_ORG, prisma: mockPrisma },
             );
 
-            expect(mockGitRaw).toHaveBeenCalledWith(['show', 'main:src/index.ts']);
+            expect(mockGitRaw).toHaveBeenCalledWith(['rev-parse', 'main^{commit}']);
         });
 
         it('falls back to HEAD when both ref and defaultBranch are absent', async () => {
@@ -306,7 +314,28 @@ describe('getFileSourceForRepo', () => {
                 { org: MOCK_ORG, prisma: mockPrisma },
             );
 
-            expect(mockGitRaw).toHaveBeenCalledWith(['show', 'HEAD:src/index.ts']);
+            expect(mockGitRaw).toHaveBeenCalledWith(['rev-parse', 'HEAD^{commit}']);
+        });
+
+        it('reads content at the symbolic ref when rev-parse fails', async () => {
+            mockGitRaw.mockImplementation(async (args: string[]) => {
+                if (args[0] === 'rev-parse') {
+                    throw new Error('unknown revision');
+                }
+                if (args[1]?.endsWith('.gitattributes')) {
+                    throw new Error('does not exist');
+                }
+                return 'console.log("hello");';
+            });
+
+            const result = await getFileSourceForRepo(
+                { path: 'src/index.ts', repo: 'github.com/owner/repo', ref: 'main' },
+                { org: MOCK_ORG, prisma: mockPrisma },
+            );
+
+            expect(mockGitRaw).toHaveBeenCalledWith(['show', 'main:src/index.ts']);
+            expect(result).toMatchObject({ source: 'console.log("hello");' });
+            expect((result as { commitSha?: string }).commitSha).toBeUndefined();
         });
 
         it('uses the repo path from getRepoPath for the git working directory', async () => {

--- a/packages/web/src/features/git/getFileSourceApi.ts
+++ b/packages/web/src/features/git/getFileSourceApi.ts
@@ -47,9 +47,21 @@ export const getFileSourceForRepo = async (
 
     const gitRef = ref ?? repo.defaultBranch ?? 'HEAD';
 
+    // Resolve the symbolic ref to a concrete commit up front so the content,
+    // language, and commitSha all come from the same revision even if the ref
+    // moves mid-request. `^{commit}` peels annotated tags. Reads below fall back
+    // to the symbolic ref when resolution fails.
+    let commitSha: string | undefined;
+    try {
+        commitSha = (await git.raw(['rev-parse', `${gitRef}^{commit}`])).trim();
+    } catch {
+        // Leave unpinned; the reads below use the symbolic ref.
+    }
+    const readRef = commitSha ?? gitRef;
+
     let fileContent: string;
     try {
-        fileContent = await git.raw(['show', `${gitRef}:${filePath}`]);
+        fileContent = await git.raw(['show', `${readRef}:${filePath}`]);
     } catch (error: unknown) {
         const errorMessage = error instanceof Error ? error.message : String(error);
         if (errorMessage.includes('does not exist') || errorMessage.includes('fatal: path')) {
@@ -61,18 +73,9 @@ export const getFileSourceForRepo = async (
         return unexpectedError(errorMessage);
     }
 
-    // Resolve the symbolic ref to a concrete commit SHA so callers can pin a
-    // citation to the exact code read. `^{commit}` peels annotated tags.
-    let commitSha: string | undefined;
-    try {
-        commitSha = (await git.raw(['rev-parse', `${gitRef}^{commit}`])).trim();
-    } catch {
-        // Leave unpinned if the ref can't be resolved.
-    }
-
     let gitattributesContent: string | undefined;
     try {
-        gitattributesContent = await git.raw(['show', `${gitRef}:.gitattributes`]);
+        gitattributesContent = await git.raw(['show', `${readRef}:.gitattributes`]);
     } catch {
         // No .gitattributes in this repo/ref, that's fine
     }

--- a/packages/web/src/features/git/getFileSourceApi.ts
+++ b/packages/web/src/features/git/getFileSourceApi.ts
@@ -47,15 +47,14 @@ export const getFileSourceForRepo = async (
 
     const gitRef = ref ?? repo.defaultBranch ?? 'HEAD';
 
-    // Resolve the symbolic ref to a concrete commit up front so the content,
-    // language, and commitSha all come from the same revision even if the ref
-    // moves mid-request. `^{commit}` peels annotated tags. Reads below fall back
-    // to the symbolic ref when resolution fails.
+    // Resolve to a concrete commit up front so content, language, and commitSha
+    // all come from one revision even if the ref moves mid-request. `^{commit}`
+    // peels annotated tags. Reads below fall back to the symbolic ref.
     let commitSha: string | undefined;
     try {
         commitSha = (await git.raw(['rev-parse', `${gitRef}^{commit}`])).trim();
     } catch {
-        // Leave unpinned; the reads below use the symbolic ref.
+        // Leave unpinned.
     }
     const readRef = commitSha ?? gitRef;
 

--- a/packages/web/src/features/git/getFileSourceApi.ts
+++ b/packages/web/src/features/git/getFileSourceApi.ts
@@ -61,6 +61,15 @@ export const getFileSourceForRepo = async (
         return unexpectedError(errorMessage);
     }
 
+    // Resolve the symbolic ref to a concrete commit SHA so callers can pin a
+    // citation to the exact code read. `^{commit}` peels annotated tags.
+    let commitSha: string | undefined;
+    try {
+        commitSha = (await git.raw(['rev-parse', `${gitRef}^{commit}`])).trim();
+    } catch {
+        // Leave unpinned if the ref can't be resolved.
+    }
+
     let gitattributesContent: string | undefined;
     try {
         gitattributesContent = await git.raw(['show', `${gitRef}:.gitattributes`]);
@@ -97,6 +106,7 @@ export const getFileSourceForRepo = async (
         repoExternalWebUrl: repo.webUrl ?? undefined,
         webUrl,
         externalWebUrl,
+        commitSha,
     } satisfies FileSourceResponse;
 });
 

--- a/packages/web/src/features/git/index.ts
+++ b/packages/web/src/features/git/index.ts
@@ -4,6 +4,7 @@ export * from './getFilesApi';
 export * from './getFolderContentsApi';
 export * from './getTreeApi';
 export * from './getFileSourceApi';
+export * from './getFileFreshnessApi';
 export * from './getFileBlameApi';
 export * from './listCommitsApi';
 export * from './listCommitAuthorsApi';

--- a/packages/web/src/features/git/schemas.ts
+++ b/packages/web/src/features/git/schemas.ts
@@ -35,6 +35,8 @@ export const fileSourceResponseSchema = z.object({
     repoExternalWebUrl: z.string().optional(),
     webUrl: z.string(),
     externalWebUrl: z.string().optional(),
+    // The concrete commit SHA that `ref` resolved to. Undefined if unresolvable.
+    commitSha: z.string().optional(),
 });
 
 export const getDiffRequestSchema = z.object({

--- a/packages/web/src/features/git/schemas.ts
+++ b/packages/web/src/features/git/schemas.ts
@@ -39,6 +39,24 @@ export const fileSourceResponseSchema = z.object({
     commitSha: z.string().optional(),
 });
 
+export const fileFreshnessRequestSchema = z.object({
+    repo: z.string(),
+    path: z.string(),
+    // The pinned commit SHA a citation was sourced at.
+    sinceSha: z.string(),
+});
+
+export const fileFreshnessResponseSchema = z.object({
+    // `fresh`: the cited file is byte-identical at the current tip.
+    // `changed`: the file's content differs since the pinned commit.
+    // `removed`: the file no longer exists at the current tip.
+    // `pinned_unavailable`: the pinned commit is no longer in the repo (e.g.
+    //   force-push + GC pruned it), so we can't compare against it.
+    status: z.enum(['fresh', 'changed', 'removed', 'pinned_unavailable']),
+    // The commit the current default branch points at.
+    currentSha: z.string(),
+});
+
 export const getDiffRequestSchema = z.object({
     repo: z.string().describe('The fully-qualified repository name.'),
     base: z.string().describe('The base git ref (branch, tag, or commit SHA) to diff from.'),

--- a/packages/web/src/features/search/types.ts
+++ b/packages/web/src/features/search/types.ts
@@ -27,6 +27,8 @@ export const repositoryInfoSchema = z.object({
     name: z.string(),
     displayName: z.string().optional(),
     webUrl: z.string().optional(),
+    // The commit Zoekt last indexed; lets callers pin a result to that commit.
+    indexedCommitHash: z.string().optional(),
 });
 export type RepositoryInfo = z.infer<typeof repositoryInfoSchema>;
 

--- a/packages/web/src/features/search/zoektSearcher.ts
+++ b/packages/web/src/features/search/zoektSearcher.ts
@@ -511,6 +511,7 @@ const transformZoektSearchResponse = async (response: ZoektGrpcSearchResponse, r
             name: repo.name,
             displayName: repo.displayName ?? undefined,
             webUrl: repo.webUrl ?? undefined,
+            indexedCommitHash: repo.indexedCommitHash ?? undefined,
         })),
         stats,
     }

--- a/packages/web/src/features/tools/findSymbolDefinitions.ts
+++ b/packages/web/src/features/tools/findSymbolDefinitions.ts
@@ -72,6 +72,7 @@ export const findSymbolDefinitionsDefinition: ToolDefinition<
                 fileName: file.fileName,
                 repo: file.repository,
                 revision,
+                commitSha: repoInfoResult.indexedCommitHash,
             })),
         };
 
@@ -105,6 +106,7 @@ export const findSymbolDefinitionsDefinition: ToolDefinition<
             path: file.fileName,
             name: file.fileName.split('/').pop() ?? file.fileName,
             revision: file.revision,
+            commitSha: file.commitSha,
         }));
 
         return {

--- a/packages/web/src/features/tools/findSymbolDefinitions.ts
+++ b/packages/web/src/features/tools/findSymbolDefinitions.ts
@@ -63,9 +63,8 @@ export const findSymbolDefinitionsDefinition: ToolDefinition<
             codeHostType: repoInfoResult.codeHostType,
         };
 
-        // Pin to the indexed commit carried by the same search snapshot that
-        // produced these matches, rather than a follow-up repo-info lookup that
-        // could drift if the index advances in between.
+        // Pin from the indexed commit in this search's snapshot, not a separate
+        // repo-info lookup that could drift if the index advances in between.
         const indexedCommitShaByRepo = new Map(
             response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
         );

--- a/packages/web/src/features/tools/findSymbolDefinitions.ts
+++ b/packages/web/src/features/tools/findSymbolDefinitions.ts
@@ -63,6 +63,13 @@ export const findSymbolDefinitionsDefinition: ToolDefinition<
             codeHostType: repoInfoResult.codeHostType,
         };
 
+        // Pin to the indexed commit carried by the same search snapshot that
+        // produced these matches, rather than a follow-up repo-info lookup that
+        // could drift if the index advances in between.
+        const indexedCommitShaByRepo = new Map(
+            response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
+        );
+
         const metadata: FindSymbolDefinitionsMetadata = {
             symbol,
             matchCount,
@@ -72,7 +79,7 @@ export const findSymbolDefinitionsDefinition: ToolDefinition<
                 fileName: file.fileName,
                 repo: file.repository,
                 revision,
-                commitSha: repoInfoResult.indexedCommitHash,
+                commitSha: indexedCommitShaByRepo.get(file.repository),
             })),
         };
 

--- a/packages/web/src/features/tools/findSymbolReferences.ts
+++ b/packages/web/src/features/tools/findSymbolReferences.ts
@@ -74,9 +74,8 @@ export const findSymbolReferencesDefinition: ToolDefinition<
             codeHostType: repoInfoResult.codeHostType,
         };
 
-        // Pin to the indexed commit carried by the same search snapshot that
-        // produced these matches, rather than a follow-up repo-info lookup that
-        // could drift if the index advances in between.
+        // Pin from the indexed commit in this search's snapshot, not a separate
+        // repo-info lookup that could drift if the index advances in between.
         const indexedCommitShaByRepo = new Map(
             response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
         );

--- a/packages/web/src/features/tools/findSymbolReferences.ts
+++ b/packages/web/src/features/tools/findSymbolReferences.ts
@@ -25,6 +25,7 @@ export type FindSymbolFile = {
     fileName: string;
     repo: string;
     revision: string;
+    commitSha?: string;
 };
 
 export type FindSymbolReferencesMetadata = {
@@ -82,6 +83,7 @@ export const findSymbolReferencesDefinition: ToolDefinition<
                 fileName: file.fileName,
                 repo: file.repository,
                 revision,
+                commitSha: repoInfoResult.indexedCommitHash,
             })),
         };
 
@@ -115,6 +117,7 @@ export const findSymbolReferencesDefinition: ToolDefinition<
             path: file.fileName,
             name: file.fileName.split('/').pop() ?? file.fileName,
             revision: file.revision,
+            commitSha: file.commitSha,
         }));
 
         return {

--- a/packages/web/src/features/tools/findSymbolReferences.ts
+++ b/packages/web/src/features/tools/findSymbolReferences.ts
@@ -74,6 +74,13 @@ export const findSymbolReferencesDefinition: ToolDefinition<
             codeHostType: repoInfoResult.codeHostType,
         };
 
+        // Pin to the indexed commit carried by the same search snapshot that
+        // produced these matches, rather than a follow-up repo-info lookup that
+        // could drift if the index advances in between.
+        const indexedCommitShaByRepo = new Map(
+            response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
+        );
+
         const metadata: FindSymbolReferencesMetadata = {
             symbol,
             matchCount,
@@ -83,7 +90,7 @@ export const findSymbolReferencesDefinition: ToolDefinition<
                 fileName: file.fileName,
                 repo: file.repository,
                 revision,
-                commitSha: repoInfoResult.indexedCommitHash,
+                commitSha: indexedCommitShaByRepo.get(file.repository),
             })),
         };
 

--- a/packages/web/src/features/tools/glob.ts
+++ b/packages/web/src/features/tools/glob.ts
@@ -44,6 +44,7 @@ export type GlobFile = {
     name: string;
     repo: string;
     revision: string;
+    commitSha?: string;
 };
 
 export type GlobRepoInfo = {
@@ -113,11 +114,17 @@ export const globDefinition: ToolDefinition<'glob', typeof globShape, GlobMetada
             throw new Error(response.message);
         }
 
+        // Matches reflect the commit Zoekt last indexed; pin each to it.
+        const indexedCommitShaByRepo = new Map(
+            response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
+        );
+
         const files = response.files.map((file) => ({
             path: file.fileName.text,
             name: file.fileName.text.split('/').pop() ?? file.fileName.text,
             repo: file.repository,
             revision: ref ?? 'HEAD',
+            commitSha: indexedCommitShaByRepo.get(file.repository),
         } satisfies GlobFile));
 
         const repoInfoMap = Object.fromEntries(
@@ -190,6 +197,7 @@ export const globDefinition: ToolDefinition<'glob', typeof globShape, GlobMetada
             path: file.path,
             name: file.name,
             revision: file.revision,
+            commitSha: file.commitSha,
         }));
 
         return {

--- a/packages/web/src/features/tools/grep.ts
+++ b/packages/web/src/features/tools/grep.ts
@@ -55,6 +55,7 @@ export type GrepFile = {
     name: string;
     repo: string;
     revision: string;
+    commitSha?: string;
 };
 
 export type GrepRepoInfo = {
@@ -132,11 +133,17 @@ export const grepDefinition: ToolDefinition<'grep', typeof grepShape, GrepMetada
             throw new Error(response.message);
         }
 
+        // Matches reflect the commit Zoekt last indexed; pin each to it.
+        const indexedCommitShaByRepo = new Map(
+            response.repositoryInfo.map((info) => [info.name, info.indexedCommitHash]),
+        );
+
         const files = response.files.map((file) => ({
             path: file.fileName.text,
             name: file.fileName.text.split('/').pop() ?? file.fileName.text,
             repo: file.repository,
             revision: ref ?? 'HEAD',
+            commitSha: indexedCommitShaByRepo.get(file.repository),
         } satisfies GrepFile));
 
         const repoInfoMap = Object.fromEntries(
@@ -241,6 +248,7 @@ export const grepDefinition: ToolDefinition<'grep', typeof grepShape, GrepMetada
                 path: file.path,
                 name: file.path.split('/').pop() ?? file.path,
                 revision: file.revision,
+                commitSha: file.commitSha,
             }));
 
             return {

--- a/packages/web/src/features/tools/readFile.ts
+++ b/packages/web/src/features/tools/readFile.ts
@@ -133,6 +133,7 @@ export const readFileDefinition: ToolDefinition<"read_file", typeof readFileShap
                 path: fileSource.path,
                 name: fileSource.path.split('/').pop() ?? fileSource.path,
                 revision: ref,
+                commitSha: fileSource.commitSha,
             }],
         };
     },

--- a/packages/web/src/features/tools/types.ts
+++ b/packages/web/src/features/tools/types.ts
@@ -6,6 +6,9 @@ const fileSourceSchema = z.object({
     path: z.string(),
     name: z.string(),
     revision: z.string(),
+    // The concrete commit SHA the content was served at. Optional for
+    // backwards-compatibility with sources persisted before pinning existed.
+    commitSha: z.string().optional(),
 });
 export type FileSource = z.infer<typeof fileSourceSchema>;
 


### PR DESCRIPTION
Pins each Ask file citation to the commit SHA it was sourced at (`git rev-parse` for `read_file`; the repo's indexed commit for `grep`/`glob`/symbol search), and fetches the evidence panel + copied links at that SHA. Keeps citation content and line ranges aligned with the code as it was when answered, rather than drifting against HEAD. `commitSha` **is optional,** so older chats fall back to the symbolic ref.

Groundwork for a follow-up freshness hint. `get_diff`/`list_tree` left unpinned for now.

Should be basically indistinguishable UI/UX difference, just now that any code referenced in the evidence panel should be as-the-agent-saw-it. In the event that the revision was lost in git history, it will fallback to one retry fetch from effectively `latest`, which is the existing behaviour.

## Additional

Adds a per-citation freshness hint: `/api/source/freshness` compares a pinned commit to the repo's current default-branch tip (file-level blob comparison), and the evidence panel shows a badge when the cited file has `changed` / `removed` / `pinned_unavailable`, with a "View latest" link. Also resolves a citation to a pinned source when multiple tools sourced the same file in one turn.

Scope: panel-only (no inline-chip dots or answer rollup yet); `list_tree`/`get_diff` remain unpinned.

(removed the "view latest" button from these two, but here's what the badges look like for the other two statuses (not included in the screenrecording)

<img width="862" height="54" alt="Screenshot 2026-06-29 at 2 19 13 PM" src="https://github.com/user-attachments/assets/fb738d3c-d55f-4d68-96b4-4866ccbfa24a" />
<img width="862" height="56" alt="Screenshot 2026-06-29 at 2 19 27 PM" src="https://github.com/user-attachments/assets/51731991-f78e-4642-a5c2-3b4f611453ea" />


https://github.com/user-attachments/assets/8eeca34b-f101-4fb6-bef6-9ca108447d93

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * File citations are now pinned to the commit they were generated from, keeping the displayed line ranges aligned over time.
  * Added file citation staleness hints plus a freshness indicator in the referenced file view (including “view latest” when available).
  * Search and developer tools (symbols, references, grep, glob, and file reads) now surface commit-specific source details for more precise referencing.
* **Bug Fixes**
  * When a pinned file ref is invalid, the app falls back to an alternate revision to keep content rendering.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->