### PR TITLE
feat(web): flag Ask citations whose code changed since the answer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added mermaid diagram rendering to Ask Sourcebot answers, with pan/zoom, copy/export, in-thread deep links, and an interleaved right-panel view. [#1369](https://github.com/sourcebot-dev/sourcebot/pull/1369)
 - [EE] Added a context-window usage gauge to the Ask Sourcebot chat details, showing how much of the selected model's context window each turn occupies. Window sizes are resolved from the models.dev catalog. [#1370](https://github.com/sourcebot-dev/sourcebot/pull/1370)
 - Added language model input-modality and document capability resolution, automatically resolved from the models.dev catalog (falls back to text-only for uncatalogued/self-hosted models). [#1372](https://github.com/sourcebot-dev/sourcebot/pull/1372)
+- [EE] Added a staleness hint to Ask Sourcebot file citations that flags when the cited file has changed since the answer was generated, with a link to the latest version. [#1399](https://github.com/sourcebot-dev/sourcebot/pull/1399)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/packages/web/src/app/api/(client)/client.ts
+++ b/packages/web/src/app/api/(client)/client.ts
@@ -20,6 +20,8 @@ import {
     GetTreeResponse,
     FileSourceRequest,
     FileSourceResponse,
+    FileFreshnessRequest,
+    FileFreshnessResponse,
     ListCommitsQueryParams,
     ListCommitsResponse,
 } from "@/features/git";
@@ -66,6 +68,22 @@ export const getFileSource = async (queryParams: FileSourceRequest): Promise<Fil
     }).then(response => response.json());
 
     return result as FileSourceResponse | ServiceError;
+}
+
+export const getFileFreshness = async (queryParams: FileFreshnessRequest): Promise<FileFreshnessResponse | ServiceError> => {
+    const url = new URL("/api/source/freshness", window.location.origin);
+    for (const [key, value] of Object.entries(queryParams)) {
+        url.searchParams.set(key, value.toString());
+    }
+
+    const result = await fetch(url, {
+        method: "GET",
+        headers: {
+            "X-Sourcebot-Client-Source": "sourcebot-web-client",
+        }
+    }).then(response => response.json());
+
+    return result as FileFreshnessResponse | ServiceError;
 }
 
 export const listRepos = async (queryParams: ListReposQueryParams): Promise<ListReposResponse | ServiceError> => {

--- a/packages/web/src/app/api/(server)/source/freshness/route.ts
+++ b/packages/web/src/app/api/(server)/source/freshness/route.ts
@@ -1,0 +1,34 @@
+'use server';
+
+import { getFileFreshness } from '@/features/git';
+import { fileFreshnessRequestSchema } from '@/features/git/schemas';
+import { apiHandler } from "@/lib/apiHandler";
+import { queryParamsSchemaValidationError, serviceErrorResponse } from "@/lib/serviceError";
+import { isServiceError } from "@/lib/utils";
+import { NextRequest } from "next/server";
+
+// eslint-disable-next-line authz/require-auth-wrapper -- delegates to getFileFreshness() which calls withOptionalAuth
+export const GET = apiHandler(async (request: NextRequest) => {
+    const rawParams = Object.fromEntries(
+        Object.keys(fileFreshnessRequestSchema.shape).map(key => [
+            key,
+            request.nextUrl.searchParams.get(key) ?? undefined
+        ])
+    );
+    const parsed = fileFreshnessRequestSchema.safeParse(rawParams);
+
+    if (!parsed.success) {
+        return serviceErrorResponse(
+            queryParamsSchemaValidationError(parsed.error)
+        );
+    }
+
+    const { repo, path, sinceSha } = parsed.data;
+    const response = await getFileFreshness({ repo, path, sinceSha });
+
+    if (isServiceError(response)) {
+        return serviceErrorResponse(response);
+    }
+
+    return Response.json(response);
+});

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItem.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItem.tsx
@@ -8,16 +8,95 @@ import { useCodeMirrorLanguageExtension } from "@/hooks/useCodeMirrorLanguageExt
 import { useCodeMirrorTheme } from "@/hooks/useCodeMirrorTheme";
 import { useExtensionWithDependency } from "@/hooks/useExtensionWithDependency";
 import { useKeymapExtension } from "@/hooks/useKeymapExtension";
-import { cn } from "@/lib/utils";
+import { cn, truncateSha } from "@/lib/utils";
+import { getBrowsePath } from "@/app/(app)/browse/hooks/utils";
 import { EditorView } from '@codemirror/view';
 import { CodeHostType } from "@sourcebot/db";
 import CodeMirror, { ReactCodeMirrorRef } from '@uiw/react-codemirror';
 import isEqual from "fast-deep-equal/react";
-import { ChevronDown, ChevronRight } from "lucide-react";
+import { ChevronDown, ChevronRight, History } from "lucide-react";
+import Link from "next/link";
 import { forwardRef, memo, Ref, useEffect, useImperativeHandle, useMemo, useState } from "react";
 import { FileReference } from "@/features/chat/types";
+import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { createCodeFoldingExtension } from "./codeFoldingExtension";
 import { createReferencesHighlightExtension, setHoveredIdEffect, setSelectedIdEffect } from "./referencesHighlightExtension";
+
+export type FileFreshnessStatus = 'fresh' | 'changed' | 'removed' | 'pinned_unavailable';
+
+const FreshnessBadge = ({
+    status,
+    pinnedSha,
+    currentSha,
+    repoName,
+    path,
+}: {
+    status: FileFreshnessStatus;
+    pinnedSha?: string;
+    currentSha?: string;
+    repoName: string;
+    path: string;
+}) => {
+    if (status === 'fresh') {
+        return null;
+    }
+
+    const shortPinned = pinnedSha ? truncateSha(pinnedSha) : undefined;
+
+    const { label, tooltip, className } = (() => {
+        switch (status) {
+            case 'changed':
+                return {
+                    label: 'Changed since',
+                    tooltip: `Shown as of ${shortPinned ?? 'the cited commit'}. This file has changed since this answer was generated.`,
+                    className: 'text-amber-600 dark:text-amber-500',
+                };
+            case 'removed':
+                return {
+                    label: 'Removed since',
+                    tooltip: `Shown as of ${shortPinned ?? 'the cited commit'}. This file no longer exists at the latest revision.`,
+                    className: 'text-destructive',
+                };
+            case 'pinned_unavailable':
+                return {
+                    label: 'Showing latest',
+                    tooltip: `The cited commit ${shortPinned ? `(${shortPinned}) ` : ''}is no longer available, so the latest version is shown.`,
+                    className: 'text-muted-foreground',
+                };
+        }
+    })();
+
+    return (
+        <div className="flex shrink-0 items-center gap-1.5">
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    <span className={cn('flex items-center gap-1 text-xs font-medium', className)}>
+                        <History className="h-3 w-3" />
+                        {label}
+                    </span>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" className="max-w-xs">
+                    {tooltip}
+                </TooltipContent>
+            </Tooltip>
+            {status === 'changed' && currentSha && (
+                <Link
+                    href={getBrowsePath({
+                        repoName,
+                        revisionName: currentSha,
+                        path,
+                        pathType: 'blob',
+                    })}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="text-xs text-muted-foreground underline hover:text-foreground"
+                >
+                    View latest
+                </Link>
+            )}
+        </div>
+    );
+};
 
 const CODEMIRROR_BASIC_SETUP = {
     highlightActiveLine: false,
@@ -37,6 +116,14 @@ interface ReferencedFileSourceListItemProps {
     repoWebUrl?: string;
     fileName: string;
     references: FileReference[];
+    // The pinned commit the file content is shown at (short-displayed in the
+    // staleness hint). Undefined for un-pinned (pre-pinning) sources.
+    pinnedSha?: string;
+    // Result of comparing the pinned commit against the current tip. Undefined
+    // while loading or for un-pinned sources.
+    freshnessStatus?: FileFreshnessStatus;
+    // The current default-branch commit, used to link to the latest version.
+    currentSha?: string;
     selectedReference?: FileReference;
     hoveredReference?: FileReference;
     onSelectedReferenceChanged: (reference?: FileReference) => void;
@@ -56,6 +143,9 @@ const ReferencedFileSourceListItemComponent = ({
     repoWebUrl,
     fileName,
     references,
+    pinnedSha,
+    freshnessStatus,
+    currentSha,
     selectedReference,
     hoveredReference,
     onSelectedReferenceChanged,
@@ -145,6 +235,15 @@ const ReferencedFileSourceListItemComponent = ({
                     revisionName={revision === 'HEAD' ? undefined : revision}
                     repoNameClassName="font-normal text-muted-foreground text-sm"
                 />
+                {freshnessStatus && (
+                    <FreshnessBadge
+                        status={freshnessStatus}
+                        pinnedSha={pinnedSha}
+                        currentSha={currentSha}
+                        repoName={repoName}
+                        path={fileName}
+                    />
+                )}
             </div>
 
             {/* Code container */}

--- a/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/referencedFileSourceListItemContainer.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { getFileSource } from "@/app/api/(client)/client";
+import { getFileFreshness, getFileSource } from "@/app/api/(client)/client";
 import { VscodeFileIcon } from "@/app/components/vscodeFileIcon";
 import { Skeleton } from "@/components/ui/skeleton";
 import { isServiceError, unwrapServiceError } from "@/lib/utils";
@@ -66,6 +66,19 @@ const ReferencedFileSourceListItemContainerComponent = ({
         staleTime: Infinity,
     });
 
+    // Whether the cited file has changed since the pinned commit. Only checked
+    // for pinned sources; older un-pinned sources have nothing to compare.
+    const { data: freshness } = useQuery({
+        queryKey: ['fileFreshness', fileSource.repo, fileSource.path, fileSource.commitSha],
+        queryFn: () => unwrapServiceError(getFileFreshness({
+            repo: fileSource.repo,
+            path: fileSource.path,
+            sinceSha: fileSource.commitSha!,
+        })),
+        enabled: !!fileSource.commitSha,
+        staleTime: 5 * 60 * 1000,
+    });
+
     const handleRef = useCallback((ref: ReactCodeMirrorRef | null) => {
         onEditorRef(fileId, ref);
     }, [fileId, onEditorRef]);
@@ -112,6 +125,9 @@ const ReferencedFileSourceListItemContainerComponent = ({
             repoWebUrl={data.repoExternalWebUrl}
             fileName={data.path}
             references={references}
+            pinnedSha={fileSource.commitSha}
+            freshnessStatus={freshness?.status}
+            currentSha={freshness?.currentSha}
             ref={handleRef}
             onSelectedReferenceChanged={onSelectedReferenceChanged}
             onHoveredReferenceChanged={onHoveredReferenceChanged}

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -443,8 +443,12 @@ export const getLanguageModelKey = (model: Pick<LanguageModelInfo, 'provider' | 
  * Given a file reference and a list of file sources, attempts to resolve the file source that the reference points to.
  */
 export const tryResolveFileReference = (reference: FileReference, sources: FileSource[]): FileSource | undefined => {
-    return sources.find(
+    const matches = sources.filter(
         (source) => source.repo.endsWith(reference.repo) &&
             source.path.endsWith(reference.path)
     );
+    // The same file can be sourced by multiple tools in one turn (e.g. an
+    // unpinned `list_tree` listing plus a pinned `read_file`). Prefer a pinned
+    // source so citations resolve to the commit the content was read at.
+    return matches.find((source) => source.commitSha) ?? matches[0];
 };

--- a/packages/web/src/features/git/getFileFreshnessApi.test.ts
+++ b/packages/web/src/features/git/getFileFreshnessApi.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockSimpleGit = vi.hoisted(() => vi.fn());
+
+vi.mock('simple-git', () => ({
+    default: mockSimpleGit,
+    simpleGit: mockSimpleGit,
+}));
+vi.mock('@sourcebot/shared', () => ({
+    getRepoPath: (repo: { id: number }) => ({ path: `/mock/repos/${repo.id}` }),
+    createLogger: () => ({ debug: vi.fn(), info: vi.fn(), warn: vi.fn(), error: vi.fn() }),
+}));
+vi.mock('@/middleware/sew', () => ({
+    sew: async <T>(fn: () => Promise<T> | T): Promise<T> => {
+        try {
+            return await fn();
+        } catch (error) {
+            return {
+                errorCode: 'UNEXPECTED_ERROR',
+                message: error instanceof Error ? error.message : String(error),
+            } as T;
+        }
+    },
+}));
+vi.mock('@/middleware/withAuth', () => ({
+    // Invoke the callback with a minimal auth context.
+    withOptionalAuth: (fn: (ctx: { org: unknown; prisma: unknown }) => unknown) =>
+        fn({ org: MOCK_ORG, prisma: mockPrisma }),
+}));
+
+import { getFileFreshness } from './getFileFreshnessApi';
+
+const MOCK_ORG = { id: 1, name: 'test-org' } as never;
+
+const MOCK_REPO = {
+    id: 123,
+    name: 'github.com/owner/repo',
+    orgId: 1,
+    defaultBranch: 'main',
+};
+
+const mockGitRaw = vi.fn();
+const mockCwd = vi.fn();
+const mockFindFirst = vi.fn();
+const mockPrisma = { repo: { findFirst: (...args: unknown[]) => mockFindFirst(...args) } } as never;
+
+const PATH = 'src/index.ts';
+
+describe('getFileFreshness', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mockCwd.mockReturnValue({ raw: mockGitRaw });
+        mockSimpleGit.mockReturnValue({ cwd: mockCwd });
+        mockFindFirst.mockResolvedValue(MOCK_REPO);
+    });
+
+    it('returns NOT_FOUND when the repo is absent', async () => {
+        mockFindFirst.mockResolvedValue(null);
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'abc' });
+        expect(result).toMatchObject({ errorCode: 'NOT_FOUND' });
+    });
+
+    it('returns FILE_NOT_FOUND for path traversal', async () => {
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: 'src/../../etc/passwd', sinceSha: 'abc' });
+        expect(result).toMatchObject({ errorCode: 'FILE_NOT_FOUND' });
+    });
+
+    it('returns INVALID_GIT_REF for refs starting with "-"', async () => {
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: '--evil' });
+        expect(result).toMatchObject({ errorCode: 'INVALID_GIT_REF' });
+    });
+
+    it('is fresh (fast path) when the pinned commit equals the current tip', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            throw new Error('should not reach blob comparison');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'currentsha' });
+        expect(result).toMatchObject({ status: 'fresh', currentSha: 'currentsha' });
+    });
+
+    it('is fresh when the blob is identical at both commits', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'sameblob\n';
+            if (args[1] === `currentsha:${PATH}`) return 'sameblob\n';
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'fresh', currentSha: 'currentsha' });
+    });
+
+    it('is changed when the blob differs', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'oldblob\n';
+            if (args[1] === `currentsha:${PATH}`) return 'newblob\n';
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'changed', currentSha: 'currentsha' });
+    });
+
+    it('is removed when the path is absent at the current tip', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `pinnedsha:${PATH}`) return 'oldblob\n';
+            if (args[1] === `currentsha:${PATH}`) throw new Error('does not exist');
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ status: 'removed', currentSha: 'currentsha' });
+    });
+
+    it('is pinned_unavailable when the pinned commit is gone', async () => {
+        mockGitRaw.mockImplementation(async (args: string[]) => {
+            if (args[1] === 'main^{commit}') return 'currentsha\n';
+            if (args[1] === `gonepin:${PATH}`) throw new Error('bad revision');
+            throw new Error('unexpected');
+        });
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'gonepin' });
+        expect(result).toMatchObject({ status: 'pinned_unavailable', currentSha: 'currentsha' });
+    });
+
+    it('returns UNEXPECTED_ERROR when resolving the current tip fails', async () => {
+        mockGitRaw.mockRejectedValueOnce(new Error('I/O error'));
+        const result = await getFileFreshness({ repo: MOCK_REPO.name, path: PATH, sinceSha: 'pinnedsha' });
+        expect(result).toMatchObject({ errorCode: 'UNEXPECTED_ERROR' });
+    });
+});

--- a/packages/web/src/features/git/getFileFreshnessApi.ts
+++ b/packages/web/src/features/git/getFileFreshnessApi.ts
@@ -1,0 +1,85 @@
+import { sew } from "@/middleware/sew";
+import { fileNotFound, invalidGitRef, notFound, ServiceError, unexpectedError } from '@/lib/serviceError';
+import { withOptionalAuth } from '@/middleware/withAuth';
+import { getRepoPath } from '@sourcebot/shared';
+import simpleGit from 'simple-git';
+import type z from 'zod';
+import { isGitRefValid, isPathValid } from './utils';
+import { fileFreshnessRequestSchema, fileFreshnessResponseSchema } from './schemas';
+
+export { fileFreshnessRequestSchema, fileFreshnessResponseSchema } from './schemas';
+export type FileFreshnessRequest = z.infer<typeof fileFreshnessRequestSchema>;
+export type FileFreshnessResponse = z.infer<typeof fileFreshnessResponseSchema>;
+
+// Resolves the blob OID of `path` at a ref, or undefined if it can't be
+// resolved (ref or path absent at that ref).
+const resolveBlobOid = async (
+    git: ReturnType<typeof simpleGit>,
+    ref: string,
+    path: string,
+): Promise<string | undefined> => {
+    try {
+        return (await git.raw(['rev-parse', `${ref}:${path}`])).trim();
+    } catch {
+        return undefined;
+    }
+};
+
+/**
+ * Compares a citation's pinned commit against the repo's current default-branch
+ * tip to determine whether the cited file has changed since the answer was
+ * generated. File-level (blob identity), not line-level. Best-effort: a pinned
+ * commit that no longer exists (e.g. force-push + GC) yields `pinned_unavailable`.
+ */
+export const getFileFreshness = async (
+    { repo: repoName, path: filePath, sinceSha }: FileFreshnessRequest,
+): Promise<FileFreshnessResponse | ServiceError> => sew(() =>
+    withOptionalAuth(async ({ org, prisma }) => {
+        const repo = await prisma.repo.findFirst({
+            where: { name: repoName, orgId: org.id },
+        });
+        if (!repo) {
+            return notFound(`Repository "${repoName}" not found.`);
+        }
+
+        if (!isPathValid(filePath)) {
+            return fileNotFound(filePath, repoName);
+        }
+
+        if (!isGitRefValid(sinceSha)) {
+            return invalidGitRef(sinceSha);
+        }
+
+        const { path: repoPath } = getRepoPath(repo);
+        const git = simpleGit().cwd(repoPath);
+        const currentRef = repo.defaultBranch ?? 'HEAD';
+
+        let currentSha: string;
+        try {
+            currentSha = (await git.raw(['rev-parse', `${currentRef}^{commit}`])).trim();
+        } catch (error) {
+            return unexpectedError(error instanceof Error ? error.message : String(error));
+        }
+
+        // Nothing has advanced since the pin: definitively fresh, no blob work.
+        if (sinceSha === currentSha) {
+            return { status: 'fresh', currentSha };
+        }
+
+        const pinnedBlob = await resolveBlobOid(git, sinceSha, filePath);
+        if (pinnedBlob === undefined) {
+            // The pinned commit (or the path within it) is gone.
+            return { status: 'pinned_unavailable', currentSha };
+        }
+
+        const currentBlob = await resolveBlobOid(git, currentSha, filePath);
+        if (currentBlob === undefined) {
+            return { status: 'removed', currentSha };
+        }
+
+        return {
+            status: pinnedBlob === currentBlob ? 'fresh' : 'changed',
+            currentSha,
+        };
+    }),
+);

--- a/packages/web/src/features/git/index.ts
+++ b/packages/web/src/features/git/index.ts
@@ -4,6 +4,7 @@ export * from './getFilesApi';
 export * from './getFolderContentsApi';
 export * from './getTreeApi';
 export * from './getFileSourceApi';
+export * from './getFileFreshnessApi';
 export * from './getFileBlameApi';
 export * from './listCommitsApi';
 export * from './listCommitAuthorsApi';

--- a/packages/web/src/features/git/schemas.ts
+++ b/packages/web/src/features/git/schemas.ts
@@ -39,6 +39,24 @@ export const fileSourceResponseSchema = z.object({
     commitSha: z.string().optional(),
 });
 
+export const fileFreshnessRequestSchema = z.object({
+    repo: z.string(),
+    path: z.string(),
+    // The pinned commit SHA a citation was sourced at.
+    sinceSha: z.string(),
+});
+
+export const fileFreshnessResponseSchema = z.object({
+    // `fresh`: the cited file is byte-identical at the current tip.
+    // `changed`: the file's content differs since the pinned commit.
+    // `removed`: the file no longer exists at the current tip.
+    // `pinned_unavailable`: the pinned commit is no longer in the repo (e.g.
+    //   force-push + GC pruned it), so we can't compare against it.
+    status: z.enum(['fresh', 'changed', 'removed', 'pinned_unavailable']),
+    // The commit the current default branch points at.
+    currentSha: z.string(),
+});
+
 export const getDiffRequestSchema = z.object({
     repo: z.string().describe('The fully-qualified repository name.'),
     base: z.string().describe('The base git ref (branch, tag, or commit SHA) to diff from.'),


### PR DESCRIPTION
Stacked on #1397. Adds a per-citation freshness hint: `/api/source/freshness` compares a pinned commit to the repo's current default-branch tip (file-level blob comparison), and the evidence panel shows a badge when the cited file has `changed` / `removed` / `pinned_unavailable`, with a "View latest" link. Also resolves a citation to a pinned source when multiple tools sourced the same file in one turn.

Scope: panel-only (no inline-chip dots or answer rollup yet); `list_tree`/`get_diff` remain unpinned.

(removed the "view latest" button from these two, but here's what the badges look like for the other two statuses (not included in the screenrecording)

<img width="862" height="54" alt="Screenshot 2026-06-29 at 2 19 13 PM" src="https://github.com/user-attachments/assets/fb738d3c-d55f-4d68-96b4-4866ccbfa24a" />
<img width="862" height="56" alt="Screenshot 2026-06-29 at 2 19 27 PM" src="https://github.com/user-attachments/assets/51731991-f78e-4642-a5c2-3b4f611453ea" />


https://github.com/user-attachments/assets/8eeca34b-f101-4fb6-bef6-9ca108447d93

