### PR TITLE
feat(web): native PDF attachments for Ask mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added a context-window usage gauge to the Ask Sourcebot chat details, showing how much of the selected model's context window each turn occupies. Window sizes are resolved from the models.dev catalog. [#1370](https://github.com/sourcebot-dev/sourcebot/pull/1370)
 - Added language model input-modality and document capability resolution, automatically resolved from the models.dev catalog (falls back to text-only for uncatalogued/self-hosted models). [#1372](https://github.com/sourcebot-dev/sourcebot/pull/1372)
 - [EE] Added text file attachments to Ask Sourcebot, letting users attach text/code/config files to a chat message via the paperclip button, drag-and-drop, or paste, with large pastes auto-converted to attachments. [#1374](https://github.com/sourcebot-dev/sourcebot/pull/1374)
+- [EE] Added PDF attachments to Ask Sourcebot, letting users attach PDFs that are sent natively to models that support PDF input (gated on the model's resolved document capabilities). [#XXXX](https://github.com/sourcebot-dev/sourcebot/pull/XXXX)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added a context-window usage gauge to the Ask Sourcebot chat details, showing how much of the selected model's context window each turn occupies. Window sizes are resolved from the models.dev catalog. [#1370](https://github.com/sourcebot-dev/sourcebot/pull/1370)
 - Added language model input-modality and document capability resolution, automatically resolved from the models.dev catalog (falls back to text-only for uncatalogued/self-hosted models). [#1372](https://github.com/sourcebot-dev/sourcebot/pull/1372)
 - [EE] Added text file attachments to Ask Sourcebot, letting users attach text/code/config files to a chat message via the paperclip button, drag-and-drop, or paste, with large pastes auto-converted to attachments. [#1374](https://github.com/sourcebot-dev/sourcebot/pull/1374)
-- [EE] Added PDF attachments to Ask Sourcebot, letting users attach PDFs that are sent natively to models that support PDF input (gated on the model's resolved document capabilities). [#XXXX](https://github.com/sourcebot-dev/sourcebot/pull/XXXX)
+- [EE] Added PDF attachments to Ask Sourcebot, letting users attach PDFs that are sent natively to models that support PDF input (gated on the model's resolved document capabilities and the provider adapter's ability to carry PDF file parts). [#1402](https://github.com/sourcebot-dev/sourcebot/pull/1402)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/docs/docs/configuration/environment-variables.mdx
+++ b/docs/docs/configuration/environment-variables.mdx
@@ -41,6 +41,7 @@ The following environment variables allow you to configure your Sourcebot deploy
 | `DEFAULT_MAX_MATCH_COUNT` | `10000` | <p>The default maximum number of search results to return when using search in the web app.</p> |
 | `ALWAYS_INDEX_FILE_PATTERNS` | - | <p>A comma separated list of glob patterns matching file paths that should always be indexed, regardless of size or number of trigrams.</p> |
 | `SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES` | `10485760` (10 MiB) | <p>Maximum size in bytes of a single image attachment uploaded to Ask Sourcebot. Enforced server-side at upload time.</p> |
+| `SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES` | `33554432` (32 MiB) | <p>Maximum size in bytes of a single PDF attachment uploaded to Ask Sourcebot. Enforced server-side at upload time. PDF attachments are only available on models that natively support PDF input.</p> |
 | `SOURCEBOT_CHAT_ATTACHMENT_ORPHAN_TTL_HOURS` | `24` | <p>How long in hours an uploaded-but-unsent attachment is retained before being deleted by the orphan sweep. Set to `0` to disable the sweep.</p> |
 | `NODE_USE_ENV_PROXY` | `0` | <p>Enables Node.js to automatically use `HTTP_PROXY`, `HTTPS_PROXY`, and `NO_PROXY` environment variables for network requests. Set to `1` to enable or `0` to disable. See [this doc](https://nodejs.org/en/learn/http/enterprise-network-configuration) for more info.</p> |
 | `HTTP_PROXY` | - | <p>HTTP proxy URL for routing non-SSL requests through a proxy server (e.g., `http://proxy.company.com:8080`). Requires `NODE_USE_ENV_PROXY=1`.</p> |

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -330,6 +330,14 @@ const options = {
         SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES: numberSchema.int().positive().default(10 * 1024 * 1024),
 
         /**
+         * Maximum size (in bytes) of a single PDF attachment uploaded to the
+         * Ask chat. Enforced server-side at upload time. PDFs are gated on the
+         * selected model's native PDF support (`supportedDocumentTypes`).
+         * @default 32 MiB
+         */
+        SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES: numberSchema.int().positive().default(32 * 1024 * 1024),
+
+        /**
          * How long (in hours) an uploaded-but-unlinked (PENDING) attachment
          * blob is retained before the orphan sweep deletes it and its bytes.
          * Covers "select a file then never send" abandonment. Set to 0 to

--- a/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/landingPage.tsx
+++ b/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/landingPage.tsx
@@ -22,6 +22,7 @@ interface LandingPageProps {
     repoId: number;
     isAuthenticated: boolean;
     maxImageBytes: number;
+    maxPdfBytes: number;
 }
 
 export const LandingPage = ({
@@ -32,6 +33,7 @@ export const LandingPage = ({
     repoId,
     isAuthenticated,
     maxImageBytes,
+    maxPdfBytes,
 }: LandingPageProps) => {
     const { createNewChatThread, isLoading } = useCreateNewChatThread();
     const [isContextSelectorOpen, setIsContextSelectorOpen] = useState(false);
@@ -90,6 +92,7 @@ export const LandingPage = ({
                             isAuthenticated={isAuthenticated}
                             isLoginWallEnabled={true}
                             maxImageBytes={maxImageBytes}
+                            maxPdfBytes={maxPdfBytes}
                         />
                         <Separator />
                         <div className="relative">

--- a/packages/web/src/app/(app)/askgh/[owner]/[repo]/page.tsx
+++ b/packages/web/src/app/(app)/askgh/[owner]/[repo]/page.tsx
@@ -70,6 +70,7 @@ export default async function GitHubRepoPage(props: PageProps) {
                     repoId={repoInfo.id}
                     isAuthenticated={!!session?.user}
                     maxImageBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES}
+                    maxPdfBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES}
                 />
             </CustomSlateEditor>
         </RepoIndexedGuard>

--- a/packages/web/src/app/(app)/chat/[id]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[id]/page.tsx
@@ -180,6 +180,7 @@ export default async function Page(props: PageProps) {
                 isAuthenticated={!!session}
                 isLoginWallEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
                 maxImageBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES}
+                maxPdfBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES}
                 chatName={name ?? undefined}
             />
         </div>

--- a/packages/web/src/app/(app)/chat/chatLandingPage.tsx
+++ b/packages/web/src/app/(app)/chat/chatLandingPage.tsx
@@ -72,6 +72,7 @@ export async function ChatLandingPage() {
                             isAuthenticated={!!session}
                             isLoginWallEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
                             maxImageBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES}
+                            maxPdfBytes={env.SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES}
                         />
                     </CustomSlateEditor>
 

--- a/packages/web/src/app/(app)/chat/components/landingPageChatBox.tsx
+++ b/packages/web/src/app/(app)/chat/components/landingPageChatBox.tsx
@@ -20,6 +20,7 @@ interface LandingPageChatBox {
     isAuthenticated: boolean;
     isLoginWallEnabled: boolean;
     maxImageBytes: number;
+    maxPdfBytes: number;
 }
 
 export const LandingPageChatBox = ({
@@ -29,6 +30,7 @@ export const LandingPageChatBox = ({
     isAuthenticated,
     isLoginWallEnabled,
     maxImageBytes,
+    maxPdfBytes,
 }: LandingPageChatBox) => {
     const { createNewChatThread, isLoading } = useCreateNewChatThread();
     const [selectedSearchScopes, setSelectedSearchScopes] = useLocalStorage<SearchScope[]>(SELECTED_SEARCH_SCOPES_LOCAL_STORAGE_KEY, [], { initializeWithValue: false });
@@ -53,6 +55,7 @@ export const LandingPageChatBox = ({
                     isAuthenticated={isAuthenticated}
                     isLoginWallEnabled={isLoginWallEnabled}
                     maxImageBytes={maxImageBytes}
+                    maxPdfBytes={maxPdfBytes}
                 />
                 <Separator />
                 <div className="relative">

--- a/packages/web/src/app/api/(server)/ee/chat/attachments/route.ts
+++ b/packages/web/src/app/api/(server)/ee/chat/attachments/route.ts
@@ -7,6 +7,7 @@ import { isServiceError } from "@/lib/utils";
 import { withAuth } from "@/middleware/withAuth";
 import { checkAskEntitlement } from "@/features/chat/utils.server";
 import { validateImageAttachment } from "@/features/chat/attachments/validation";
+import { looksLikePdf, validatePdfAttachment } from "@/features/chat/attachments/pdfValidation";
 import { sanitizeFilename } from "@/features/chat/attachments/filename";
 import { env, getStorageBackend } from "@sourcebot/shared";
 import { createHash, randomUUID } from "crypto";
@@ -16,15 +17,17 @@ import { NextRequest } from "next/server";
 export const POST = apiHandler(async (req: NextRequest) => {
     // Reject obviously-oversized bodies before reading them into memory. The
     // multipart envelope adds some overhead beyond the raw bytes, so allow a
-    // 1 MiB slack on top of the image cap; the exact byte cap is re-checked
-    // against the decoded buffer below.
+    // 1 MiB slack on top of the largest per-type cap; the exact (per-type) byte
+    // cap is re-checked against the decoded buffer below.
     const maxImageBytes = env.SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES;
+    const maxPdfBytes = env.SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES;
+    const maxAttachmentBytes = Math.max(maxImageBytes, maxPdfBytes);
     const contentLength = Number(req.headers.get('content-length') ?? 0);
-    if (contentLength > maxImageBytes + 1024 * 1024) {
+    if (contentLength > maxAttachmentBytes + 1024 * 1024) {
         return serviceErrorResponse({
             statusCode: StatusCodes.REQUEST_TOO_LONG,
             errorCode: ErrorCode.INVALID_REQUEST_BODY,
-            message: `Attachment exceeds the ${Math.round(maxImageBytes / (1024 * 1024))}MB limit.`,
+            message: `Attachment exceeds the ${Math.round(maxAttachmentBytes / (1024 * 1024))}MB limit.`,
         } satisfies ServiceError);
     }
 
@@ -49,20 +52,25 @@ export const POST = apiHandler(async (req: NextRequest) => {
 
             // Authoritative size reject from the parsed file, independent of the
             // (best-effort, spoofable) content-length header, before buffering
-            // the bytes into a Buffer.
-            if (file.size > maxImageBytes) {
+            // the bytes into a Buffer. Use the largest per-type cap here; the
+            // exact per-type cap is enforced by the type-specific validator.
+            if (file.size > maxAttachmentBytes) {
                 return {
                     statusCode: StatusCodes.REQUEST_TOO_LONG,
                     errorCode: ErrorCode.INVALID_REQUEST_BODY,
-                    message: `Attachment exceeds the ${Math.round(maxImageBytes / (1024 * 1024))}MB limit.`,
+                    message: `Attachment exceeds the ${Math.round(maxAttachmentBytes / (1024 * 1024))}MB limit.`,
                 } satisfies ServiceError;
             }
 
             const buffer = Buffer.from(await file.arrayBuffer());
 
-            // Authoritative content-type + size check by decoding the image
-            // (never the client-supplied MIME type or extension).
-            const validation = await validateImageAttachment(buffer, maxImageBytes);
+            // Authoritative content-type + size check by inspecting the bytes
+            // (never the client-supplied MIME type or extension). PDFs are
+            // sniffed by their `%PDF-` magic bytes; everything else is decoded
+            // as an image. The persisted `mediaType` comes from the validator.
+            const validation = looksLikePdf(buffer)
+                ? validatePdfAttachment(buffer, maxPdfBytes)
+                : await validateImageAttachment(buffer, maxImageBytes);
             if (!validation.ok) {
                 return {
                     statusCode: StatusCodes.BAD_REQUEST,

--- a/packages/web/src/app/api/(server)/ee/chat/route.ts
+++ b/packages/web/src/app/api/(server)/ee/chat/route.ts
@@ -5,7 +5,7 @@ import { getPromptCacheStrategy } from "@/ee/features/chat/promptCaching";
 import { additionalChatRequestParamsSchema } from "@/features/chat/types";
 import { getLanguageModelKey, getMessageTextBytes, getUserMessageAttachments } from "@/features/chat/utils";
 import { ATTACHMENT_MAX_TURN_TEXT_BYTES } from "@/features/chat/constants";
-import { isMediaTypeAccepted, mediaTypeToModality } from "@/features/chat/attachments/modality";
+import { isAttachmentAccepted, isNativeMediaType } from "@/features/chat/attachments/modality";
 import { resolveModelCapabilities } from "@/features/chat/modelCapabilities.server";
 import { checkAskEntitlement, commitMessageAttachments, getConfiguredLanguageModels, isOwnerOfChat, updateChatMessages } from "@/features/chat/utils.server";
 import { getAISDKLanguageModelAndOptions } from "@/features/chat/llm.server";
@@ -136,17 +136,19 @@ export const POST = apiHandler(async (req: NextRequest) => {
             const { model, providerOptions, temperature } = await getAISDKLanguageModelAndOptions(languageModelConfig);
 
             // Authoritative, server-side resolution of the model's input
-            // modalities. The agent's multimodal content builder and degrade
-            // logic rely on this value, never the client.
-            const acceptedModalities = (await resolveModelCapabilities(languageModelConfig)).inputModalities;
+            // capabilities (single-medium modalities plus compound document
+            // types like PDF). The agent's multimodal content builder and
+            // degrade logic rely on these values, never the client.
+            const { inputModalities: acceptedModalities, supportedDocumentTypes } =
+                await resolveModelCapabilities(languageModelConfig);
 
             // If the latest message carries native-media attachments the selected
             // model cannot accept, the agent will degrade (omit the bytes). Record it.
             const droppedAttachmentCount = getUserMessageAttachments(latestMessage).filter(
                 (attachment) =>
                     attachment.kind === 'blob' &&
-                    mediaTypeToModality(attachment.mediaType) !== undefined &&
-                    !isMediaTypeAccepted(attachment.mediaType, acceptedModalities),
+                    isNativeMediaType(attachment.mediaType) &&
+                    !isAttachmentAccepted(attachment.mediaType, { inputModalities: acceptedModalities, supportedDocumentTypes }),
             ).length;
             if (droppedAttachmentCount > 0) {
                 await captureEvent('chat_attachment_degraded', {
@@ -220,6 +222,7 @@ export const POST = apiHandler(async (req: NextRequest) => {
                 userId: user?.id,
                 orgId: org.id,
                 acceptedModalities,
+                supportedDocumentTypes,
                 onFinish: async ({ messages }) => {
                     await updateChatMessages({ chatId: id, messages, prisma });
                     const askMcpTurnCompleted = getAskMcpTurnCompletedAnalytics({
@@ -247,6 +250,14 @@ export const POST = apiHandler(async (req: NextRequest) => {
                     }
 
                     if (error instanceof Error) {
+                        // Backstop for the provider-adapter PDF gate: if a PDF
+                        // file part still reaches an adapter that can't carry it
+                        // (the model claims PDF support but the adapter throws
+                        // AI_UnsupportedFunctionalityError), surface a friendly
+                        // message instead of the raw SDK error.
+                        if (error.message.includes('file part media type application/pdf')) {
+                            return 'The selected model cannot accept PDF attachments. Remove the PDF or switch to a model that supports PDF input.';
+                        }
                         return error.message;
                     }
 

--- a/packages/web/src/app/components/vscodeFileIcon.tsx
+++ b/packages/web/src/app/components/vscodeFileIcon.tsx
@@ -10,12 +10,21 @@ interface VscodeFileIconProps {
     className?: string;
 }
 
+// `vscode-icons-js` returns some filenames whose stem does not match the id used
+// by the Iconify `vscode-icons` set (the upstream theme ships versioned
+// variants). A mismatched id resolves to nothing in Iconify, so the icon
+// silently renders as a zero-size element. Remap the known offenders here.
+const ICONIFY_NAME_OVERRIDES: Record<string, string> = {
+    // Iconify only ships the `2` variant of the PDF icon.
+    "file-type-pdf": "file-type-pdf2",
+};
+
 export const VscodeFileIcon = ({ fileName, className }: VscodeFileIconProps) => {
     const iconName = useMemo(() => {
         const icon = getIconForFile(fileName);
         if (icon && typeof icon === 'string') {
-            const iconName = `vscode-icons:${icon.substring(0, icon.indexOf('.')).replaceAll('_', '-')}`;
-            return iconName;
+            const stem = icon.substring(0, icon.indexOf('.')).replaceAll('_', '-');
+            return `vscode-icons:${ICONIFY_NAME_OVERRIDES[stem] ?? stem}`;
         }
 
         return "vscode-icons:default-file";

--- a/packages/web/src/ee/features/chat/agent.test.ts
+++ b/packages/web/src/ee/features/chat/agent.test.ts
@@ -20,6 +20,16 @@ const mockAi = vi.hoisted(() => ({
     streamText: vi.fn(),
 }));
 
+// Stable storage-backend mock so tests can control the bytes returned for a
+// resolved attachment (the module returns the same object on every call).
+const mockStorage = vi.hoisted(() => ({
+    get: vi.fn(),
+    put: vi.fn(),
+    stat: vi.fn(),
+    createReadStream: vi.fn(),
+    delete: vi.fn(),
+}));
+
 vi.mock('@sourcebot/shared', () => ({
     createLogger: () => mockLogger,
     env: {
@@ -31,13 +41,7 @@ vi.mock('@sourcebot/shared', () => ({
         SOURCEBOT_CHAT_PROMPT_CACHE_BREAK_DETECTION_ENABLED: 'false',
     },
     getDBConnectionString: () => 'postgresql://sourcebot:sourcebot@db.example.com:5432/sourcebot',
-    getStorageBackend: () => ({
-        get: vi.fn(),
-        put: vi.fn(),
-        stat: vi.fn(),
-        createReadStream: vi.fn(),
-        delete: vi.fn(),
-    }),
+    getStorageBackend: () => mockStorage,
 }));
 
 vi.mock('server-only', () => ({}));
@@ -80,6 +84,7 @@ vi.mock('@/features/tools', () => {
         listReposDefinition: createToolDefinition('list_repos'),
         listTreeDefinition: createToolDefinition('list_tree'),
         readFileDefinition: createToolDefinition('read_file'),
+        readAttachmentDefinition: createToolDefinition('read_attachment'),
         toVercelAITool: vi.fn((definition: { name: string }) => ({
             name: definition.name,
         })),
@@ -187,6 +192,10 @@ const runCreateMessageStream = async (
     opts: {
         promptCacheStrategy?: PromptCacheStrategy;
         selectedRepos?: string[];
+        prisma?: unknown;
+        orgId?: number;
+        acceptedModalities?: string[];
+        supportedDocumentTypes?: string[];
     } = {},
 ): Promise<StreamTextArgs> => {
     const convertedLastTurn: ModelMessage = {
@@ -200,7 +209,10 @@ const runCreateMessageStream = async (
         chatId: 'chat-id',
         messages,
         selectedRepos: opts.selectedRepos ?? [],
-        prisma: {},
+        prisma: opts.prisma ?? {},
+        orgId: opts.orgId,
+        acceptedModalities: opts.acceptedModalities,
+        supportedDocumentTypes: opts.supportedDocumentTypes,
         model: {},
         modelName: 'test-model',
         // Default to a no-op strategy so the approval-continuation tests below
@@ -452,5 +464,76 @@ describe('createMessageStream prompt caching', () => {
         });
 
         expect(first.system[0].content).toBe(second.system[0].content);
+    });
+});
+
+const createUserMessageWithPdf = (): SBChatMessage => ({
+    id: 'user-message',
+    role: 'user',
+    parts: [
+        {
+            type: 'text',
+            text: 'Summarize this document',
+        },
+        {
+            type: 'data-attachment',
+            data: {
+                kind: 'blob',
+                attachmentId: 'att-pdf-1',
+                filename: 'doc.pdf',
+                mediaType: 'application/pdf',
+                sizeBytes: 1234,
+            },
+        },
+    ],
+});
+
+describe('createMessageStream PDF attachments', () => {
+    const pdfBytes = Buffer.from('%PDF-1.7 fake pdf bytes');
+
+    const prismaWithPdf = () => ({
+        attachment: {
+            findMany: vi.fn().mockResolvedValue([
+                { id: 'att-pdf-1', storageKey: 'org/att-pdf-1', mediaType: 'application/pdf' },
+            ]),
+        },
+    });
+
+    test('sends the PDF as a model `file` part when the model supports PDF documents', async () => {
+        mockStorage.get.mockResolvedValue(pdfBytes);
+
+        const { messages } = await runCreateMessageStream([createUserMessageWithPdf()], {
+            prisma: prismaWithPdf(),
+            orgId: 1,
+            acceptedModalities: ['text'],
+            supportedDocumentTypes: ['pdf'],
+        });
+
+        const userMessage = messages[0];
+        expect(Array.isArray(userMessage.content)).toBe(true);
+        const parts = userMessage.content as Array<{ type: string; mediaType?: string; data?: Buffer }>;
+        const filePart = parts.find((part) => part.type === 'file');
+        expect(filePart).toBeDefined();
+        expect(filePart?.mediaType).toBe('application/pdf');
+        expect(filePart?.data).toEqual(pdfBytes);
+    });
+
+    test('omits the PDF and leaves a degrade note when the model does not support PDF documents', async () => {
+        const findMany = vi.fn().mockResolvedValue([]);
+        mockStorage.get.mockResolvedValue(pdfBytes);
+
+        const { messages } = await runCreateMessageStream([createUserMessageWithPdf()], {
+            prisma: { attachment: { findMany } },
+            orgId: 1,
+            acceptedModalities: ['text'],
+            supportedDocumentTypes: [],
+        });
+
+        const userMessage = messages[0];
+        // No accepted media → content is a plain string carrying the degrade note.
+        expect(typeof userMessage.content).toBe('string');
+        expect(userMessage.content as string).toContain('does not support that file type');
+        // Fail-closed: an unsupported document is never read from storage.
+        expect(findMany).not.toHaveBeenCalled();
     });
 });

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -1,5 +1,5 @@
-import { BlobAttachment, InputModality, SBChatMessage, SBChatMessageMetadata, StepTokenUsageEntry, ToolTokenUsageEntry } from "@/features/chat/types";
-import { isMediaTypeAccepted, mediaTypeToModality } from "@/features/chat/attachments/modality";
+import { BlobAttachment, DocumentType, InputModality, SBChatMessage, SBChatMessageMetadata, StepTokenUsageEntry, ToolTokenUsageEntry } from "@/features/chat/types";
+import { AttachmentCapabilities, isAttachmentAccepted, isNativeMediaType, mediaTypeToDocumentType, mediaTypeToModality } from "@/features/chat/attachments/modality";
 import { getStorageBackend } from "@sourcebot/shared";
 import { estimateModelToolOutputTokens } from "@/ee/features/chat/tokenEstimation";
 import { getFileSource } from '@/features/git';
@@ -43,16 +43,21 @@ type ResolvedTurnMedia = Map<string, { bytes: Buffer; mediaType: string }>;
 
 // A native (non-text) attachment part for a model message. The single place
 // that maps a stored blob to its model content part; extend this resolver to
-// add PDF / audio / video support.
-type ModelMediaPart = { type: 'image'; image: Buffer; mediaType: string };
+// add audio / video support. Images map to an `image` part; PDFs map to the AI
+// SDK `file` part (the provider decodes the document server-side).
+type ModelMediaPart =
+    | { type: 'image'; image: Buffer; mediaType: string }
+    | { type: 'file'; data: Buffer; mediaType: string };
 
 const buildModelMediaPart = (bytes: Buffer, mediaType: string): ModelMediaPart | undefined => {
-    const modality = mediaTypeToModality(mediaType);
-    if (modality === 'image') {
+    if (mediaTypeToModality(mediaType) === 'image') {
         return { type: 'image', image: bytes, mediaType };
     }
-    // audio / video / document modalities are not yet wired into the model
-    // content; callers leave a degrade marker in their place.
+    if (mediaTypeToDocumentType(mediaType) === 'pdf') {
+        return { type: 'file', data: bytes, mediaType };
+    }
+    // audio / video modalities are not yet wired into the model content;
+    // callers leave a degrade marker in their place.
     return undefined;
 };
 
@@ -84,26 +89,28 @@ const collectTextAttachments = (messages: SBChatMessage[]): TurnTextAttachment[]
     return [...byId.values()];
 };
 
-// The native-media (non-text) attachment blobs carried by a user message.
+// The native-media (non-text) attachment blobs carried by a user message. This
+// spans both capability axes: single-medium modalities (images) and compound
+// document types (PDFs).
 const getMediaBlobs = (message: SBChatMessage): BlobAttachment[] =>
     getUserMessageAttachments(message)
         .filter((attachment): attachment is BlobAttachment =>
-            attachment.kind === 'blob' && mediaTypeToModality(attachment.mediaType) !== undefined);
+            attachment.kind === 'blob' && isNativeMediaType(attachment.mediaType));
 
 // Reads the native-media attachment bytes for one user turn from the
-// StorageBackend. Fail-closed: only blobs whose modality the model accepts are
-// loaded, and only when linked to this chat (mirroring the serving route's
-// chat-derived access), so a text-only model resolves nothing here and the
-// builder leaves a marker instead.
+// StorageBackend. Fail-closed: only blobs the model can natively accept (by
+// modality or document type) are loaded, and only when linked to this chat
+// (mirroring the serving route's chat-derived access), so a text-only model
+// resolves nothing here and the builder leaves a marker instead.
 const resolveLatestTurnMedia = async ({
     message,
-    acceptedModalities,
+    capabilities,
     prisma,
     orgId,
     chatId,
 }: {
     message: SBChatMessage | undefined;
-    acceptedModalities: InputModality[];
+    capabilities: AttachmentCapabilities;
     prisma: PrismaClient;
     orgId?: number;
     chatId: string;
@@ -114,7 +121,7 @@ const resolveLatestTurnMedia = async ({
     }
 
     const acceptedBlobs = getMediaBlobs(message)
-        .filter((blob) => isMediaTypeAccepted(blob.mediaType, acceptedModalities));
+        .filter((blob) => isAttachmentAccepted(blob.mediaType, capabilities));
     if (acceptedBlobs.length === 0) {
         return result;
     }
@@ -145,12 +152,12 @@ const resolveLatestTurnMedia = async ({
 const buildUserModelMessage = ({
     message,
     isLatestUserTurn,
-    acceptedModalities,
+    capabilities,
     resolvedMedia,
 }: {
     message: SBChatMessage;
     isLatestUserTurn: boolean;
-    acceptedModalities: InputModality[];
+    capabilities: AttachmentCapabilities;
     resolvedMedia?: ResolvedTurnMedia;
 }): ModelMessage => {
     const text = getUserMessageText(message);
@@ -180,7 +187,7 @@ const buildUserModelMessage = ({
         return { role: 'user', content: baseText };
     }
 
-    const acceptedBlobs = mediaBlobs.filter((blob) => isMediaTypeAccepted(blob.mediaType, acceptedModalities));
+    const acceptedBlobs = mediaBlobs.filter((blob) => isAttachmentAccepted(blob.mediaType, capabilities));
     const unsupportedCount = mediaBlobs.length - acceptedBlobs.length;
 
     const mediaParts = acceptedBlobs
@@ -247,6 +254,10 @@ interface CreateMessageStreamResponseProps {
     // to text-only): attachments whose modality isn't listed are omitted from
     // the model content and a marker is left in their place.
     acceptedModalities?: InputModality[];
+    // Authoritative, server-resolved set of compound document types (e.g. PDF)
+    // the selected model can natively ingest. Fail-closed (defaults to none):
+    // documents whose type isn't listed are omitted and a marker is left.
+    supportedDocumentTypes?: DocumentType[];
 }
 
 export const createMessageStream = async ({
@@ -267,7 +278,14 @@ export const createMessageStream = async ({
     userId,
     orgId,
     acceptedModalities = [],
+    supportedDocumentTypes = [],
 }: CreateMessageStreamResponseProps) => {
+    // The model's native attachment capabilities across both axes, threaded
+    // into the media resolver and the per-turn content builder.
+    const attachmentCapabilities: AttachmentCapabilities = {
+        inputModalities: acceptedModalities,
+        supportedDocumentTypes,
+    };
     // Defense-in-depth: Ask Sourcebot is a paid feature. Every caller is
     // expected to gate on the `ask` entitlement before reaching here (see
     // checkAskEntitlement); this assertion backstops that contract so a future
@@ -294,7 +312,7 @@ export const createMessageStream = async ({
     const lastUserIndex = messages.map((message) => message.role).lastIndexOf('user');
     const resolvedLatestTurnMedia = await resolveLatestTurnMedia({
         message: lastUserIndex >= 0 ? messages[lastUserIndex] : undefined,
-        acceptedModalities,
+        capabilities: attachmentCapabilities,
         prisma,
         orgId,
         chatId,
@@ -306,7 +324,7 @@ export const createMessageStream = async ({
                 return buildUserModelMessage({
                     message,
                     isLatestUserTurn: index === lastUserIndex,
-                    acceptedModalities,
+                    capabilities: attachmentCapabilities,
                     resolvedMedia: index === lastUserIndex ? resolvedLatestTurnMedia : undefined,
                 });
             }

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -53,6 +53,7 @@ interface ChatThreadProps {
     isAuthenticated: boolean;
     isLoginWallEnabled: boolean;
     maxImageBytes: number;
+    maxPdfBytes: number;
     chatName?: string;
 }
 
@@ -71,6 +72,7 @@ export const ChatThread = ({
     isAuthenticated,
     isLoginWallEnabled,
     maxImageBytes,
+    maxPdfBytes,
     chatName,
 }: ChatThreadProps) => {
     const [isErrorBannerVisible, setIsErrorBannerVisible] = useState(false);
@@ -500,6 +502,7 @@ export const ChatThread = ({
                                     isAuthenticated={isAuthenticated}
                                     isLoginWallEnabled={isLoginWallEnabled}
                                     maxImageBytes={maxImageBytes}
+                                    maxPdfBytes={maxPdfBytes}
                                 />
                                 <div className="w-full flex flex-row items-center bg-accent rounded-b-md px-2">
                                     <ChatBoxToolbar

--- a/packages/web/src/ee/features/chat/components/chatThread/messageAttachments.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/messageAttachments.tsx
@@ -3,7 +3,7 @@
 import { VscodeFileIcon } from "@/app/components/vscodeFileIcon";
 import { HoverCard, HoverCardContent, HoverCardTrigger } from "@/components/ui/hover-card";
 import { AttachmentViewerDialog } from "@/features/chat/components/chatBox/attachmentViewerDialog";
-import { mediaTypeToModality } from "@/features/chat/attachments/modality";
+import { mediaTypeToDocumentType, mediaTypeToModality } from "@/features/chat/attachments/modality";
 import { AttachmentData } from "@/features/chat/types";
 import { cn } from "@/lib/utils";
 import { useState } from "react";
@@ -71,6 +71,26 @@ export const MessageAttachments = ({ attachments, chatId, className }: MessageAt
                                     />
                                 </HoverCardContent>
                             </HoverCard>
+                        );
+                    }
+
+                    // Sent PDFs open in a new tab from their chat-scoped serving
+                    // URL (a download chip) rather than the inline viewer dialog.
+                    if (attachment.kind === 'blob' && mediaTypeToDocumentType(attachment.mediaType) === 'pdf') {
+                        return (
+                            <a
+                                key={attachment.attachmentId}
+                                href={getAttachmentServingUrl(chatId, attachment.attachmentId)}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="flex flex-row items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs hover:bg-accent transition-colors"
+                                title={`Open ${attachment.filename}`}
+                            >
+                                <VscodeFileIcon fileName={attachment.filename} className="w-3 h-3" />
+                                <span className="font-mono max-w-[160px] truncate">
+                                    {attachment.filename}
+                                </span>
+                            </a>
                         );
                     }
 

--- a/packages/web/src/ee/features/chat/components/chatThreadPanel.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThreadPanel.test.tsx
@@ -81,6 +81,7 @@ describe('ChatThreadPanel', () => {
                 isAuthenticated={true}
                 isLoginWallEnabled={false}
                 maxImageBytes={10 * 1024 * 1024}
+                maxPdfBytes={32 * 1024 * 1024}
             />
         );
 

--- a/packages/web/src/ee/features/chat/components/chatThreadPanel.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThreadPanel.tsx
@@ -18,6 +18,7 @@ interface ChatThreadPanelProps {
     isAuthenticated: boolean;
     isLoginWallEnabled: boolean;
     maxImageBytes: number;
+    maxPdfBytes: number;
     chatName?: string;
 }
 
@@ -38,6 +39,7 @@ export const ChatThreadPanel = ({
     isAuthenticated,
     isLoginWallEnabled,
     maxImageBytes,
+    maxPdfBytes,
     chatName,
 }: ChatThreadPanelProps) => {
     // @note: we are guaranteed to have a chatId because this component will only be
@@ -93,6 +95,7 @@ export const ChatThreadPanel = ({
                 isAuthenticated={isAuthenticated}
                 isLoginWallEnabled={isLoginWallEnabled}
                 maxImageBytes={maxImageBytes}
+                maxPdfBytes={maxPdfBytes}
                 chatName={chatName}
             />
         </div>

--- a/packages/web/src/features/chat/attachmentUtils.ts
+++ b/packages/web/src/features/chat/attachmentUtils.ts
@@ -2,10 +2,13 @@
 
 import {
     ATTACHMENT_ALLOWED_IMAGE_MIME_TYPES,
+    ATTACHMENT_ALLOWED_PDF_MIME_TYPES,
     ATTACHMENT_ALLOWED_TEXT_EXTENSIONS,
     ATTACHMENT_ALLOWED_TEXT_MIME_TYPES,
     ATTACHMENT_MAX_IMAGE_BYTES,
     ATTACHMENT_MAX_IMAGE_COUNT,
+    ATTACHMENT_MAX_PDF_BYTES,
+    ATTACHMENT_MAX_PDF_COUNT,
     ATTACHMENT_MAX_TURN_TEXT_BYTES,
     ATTACHMENT_PASTE_AUTO_CONVERT_MIN_CHARS,
     ATTACHMENT_PASTE_AUTO_CONVERT_MIN_LINES,
@@ -44,21 +47,48 @@ export type PendingImageAttachment = {
     error?: string;
 };
 
+// A PDF attachment selected in the chat box. Like images, the bytes are
+// uploaded to blob storage on select and `status`/`attachmentId` track that
+// upload. Unlike images there is no `previewUrl` (PDFs are not rendered as a
+// thumbnail); the tray shows a file-icon chip instead.
+export type PendingPdfAttachment = {
+    kind: 'pdf';
+    id: string;
+    filename: string;
+    mediaType: string;
+    sizeBytes: number;
+    file: File;
+    status: 'uploading' | 'uploaded' | 'error';
+    attachmentId?: string;
+    error?: string;
+};
+
 // An attachment selected in the chat box but not yet submitted. For text
 // attachments the `id` is the stable handle carried into the message so the
-// content can be cited and resolved; for images it is a client-only list key
-// (images are addressed by their uploaded `attachmentId` instead).
-export type PendingAttachment = PendingTextAttachment | PendingImageAttachment;
+// content can be cited and resolved; for images and PDFs it is a client-only
+// list key (they are addressed by their uploaded `attachmentId` instead).
+export type PendingAttachment = PendingTextAttachment | PendingImageAttachment | PendingPdfAttachment;
+
+// Whether a pending attachment is an upload-backed blob (image or PDF): its
+// bytes are uploaded on select and it carries an `attachmentId`/`status`.
+export type PendingUploadAttachment = PendingImageAttachment | PendingPdfAttachment;
+
+export const isPendingUploadAttachment = (
+    attachment: PendingAttachment,
+): attachment is PendingUploadAttachment =>
+    attachment.kind === 'image' || attachment.kind === 'pdf';
 
 // Builds the comma-separated `accept` attribute for a native `<input type=file>`
 // so the OS picker only surfaces supported file types. Image types are included
-// only when the selected model can accept image input.
-export const getAttachmentAcceptAttribute = (includeImages: boolean): string => {
+// only when the selected model can accept image input; PDF only when it
+// natively supports PDF documents.
+export const getAttachmentAcceptAttribute = (includeImages: boolean, includePdf: boolean): string => {
     return [
         'text/*',
         ...ATTACHMENT_ALLOWED_TEXT_MIME_TYPES,
         ...ATTACHMENT_ALLOWED_TEXT_EXTENSIONS.map((extension) => `.${extension}`),
         ...(includeImages ? ATTACHMENT_ALLOWED_IMAGE_MIME_TYPES : []),
+        ...(includePdf ? [...ATTACHMENT_ALLOWED_PDF_MIME_TYPES, '.pdf'] : []),
     ].join(',');
 }
 
@@ -66,8 +96,9 @@ export const getAttachmentAcceptAttribute = (includeImages: boolean): string => 
 // the OS dialog and drag overlay only surface supported file types. The
 // extension list is attached to `text/plain` so code files that report an empty
 // or unusual MIME type are still selectable by extension. Image types are
-// included only when the selected model can accept image input.
-export const getAttachmentDropzoneAccept = (includeImages: boolean): Record<string, string[]> => {
+// included only when the selected model can accept image input; PDF only when
+// it natively supports PDF documents.
+export const getAttachmentDropzoneAccept = (includeImages: boolean, includePdf: boolean): Record<string, string[]> => {
     const accept: Record<string, string[]> = {
         'text/*': [],
         'text/plain': ATTACHMENT_ALLOWED_TEXT_EXTENSIONS.map((extension) => `.${extension}`),
@@ -78,6 +109,11 @@ export const getAttachmentDropzoneAccept = (includeImages: boolean): Record<stri
     if (includeImages) {
         for (const mimeType of ATTACHMENT_ALLOWED_IMAGE_MIME_TYPES) {
             accept[mimeType] = [];
+        }
+    }
+    if (includePdf) {
+        for (const mimeType of ATTACHMENT_ALLOWED_PDF_MIME_TYPES) {
+            accept[mimeType] = ['.pdf'];
         }
     }
     return accept;
@@ -110,6 +146,8 @@ export const toAttachmentData = (attachment: PendingAttachment): AttachmentData 
         };
     }
 
+    // Images and PDFs both become blob refs once their upload completes; an
+    // upload still in flight has no `attachmentId` and must not be referenced.
     if (attachment.status === 'uploaded' && attachment.attachmentId) {
         return {
             kind: 'blob',
@@ -153,6 +191,14 @@ export const isAllowedTextFile = (file: File): boolean => {
 
 export const isAllowedImageFile = (file: File): boolean => {
     return (ATTACHMENT_ALLOWED_IMAGE_MIME_TYPES as readonly string[]).includes(file.type);
+}
+
+export const isAllowedPdfFile = (file: File): boolean => {
+    if ((ATTACHMENT_ALLOWED_PDF_MIME_TYPES as readonly string[]).includes(file.type)) {
+        return true;
+    }
+    // Some browsers report an empty type for PDFs; fall back to the extension.
+    return getExtension(file.name) === 'pdf';
 }
 
 const readAsText = (file: File): Promise<string> => {
@@ -217,21 +263,33 @@ export type ReadFilesResult = {
 };
 
 // Reads and validates files into pending attachments, enforcing the per-file
-// size, allowed-type, and per-message image-count caps (the per-turn text budget
-// is enforced at submit time). Text is read inline; images (when `allowImages`)
-// become pending uploads the caller then kicks off. The image-count cap mirrors
-// the server's for early feedback. Rejected files yield an error, not a throw.
+// size, allowed-type, and per-message image/PDF-count caps (the per-turn text
+// budget is enforced at submit time). Text is read inline; images (when
+// `allowImages`) and PDFs (when `allowPdf`) become pending uploads the caller
+// then kicks off. The count caps mirror the server's for early feedback.
+// Rejected files yield an error, not a throw.
 export const readFilesAsAttachments = async (
     files: File[],
-    { allowImages, existingImageCount = 0, maxImageBytes = ATTACHMENT_MAX_IMAGE_BYTES }: {
+    {
+        allowImages,
+        allowPdf,
+        existingImageCount = 0,
+        existingPdfCount = 0,
+        maxImageBytes = ATTACHMENT_MAX_IMAGE_BYTES,
+        maxPdfBytes = ATTACHMENT_MAX_PDF_BYTES,
+    }: {
         allowImages: boolean;
+        allowPdf: boolean;
         existingImageCount?: number;
+        existingPdfCount?: number;
         maxImageBytes?: number;
+        maxPdfBytes?: number;
     },
 ): Promise<ReadFilesResult> => {
     const attachments: PendingAttachment[] = [];
     const errors: string[] = [];
     let imageCount = existingImageCount;
+    let pdfCount = existingPdfCount;
 
     for (const file of files) {
         if (isAllowedTextFile(file)) {
@@ -283,16 +341,43 @@ export const readFilesAsAttachments = async (
             continue;
         }
 
+        if (isAllowedPdfFile(file)) {
+            if (!allowPdf) {
+                errors.push(`${file.name}: the selected model does not support PDF input.`);
+                continue;
+            }
+            if (file.size > maxPdfBytes) {
+                errors.push(`${file.name}: exceeds the ${Math.round(maxPdfBytes / (1024 * 1024))}MB PDF limit.`);
+                continue;
+            }
+            if (pdfCount >= ATTACHMENT_MAX_PDF_COUNT) {
+                errors.push(`You can attach at most ${ATTACHMENT_MAX_PDF_COUNT} PDFs per message.`);
+                continue;
+            }
+            attachments.push({
+                id: uuidv4(),
+                kind: 'pdf',
+                filename: sanitizeFilename(file.name),
+                mediaType: 'application/pdf',
+                sizeBytes: file.size,
+                file,
+                status: 'uploading',
+            });
+            pdfCount++;
+            continue;
+        }
+
         errors.push(`${file.name}: unsupported file type.`);
     }
 
     return { attachments, errors };
 }
 
-// Uploads an image attachment's bytes to blob storage, returning the committed
-// attachment metadata (including the server-assigned `attachmentId`). Throws
-// with a human-readable message on failure.
-export const uploadImageAttachment = async (file: File): Promise<{
+// Uploads a binary (blob) attachment's bytes to blob storage, returning the
+// committed attachment metadata (including the server-assigned `attachmentId`).
+// Used for both image and PDF attachments. Throws with a human-readable message
+// on failure.
+export const uploadBlobAttachment = async (file: File): Promise<{
     attachmentId: string;
     filename: string;
     mediaType: string;
@@ -311,7 +396,7 @@ export const uploadImageAttachment = async (file: File): Promise<{
 
     if (!response.ok) {
         const body = await response.json().catch(() => undefined);
-        throw new Error(body?.message ?? 'Failed to upload image.');
+        throw new Error(body?.message ?? 'Failed to upload file.');
     }
 
     return response.json();

--- a/packages/web/src/features/chat/attachments/modality.test.ts
+++ b/packages/web/src/features/chat/attachments/modality.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, test } from 'vitest';
+import {
+    isAttachmentAccepted,
+    isMediaTypeAccepted,
+    isNativeMediaType,
+    mediaTypeToDocumentType,
+    mediaTypeToModality,
+} from './modality';
+
+describe('mediaTypeToModality', () => {
+    test('maps single-medium media types to their modality', () => {
+        expect(mediaTypeToModality('image/png')).toBe('image');
+        expect(mediaTypeToModality('audio/mpeg')).toBe('audio');
+        expect(mediaTypeToModality('video/mp4')).toBe('video');
+    });
+
+    test('does not treat PDF as a modality', () => {
+        expect(mediaTypeToModality('application/pdf')).toBeUndefined();
+    });
+
+    test('returns undefined for unrecognized types', () => {
+        expect(mediaTypeToModality('text/plain')).toBeUndefined();
+        expect(mediaTypeToModality('application/octet-stream')).toBeUndefined();
+    });
+});
+
+describe('mediaTypeToDocumentType', () => {
+    test('maps application/pdf to pdf', () => {
+        expect(mediaTypeToDocumentType('application/pdf')).toBe('pdf');
+    });
+
+    test('returns undefined for non-document types', () => {
+        expect(mediaTypeToDocumentType('image/png')).toBeUndefined();
+        expect(mediaTypeToDocumentType('text/plain')).toBeUndefined();
+    });
+});
+
+describe('isNativeMediaType', () => {
+    test('recognizes both modalities and document types', () => {
+        expect(isNativeMediaType('image/png')).toBe(true);
+        expect(isNativeMediaType('application/pdf')).toBe(true);
+    });
+
+    test('rejects plain text / unknown binaries', () => {
+        expect(isNativeMediaType('text/plain')).toBe(false);
+        expect(isNativeMediaType('application/octet-stream')).toBe(false);
+    });
+});
+
+describe('isMediaTypeAccepted', () => {
+    test('gates single-medium attachments on inputModalities only', () => {
+        expect(isMediaTypeAccepted('image/png', ['text', 'image'])).toBe(true);
+        expect(isMediaTypeAccepted('image/png', ['text'])).toBe(false);
+        // PDF is not a modality, so it is never accepted via this gate.
+        expect(isMediaTypeAccepted('application/pdf', ['text', 'image'])).toBe(false);
+    });
+});
+
+describe('isAttachmentAccepted', () => {
+    test('accepts an image only when the modality is supported', () => {
+        expect(isAttachmentAccepted('image/png', { inputModalities: ['text', 'image'], supportedDocumentTypes: [] })).toBe(true);
+        expect(isAttachmentAccepted('image/png', { inputModalities: ['text'], supportedDocumentTypes: ['pdf'] })).toBe(false);
+    });
+
+    test('accepts a PDF only when the document type is supported (independent of modalities)', () => {
+        expect(isAttachmentAccepted('application/pdf', { inputModalities: ['text'], supportedDocumentTypes: ['pdf'] })).toBe(true);
+        // Image support does not imply PDF support.
+        expect(isAttachmentAccepted('application/pdf', { inputModalities: ['text', 'image'], supportedDocumentTypes: [] })).toBe(false);
+    });
+
+    test('rejects unrecognized media types regardless of capabilities', () => {
+        expect(isAttachmentAccepted('application/octet-stream', { inputModalities: ['text', 'image'], supportedDocumentTypes: ['pdf'] })).toBe(false);
+    });
+});

--- a/packages/web/src/features/chat/attachments/modality.ts
+++ b/packages/web/src/features/chat/attachments/modality.ts
@@ -1,4 +1,4 @@
-import { InputModality } from "../types";
+import { DocumentType, InputModality } from "../types";
 
 // Single-medium modalities an attachment blob can occupy (text is excluded: it
 // travels inline in the message, not as a native attachment part).
@@ -7,8 +7,9 @@ export type AttachmentModality = Exclude<InputModality, 'text'>;
 /**
  * Maps a stored attachment's media type to the model input modality it occupies,
  * or `undefined` when it isn't a recognized single-medium attachment. The single
- * source of truth for "what kind of attachment is this"; extend it to add
- * PDF/audio/video support.
+ * source of truth for "what single-medium modality is this"; extend it to add
+ * audio/video support. Compound document formats (e.g. PDF) are NOT modalities;
+ * see `mediaTypeToDocumentType`.
  */
 export const mediaTypeToModality = (mediaType: string): AttachmentModality | undefined => {
     if (mediaType.startsWith('image/')) {
@@ -24,10 +25,56 @@ export const mediaTypeToModality = (mediaType: string): AttachmentModality | und
 };
 
 /**
+ * Maps a stored attachment's media type to the compound document type it
+ * represents, or `undefined` when it isn't a recognized document. Distinct from
+ * `mediaTypeToModality`: document types (e.g. PDF) are gated on the model's
+ * `supportedDocumentTypes`, not its `inputModalities`, because providers
+ * decompose them server-side rather than encoding them as a raw channel.
+ */
+export const mediaTypeToDocumentType = (mediaType: string): DocumentType | undefined => {
+    if (mediaType === 'application/pdf') {
+        return 'pdf';
+    }
+    return undefined;
+};
+
+// The capabilities a model exposes for native attachment ingestion: the raw
+// channels it encodes plus the compound document formats it decomposes.
+export type AttachmentCapabilities = {
+    inputModalities: InputModality[];
+    supportedDocumentTypes: DocumentType[];
+};
+
+/**
  * Whether a model that accepts `acceptedModalities` can natively ingest an
- * attachment of `mediaType`.
+ * attachment of `mediaType` as a single-medium modality.
  */
 export const isMediaTypeAccepted = (mediaType: string, acceptedModalities: InputModality[]): boolean => {
     const modality = mediaTypeToModality(mediaType);
     return modality !== undefined && acceptedModalities.includes(modality);
+};
+
+// Whether `mediaType` maps to either a known single-medium modality or a known
+// compound document type (regardless of model support). Used to recognize which
+// blob attachments are "native media" the agent may send to the model.
+export const isNativeMediaType = (mediaType: string): boolean => {
+    return mediaTypeToModality(mediaType) !== undefined || mediaTypeToDocumentType(mediaType) !== undefined;
+};
+
+/**
+ * Whether a model with `caps` can natively ingest an attachment of `mediaType`,
+ * across BOTH capability axes: a single-medium modality (image/audio/video) or a
+ * compound document type (pdf). The single gate the upload, degrade-accounting,
+ * and agent content builder all share.
+ */
+export const isAttachmentAccepted = (mediaType: string, caps: AttachmentCapabilities): boolean => {
+    const modality = mediaTypeToModality(mediaType);
+    if (modality !== undefined) {
+        return caps.inputModalities.includes(modality);
+    }
+    const documentType = mediaTypeToDocumentType(mediaType);
+    if (documentType !== undefined) {
+        return caps.supportedDocumentTypes.includes(documentType);
+    }
+    return false;
 };

--- a/packages/web/src/features/chat/attachments/pdfValidation.test.ts
+++ b/packages/web/src/features/chat/attachments/pdfValidation.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, test, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+
+const { looksLikePdf, validatePdfAttachment } = await import('./pdfValidation');
+
+const MAX_BYTES = 32 * 1024 * 1024;
+
+const pdfBuffer = (body = '1.7\n%fake') => Buffer.from(`%PDF-${body}`, 'latin1');
+
+describe('looksLikePdf', () => {
+    test('recognizes the %PDF- magic at the start', () => {
+        expect(looksLikePdf(pdfBuffer())).toBe(true);
+    });
+
+    test('tolerates a small leading offset before the magic', () => {
+        const buffer = Buffer.concat([Buffer.from('\uFEFF junk '.repeat(3), 'latin1'), pdfBuffer()]);
+        expect(looksLikePdf(buffer)).toBe(true);
+    });
+
+    test('rejects non-PDF bytes', () => {
+        expect(looksLikePdf(Buffer.from('PK\u0003\u0004 zip bytes', 'latin1'))).toBe(false);
+        expect(looksLikePdf(Buffer.from('plain text', 'latin1'))).toBe(false);
+    });
+});
+
+describe('validatePdfAttachment', () => {
+    test('accepts a well-formed PDF and reports the canonical media type', () => {
+        const result = validatePdfAttachment(pdfBuffer(), MAX_BYTES);
+        expect(result).toEqual({ ok: true, mediaType: 'application/pdf' });
+    });
+
+    test('rejects empty input', () => {
+        const result = validatePdfAttachment(Buffer.alloc(0), MAX_BYTES);
+        expect(result.ok).toBe(false);
+    });
+
+    test('rejects bytes over the size cap', () => {
+        const result = validatePdfAttachment(pdfBuffer(), 4);
+        expect(result.ok).toBe(false);
+        if (!result.ok) {
+            expect(result.reason).toContain('limit');
+        }
+    });
+
+    test('rejects bytes without the PDF magic', () => {
+        const result = validatePdfAttachment(Buffer.from('not a pdf at all', 'latin1'), MAX_BYTES);
+        expect(result.ok).toBe(false);
+    });
+});

--- a/packages/web/src/features/chat/attachments/pdfValidation.ts
+++ b/packages/web/src/features/chat/attachments/pdfValidation.ts
@@ -1,0 +1,40 @@
+import 'server-only';
+
+export type PdfValidationResult =
+    | { ok: true; mediaType: 'application/pdf' }
+    | { ok: false; reason: string };
+
+// PDF files begin with the `%PDF-` signature. A small leading offset is
+// tolerated because some producers emit a few junk/BOM bytes before the header,
+// matching the leniency of real-world PDF readers.
+const PDF_MAGIC = Buffer.from('%PDF-', 'latin1');
+const MAX_MAGIC_OFFSET = 1024;
+
+/**
+ * Validates uploaded attachment bytes as a PDF by sniffing the `%PDF-` magic
+ * bytes (never trusting the client-supplied MIME type or extension) and
+ * enforcing the byte-size cap. Deliberately does NOT parse the document: page
+ * count and render limits are enforced by the provider when the bytes are sent,
+ * so we avoid pulling an untrusted-PDF parser into the upload path.
+ */
+export const validatePdfAttachment = (buffer: Buffer, maxBytes: number): PdfValidationResult => {
+    if (buffer.length === 0) {
+        return { ok: false, reason: 'Empty file.' };
+    }
+    if (buffer.length > maxBytes) {
+        return { ok: false, reason: `PDF exceeds the ${Math.round(maxBytes / (1024 * 1024))}MB limit.` };
+    }
+
+    const header = buffer.subarray(0, MAX_MAGIC_OFFSET + PDF_MAGIC.length);
+    if (header.indexOf(PDF_MAGIC) === -1) {
+        return { ok: false, reason: 'Unsupported or corrupt PDF.' };
+    }
+
+    return { ok: true, mediaType: 'application/pdf' };
+};
+
+// Whether the buffer looks like a PDF (used by the upload route to dispatch to
+// the PDF validator instead of the image validator).
+export const looksLikePdf = (buffer: Buffer): boolean => {
+    return buffer.subarray(0, MAX_MAGIC_OFFSET + PDF_MAGIC.length).indexOf(PDF_MAGIC) !== -1;
+};

--- a/packages/web/src/features/chat/components/chatBox/attachmentButton.tsx
+++ b/packages/web/src/features/chat/components/chatBox/attachmentButton.tsx
@@ -9,10 +9,11 @@ import { useRef } from "react";
 interface AttachmentButtonProps {
     onAddFiles: (files: File[]) => void;
     acceptImages?: boolean;
+    acceptPdf?: boolean;
     disabled?: boolean;
 }
 
-export const AttachmentButton = ({ onAddFiles, acceptImages = false, disabled }: AttachmentButtonProps) => {
+export const AttachmentButton = ({ onAddFiles, acceptImages = false, acceptPdf = false, disabled }: AttachmentButtonProps) => {
     const inputRef = useRef<HTMLInputElement>(null);
 
     return (
@@ -21,7 +22,7 @@ export const AttachmentButton = ({ onAddFiles, acceptImages = false, disabled }:
                 ref={inputRef}
                 type="file"
                 multiple
-                accept={getAttachmentAcceptAttribute(acceptImages)}
+                accept={getAttachmentAcceptAttribute(acceptImages, acceptPdf)}
                 className="hidden"
                 onChange={(e) => {
                     const files = e.target.files ? Array.from(e.target.files) : [];
@@ -47,7 +48,13 @@ export const AttachmentButton = ({ onAddFiles, acceptImages = false, disabled }:
                     </Button>
                 </TooltipTrigger>
                 <TooltipContent>
-                    {acceptImages ? "Attach text files or images" : "Attach text files"}
+                    {acceptImages && acceptPdf
+                        ? "Attach text files, images, or PDFs"
+                        : acceptImages
+                            ? "Attach text files or images"
+                            : acceptPdf
+                                ? "Attach text files or PDFs"
+                                : "Attach text files"}
                 </TooltipContent>
             </Tooltip>
         </>

--- a/packages/web/src/features/chat/components/chatBox/attachmentTray.tsx
+++ b/packages/web/src/features/chat/components/chatBox/attachmentTray.tsx
@@ -80,6 +80,36 @@ export const AttachmentTray = ({ attachments, onRemove, className }: AttachmentT
                                 />
                             </HoverCardContent>
                         </HoverCard>
+                    ) : attachment.kind === 'pdf' ? (
+                        // PDFs are not previewable pre-send (no chat-scoped serving
+                        // URL yet), so the chip is non-interactive and just reflects
+                        // the upload status.
+                        <div
+                            key={attachment.id}
+                            className="flex flex-row items-center gap-1 rounded bg-muted px-1.5 py-0.5 text-xs"
+                            title={attachment.filename}
+                        >
+                            {attachment.status === 'uploading' ? (
+                                <Loader2 className="w-3 h-3 shrink-0 animate-spin text-muted-foreground" />
+                            ) : attachment.status === 'error' ? (
+                                <AlertCircle className="w-3 h-3 shrink-0 text-destructive" />
+                            ) : (
+                                <VscodeFileIcon fileName={attachment.filename} className="w-3 h-3" />
+                            )}
+                            <span className="font-mono max-w-[160px] truncate">
+                                {attachment.filename}
+                            </span>
+                            {onRemove && (
+                                <button
+                                    type="button"
+                                    onClick={() => onRemove(attachment.id)}
+                                    className="text-muted-foreground hover:text-foreground"
+                                    aria-label={`Remove ${attachment.filename}`}
+                                >
+                                    <X className="w-3 h-3" />
+                                </button>
+                            )}
+                        </div>
                     ) : (
                         <div
                             key={attachment.id}

--- a/packages/web/src/features/chat/components/chatBox/chatBox.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBox.tsx
@@ -5,7 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { AttachmentData, CustomEditor, MentionElement, RenderElementPropsFor, SearchScope } from "@/features/chat/types";
 import { insertMention, slateContentToString } from "@/features/chat/utils";
-import { createPastedTextAttachment, getSubmittedTextBytes, PendingAttachment, PendingImageAttachment, readFilesAsAttachments, shouldAutoConvertPaste, toAttachmentData, uploadImageAttachment } from "@/features/chat/attachmentUtils";
+import { createPastedTextAttachment, getSubmittedTextBytes, isPendingUploadAttachment, PendingAttachment, PendingUploadAttachment, readFilesAsAttachments, shouldAutoConvertPaste, toAttachmentData, uploadBlobAttachment } from "@/features/chat/attachmentUtils";
 import { AttachmentButton } from "./attachmentButton";
 import { AttachmentTray } from "./attachmentTray";
 import { cn } from "@/lib/utils";
@@ -26,7 +26,7 @@ import { SearchContextQuery } from "@/lib/types";
 import isEqual from "fast-deep-equal/react";
 import { LoginDialog } from "./loginDialog";
 import { usePathname } from "next/navigation";
-import { ATTACHMENT_MAX_IMAGE_BYTES, ATTACHMENT_MAX_TURN_TEXT_BYTES, PENDING_CHAT_SUBMISSION_SESSION_STORAGE_KEY } from "@/features/chat/constants";
+import { ATTACHMENT_MAX_IMAGE_BYTES, ATTACHMENT_MAX_PDF_BYTES, ATTACHMENT_MAX_TURN_TEXT_BYTES, PENDING_CHAT_SUBMISSION_SESSION_STORAGE_KEY } from "@/features/chat/constants";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useHasEntitlement } from "@/features/entitlements/useHasEntitlement";
 import { UpsellDialog } from "@/features/billing/upsellDialog";
@@ -61,6 +61,10 @@ interface ChatBoxProps {
     // (SOURCEBOT_CHAT_ATTACHMENT_MAX_IMAGE_BYTES), threaded down for early
     // client-side rejection. Defaults to the constant when not provided.
     maxImageBytes?: number;
+    // Authoritative per-PDF byte cap from the server
+    // (SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES), threaded down for early
+    // client-side rejection. Defaults to the constant when not provided.
+    maxPdfBytes?: number;
 }
 
 const ChatBoxComponent = ({
@@ -77,6 +81,7 @@ const ChatBoxComponent = ({
     selectedSearchScopes,
     searchContexts,
     maxImageBytes = ATTACHMENT_MAX_IMAGE_BYTES,
+    maxPdfBytes = ATTACHMENT_MAX_PDF_BYTES,
 }: ChatBoxProps, ref: Ref<ChatBoxHandle>) => {
     const suggestionsBoxRef = useRef<HTMLDivElement>(null);
     const [index, setIndex] = useState(0);
@@ -118,13 +123,21 @@ const ChatBoxComponent = ({
         [selectedLanguageModel],
     );
 
-    // Uploads an image attachment's bytes and reflects the outcome back into the
-    // tray (status + server attachment id).
-    const uploadAndTrackImage = useCallback(async (item: PendingImageAttachment) => {
+    // Whether the selected model natively supports PDF documents. PDF
+    // attachments are gated on this (a separate capability axis from image
+    // input); text attachments are always allowed.
+    const supportsPdf = useMemo(
+        () => selectedLanguageModel?.supportedDocumentTypes?.includes('pdf') ?? false,
+        [selectedLanguageModel],
+    );
+
+    // Uploads a blob attachment's (image or PDF) bytes and reflects the outcome
+    // back into the tray (status + server attachment id).
+    const uploadAndTrackBlob = useCallback(async (item: PendingUploadAttachment) => {
         try {
-            const result = await uploadImageAttachment(item.file);
+            const result = await uploadBlobAttachment(item.file);
             setAttachments((prev) => prev.map((attachment) =>
-                attachment.id === item.id && attachment.kind === 'image'
+                attachment.id === item.id && isPendingUploadAttachment(attachment)
                     ? {
                         ...attachment,
                         status: 'uploaded',
@@ -136,7 +149,7 @@ const ChatBoxComponent = ({
         } catch (error) {
             const message = error instanceof Error ? error.message : 'upload failed.';
             setAttachments((prev) => prev.map((attachment) =>
-                attachment.id === item.id && attachment.kind === 'image'
+                attachment.id === item.id && isPendingUploadAttachment(attachment)
                     ? { ...attachment, status: 'error', error: message }
                     : attachment));
             toast({
@@ -192,8 +205,11 @@ const ChatBoxComponent = ({
             files,
             {
                 allowImages: supportsImages,
+                allowPdf: supportsPdf,
                 existingImageCount: attachments.filter((attachment) => attachment.kind === 'image').length,
+                existingPdfCount: attachments.filter((attachment) => attachment.kind === 'pdf').length,
                 maxImageBytes,
+                maxPdfBytes,
             },
         );
         if (added.length > 0) {
@@ -212,14 +228,14 @@ const ChatBoxComponent = ({
         // Upload image attachments immediately (upload-on-select); their refs
         // are included at submit once the upload completes.
         for (const item of added) {
-            if (item.kind === 'image') {
-                void uploadAndTrackImage(item);
+            if (isPendingUploadAttachment(item)) {
+                void uploadAndTrackBlob(item);
             }
         }
 
         // Return focus to the prompt input so the user can keep typing.
         ReactEditor.focus(editor);
-    }, [attachments, toast, editor, supportsImages, uploadAndTrackImage, getOverBudgetWarning, maxImageBytes]);
+    }, [attachments, toast, editor, supportsImages, supportsPdf, uploadAndTrackBlob, getOverBudgetWarning, maxImageBytes, maxPdfBytes]);
 
     const removeAttachment = useCallback((id: string) => {
         setAttachments((prev) => {
@@ -633,6 +649,11 @@ const ChatBoxComponent = ({
                         Images won&apos;t be sent: the selected model doesn&apos;t support image input.
                     </p>
                 )}
+                {attachments.some((attachment) => attachment.kind === 'pdf') && !supportsPdf && (
+                    <p className="mb-1.5 text-xs text-amber-600 dark:text-amber-500">
+                        PDFs won&apos;t be sent: the selected model doesn&apos;t support PDF input.
+                    </p>
+                )}
                 <Editable
                     className="w-full focus-visible:outline-none focus-visible:ring-0 bg-background text-base disabled:cursor-not-allowed disabled:opacity-50 md:text-sm max-h-64 overflow-y-auto"
                     placeholder="Ask a question about your code. @mention files or select search scopes to refine your query."
@@ -671,6 +692,7 @@ const ChatBoxComponent = ({
                     <AttachmentButton
                         onAddFiles={onAddFiles}
                         acceptImages={supportsImages}
+                        acceptPdf={supportsPdf}
                         disabled={isDisabled || isRedirecting || isTurnInProgress}
                     />
                     {isRedirecting ? (

--- a/packages/web/src/features/chat/components/chatBox/chatPaneDropzone.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatPaneDropzone.tsx
@@ -27,10 +27,11 @@ export const ChatPaneDropzone = ({ onFilesDropped, disabled, className, children
     const [dragFileCount, setDragFileCount] = useState(0);
 
     const { getRootProps, getInputProps, isDragActive, isDragReject } = useDropzone({
-        // Accept images at the dropzone layer regardless of model capability;
-        // the chat box's add handler applies the authoritative image gate (and
-        // surfaces a precise message when the selected model is text-only).
-        accept: getAttachmentDropzoneAccept(true),
+        // Accept images and PDFs at the dropzone layer regardless of model
+        // capability; the chat box's add handler applies the authoritative gate
+        // (and surfaces a precise message when the selected model can't accept
+        // that type).
+        accept: getAttachmentDropzoneAccept(true, true),
         multiple: true,
         noClick: true,
         noKeyboard: true,

--- a/packages/web/src/features/chat/constants.ts
+++ b/packages/web/src/features/chat/constants.ts
@@ -42,6 +42,19 @@ export const ATTACHMENT_MAX_IMAGE_DIMENSION = 12000; // px per side
 // per-request memory/cost: each image is loaded and sent to the model.
 export const ATTACHMENT_MAX_IMAGE_COUNT = 10;
 
+// Fallback client-side PDF size cap for early rejection before upload. The
+// authoritative cap is SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES, fetched via
+// `useAttachmentLimits`; this default is only used while that loads or if it
+// fails (and matches the server default). 32MB matches common provider limits
+// (e.g. Anthropic's PDF request cap).
+export const ATTACHMENT_MAX_PDF_BYTES = 32 * 1024 * 1024; // 32MB per PDF
+
+// Max PDF (blob) attachments per message. Enforced server-side in
+// `commitMessageAttachments` (mirrored client-side for early feedback). PDFs are
+// far heavier per item than images (each page is rasterized by the provider),
+// so the cap is lower.
+export const ATTACHMENT_MAX_PDF_COUNT = 5;
+
 // A plain-text paste at or above either of these thresholds is automatically
 // converted into a text attachment instead of being inserted inline
 export const ATTACHMENT_PASTE_AUTO_CONVERT_MIN_CHARS = 1500;
@@ -69,6 +82,14 @@ export const ATTACHMENT_ALLOWED_IMAGE_MIME_TYPES = [
     'image/jpeg',
     'image/webp',
     'image/gif',
+] as const;
+
+// Allowlist for binary PDF attachments. Validated server-side by sniffing the
+// `%PDF-` magic bytes (never by client MIME/extension). Used client-side only
+// to build the file picker's `accept` filter and to gate the PDF-attach
+// affordance, which is itself gated on the model's `supportedDocumentTypes`.
+export const ATTACHMENT_ALLOWED_PDF_MIME_TYPES = [
+    'application/pdf',
 ] as const;
 
 export const ATTACHMENT_ALLOWED_TEXT_EXTENSIONS = [

--- a/packages/web/src/features/chat/modelCapabilities.server.test.ts
+++ b/packages/web/src/features/chat/modelCapabilities.server.test.ts
@@ -12,7 +12,7 @@ vi.mock('@sourcebot/shared', () => ({
     }),
 }));
 
-import { lookupModelCapabilities, resolveModelCapabilities } from './modelCapabilities.server';
+import { lookupModelCapabilities, providerSupportsPdfDocuments, resolveModelCapabilities } from './modelCapabilities.server';
 import type { ModelsDevCatalog } from './modelsDevCatalog.server';
 
 const catalog: ModelsDevCatalog = {
@@ -44,6 +44,28 @@ const catalog: ModelsDevCatalog = {
             'image-only': { id: 'image-only', modalities: { input: ['image'], output: ['text'] } },
             // Catalogued model with no `modalities` object at all.
             'no-modalities-model': { id: 'no-modalities-model' },
+            // Text + pdf on a PDF-capable adapter.
+            'gpt-pdf': { id: 'gpt-pdf', modalities: { input: ['text', 'pdf'], output: ['text'] } },
+        },
+    },
+    // Providers whose adapter cannot carry a PDF file part even though the
+    // catalogued model lists `pdf` in its input modalities.
+    'amazon-bedrock': {
+        id: 'amazon-bedrock',
+        models: {
+            'claude-on-bedrock': {
+                id: 'claude-on-bedrock',
+                modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+            },
+        },
+    },
+    xai: {
+        id: 'xai',
+        models: {
+            'grok-vision': {
+                id: 'grok-vision',
+                modalities: { input: ['text', 'image', 'pdf'], output: ['text'] },
+            },
         },
     },
 };
@@ -96,6 +118,41 @@ describe('lookupModelCapabilities', () => {
             inputModalities: ['text'],
             supportedDocumentTypes: [],
         });
+    });
+
+    test('keeps PDF support for a provider whose adapter can carry PDF file parts', () => {
+        expect(lookupModelCapabilities(catalog, model('openai', 'gpt-pdf'))).toEqual({
+            inputModalities: ['text'],
+            supportedDocumentTypes: ['pdf'],
+        });
+    });
+
+    test('drops PDF support for a provider whose adapter cannot carry PDF file parts, keeping modalities', () => {
+        // The catalog lists pdf for these models, but the adapter (amazon-bedrock
+        // is image-only; xai is version/back-end dependent) cannot send it, so we
+        // fail closed on the document axis while preserving image input.
+        expect(lookupModelCapabilities(catalog, model('amazon-bedrock', 'claude-on-bedrock'))).toEqual({
+            inputModalities: ['text', 'image'],
+            supportedDocumentTypes: [],
+        });
+        expect(lookupModelCapabilities(catalog, model('xai', 'grok-vision'))).toEqual({
+            inputModalities: ['text', 'image'],
+            supportedDocumentTypes: [],
+        });
+    });
+});
+
+describe('providerSupportsPdfDocuments', () => {
+    test('allows first-party adapters known to carry PDF file parts', () => {
+        for (const provider of ['anthropic', 'openai', 'azure', 'google-generative-ai', 'google-vertex', 'google-vertex-anthropic'] as const) {
+            expect(providerSupportsPdfDocuments(provider)).toBe(true);
+        }
+    });
+
+    test('fails closed for adapters that are image-only or back-end/version dependent', () => {
+        for (const provider of ['amazon-bedrock', 'xai', 'openrouter', 'openai-compatible', 'mistral', 'deepseek'] as const) {
+            expect(providerSupportsPdfDocuments(provider)).toBe(false);
+        }
     });
 });
 

--- a/packages/web/src/features/chat/modelCapabilities.server.ts
+++ b/packages/web/src/features/chat/modelCapabilities.server.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { LanguageModel } from '@sourcebot/schemas/v3/languageModel.type';
-import { DocumentType, InputModality } from './types';
+import { DocumentType, InputModality, LanguageModelProvider } from './types';
 import { loadCatalog, resolveProviderId, type ModelsDevCatalog } from './modelsDevCatalog.server';
 
 // models.dev folds every accepted input — perceptual channels (text, image,
@@ -18,6 +18,37 @@ const isInputModality = (value: string): value is InputModality =>
 
 const isDocumentType = (value: string): value is DocumentType =>
     (DOCUMENT_TYPE_VALUES as readonly string[]).includes(value);
+
+// A model supporting a document type (per the catalog) is necessary but not
+// sufficient: the AI SDK provider adapter we route through must also be able to
+// translate that document into a `file` part for the wire. Several adapters
+// either only handle images (e.g. amazon-bedrock) or are back-end/version
+// dependent (openai-compatible, openrouter, xai), and will throw
+// `AI_UnsupportedFunctionalityError: 'file part media type application/pdf'` at
+// stream time even when the model itself accepts PDFs. We therefore intersect
+// the catalog's document support with this fail-closed allowlist of providers
+// whose adapter is known to carry PDF file parts. Anything not listed drops
+// PDF rather than risking a hard turn failure.
+//
+// @note Verify against the bundled `@ai-sdk/*` versions before adding a
+// provider here. `azure` routes through the OpenAI responses path (input_file)
+// so it is included; `xai`/`openrouter`/`amazon-bedrock` are intentionally
+// omitted pending confirmation in their adapter versions.
+const PDF_DOCUMENT_PROVIDERS: ReadonlySet<LanguageModelProvider> = new Set([
+    'anthropic',
+    'openai',
+    'azure',
+    'google-generative-ai',
+    'google-vertex',
+    'google-vertex-anthropic',
+]);
+
+/**
+ * Whether the AI SDK adapter for `provider` can carry an `application/pdf` file
+ * part. Fail-closed: providers not on the allowlist resolve to no PDF support.
+ */
+export const providerSupportsPdfDocuments = (provider: LanguageModelProvider): boolean =>
+    PDF_DOCUMENT_PROVIDERS.has(provider);
 
 export type ModelCapabilities = {
     inputModalities: InputModality[];
@@ -46,7 +77,13 @@ export const lookupModelCapabilities = (
     }
 
     const inputModalities = inputs.filter(isInputModality);
-    const supportedDocumentTypes = inputs.filter(isDocumentType);
+    // Narrow the catalog's document support to what the provider's adapter can
+    // actually send on the wire (see PDF_DOCUMENT_PROVIDERS): a model may accept
+    // PDFs while the adapter cannot carry the file part.
+    const supportedDocumentTypes = inputs
+        .filter(isDocumentType)
+        .filter((documentType) =>
+            documentType === 'pdf' ? providerSupportsPdfDocuments(config.provider) : true);
 
     // Every model accepts text, even if the catalog omits it from the list.
     if (!inputModalities.includes('text')) {

--- a/packages/web/src/features/chat/utils.server.ts
+++ b/packages/web/src/features/chat/utils.server.ts
@@ -8,7 +8,8 @@ import fs from 'fs';
 import path from 'path';
 import { BlobAttachment, LanguageModelInfo, SBChatMessage } from './types';
 import { getUserMessageAttachments } from './utils';
-import { ATTACHMENT_MAX_IMAGE_COUNT } from './constants';
+import { ATTACHMENT_MAX_IMAGE_COUNT, ATTACHMENT_MAX_PDF_COUNT } from './constants';
+import { mediaTypeToDocumentType, mediaTypeToModality } from './attachments/modality';
 import { resolveModelCapabilities } from './modelCapabilities.server';
 import { loadCatalog } from './modelsDevCatalog.server';
 import { hasEntitlement } from '@/lib/entitlements';
@@ -139,12 +140,23 @@ export const commitMessageAttachments = async ({
         return null;
     }
 
-    // Authoritative per-message image cap (the client mirror can't be trusted).
-    if (blobRefs.length > ATTACHMENT_MAX_IMAGE_COUNT) {
+    // Authoritative per-message per-type cap (the client mirror can't be
+    // trusted). Images and PDFs are bounded independently since their
+    // per-request cost profiles differ.
+    const imageCount = blobRefs.filter((ref) => mediaTypeToModality(ref.mediaType) === 'image').length;
+    const pdfCount = blobRefs.filter((ref) => mediaTypeToDocumentType(ref.mediaType) === 'pdf').length;
+    if (imageCount > ATTACHMENT_MAX_IMAGE_COUNT) {
         return {
             statusCode: StatusCodes.BAD_REQUEST,
             errorCode: ErrorCode.INVALID_REQUEST_BODY,
             message: `You can attach at most ${ATTACHMENT_MAX_IMAGE_COUNT} images per message.`,
+        } satisfies ServiceError;
+    }
+    if (pdfCount > ATTACHMENT_MAX_PDF_COUNT) {
+        return {
+            statusCode: StatusCodes.BAD_REQUEST,
+            errorCode: ErrorCode.INVALID_REQUEST_BODY,
+            message: `You can attach at most ${ATTACHMENT_MAX_PDF_COUNT} PDFs per message.`,
         } satisfies ServiceError;
     }
 


### PR DESCRIPTION
Adds PDF as a third attachment lane in Ask, reusing the existing image blob pipeline (upload, storage, PENDING/COMMITTED linking, serving, orphan pruning).

## What
- PDFs upload as blobs, gated on a **separate capability axis** (`supportedDocumentTypes`, not `inputModalities`), and are sent to capable models as an AI SDK `{ type: 'file', mediaType: 'application/pdf' }` part on the turn they're added.
- Upload validation sniffs the `%PDF-` magic bytes + enforces a dedicated size cap (`SOURCEBOT_CHAT_ATTACHMENT_MAX_PDF_BYTES`, default 32MB). No PDF parser is pulled into the upload path; the provider enforces page/render limits.
- Sent PDFs render as a download chip (opens the serving URL in a new tab); pre-send chips show upload status.

## Provider-adapter PDF gate (the OpenCode lesson)
A model accepting PDFs is necessary but **not sufficient**: the AI SDK provider adapter must also be able to translate a `file` part onto the wire. OpenCode hit exactly this. `@ai-sdk/openai-compatible` threw `AI_UnsupportedFunctionalityError: 'file part media type application/pdf'` even when the model config declared PDF support (their issue #16338), and they maintain a per-provider PDF allowlist (`@ai-sdk/anthropic`/`openai` yes, `amazon-bedrock` image-only, `xai` only after adding translation, see their #28561).

So we intersect the catalog's document support with a **fail-closed allowlist** of providers whose adapter is known to carry PDF file parts (`anthropic`, `openai`, `azure`, `google-generative-ai`, `google-vertex`, `google-vertex-anthropic`). Everything else (`amazon-bedrock`, `xai`, `openrouter`, `openai-compatible`, `mistral`, `deepseek`) drops PDF rather than risking a hard turn failure. A backstop in the chat route maps the SDK error to a friendly message if a PDF still reaches an unsupporting adapter.

> Note: `azure` and `xai` should be re-verified against the bundled `@ai-sdk/*` versions; `xai` is currently omitted pending confirmation.

## Test plan
- [ ] Attach a PDF on a PDF-capable model (e.g. Claude) and confirm it's sent and answered.
- [ ] Attach a PDF on a text/image-only model and confirm the chip is gated off / degrade note shown.
- [ ] Oversized / non-PDF rejected at upload.
- [ ] `yarn workspace @sourcebot/web test` (capabilities, modality, pdfValidation, agent suites).

Made with [Cursor](https://cursor.com)