### PR TITLE
fix(web): add HTTP security headers to all responses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified GitHub review webhook deliveries before processing them. [#1378](https://github.com/sourcebot-dev/sourcebot/pull/1378)
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
-- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1397](https://github.com/sourcebot-dev/sourcebot/pull/1397)
+- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1397](https://github.com/sourcebot-dev/sourcebot/pull/1407)
 
 ## [5.0.4] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified GitHub review webhook deliveries before processing them. [#1378](https://github.com/sourcebot-dev/sourcebot/pull/1378)
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
-- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1397](https://github.com/sourcebot-dev/sourcebot/pull/1407)
+- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
 
 ## [5.0.4] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified GitHub review webhook deliveries before processing them. [#1378](https://github.com/sourcebot-dev/sourcebot/pull/1378)
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
+- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1397](https://github.com/sourcebot-dev/sourcebot/pull/1397)
 
 ## [5.0.4] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,7 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Verified GitHub review webhook deliveries before processing them. [#1378](https://github.com/sourcebot-dev/sourcebot/pull/1378)
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
-- Added HTTP security headers (HSTS, X-Content-Type-Options, X-Frame-Options, Referrer-Policy, Permissions-Policy, and CSP frame-ancestors) to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
+- Added HTTP security headers to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -62,6 +62,46 @@ const nextConfig = {
             }
         ];
     },
+    // Apply HTTP security headers to all responses to align with security
+    // hardening best practices (defends against clickjacking, MIME-sniffing,
+    // TLS downgrade, and referrer leakage). We intentionally avoid a strict
+    // Content-Security-Policy `script-src` here since Next.js, PostHog, and
+    // Sentry rely on inline scripts; instead CSP is scoped to `frame-ancestors`
+    // to prevent framing, mirroring the X-Frame-Options directive below.
+    async headers() {
+        return [
+            {
+                source: "/:path*",
+                headers: [
+                    {
+                        key: "Strict-Transport-Security",
+                        value: "max-age=63072000; includeSubDomains",
+                    },
+                    {
+                        key: "X-Content-Type-Options",
+                        value: "nosniff",
+                    },
+                    {
+                        key: "X-Frame-Options",
+                        value: "SAMEORIGIN",
+                    },
+                    {
+                        key: "Referrer-Policy",
+                        value: "strict-origin-when-cross-origin",
+                    },
+                    {
+                        key: "Permissions-Policy",
+                        value: "camera=(), microphone=(), geolocation=()",
+                    },
+                    {
+                        key: "Content-Security-Policy",
+                        value: "frame-ancestors 'self'",
+                    },
+                ],
+            },
+        ];
+    },
+
     // This is required to support PostHog trailing slash API requests
     skipTrailingSlashRedirect: true,
 


### PR DESCRIPTION
Fixes SOU-1466

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Added security-related HTTP response headers to all web app pages, including protections for framing, content sniffing, transport security, referrer handling, and device access.
  * Strengthened response security with a content policy that limits where the app can be embedded.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->