### PR TITLE
fix: drop displayName from getLanguageModelKey to fix MCP model selection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
 - Added HTTP security headers to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
-- Dropped `displayName` from `getLanguageModelKey` so the MCP `ask_codebase` tool matches models by `provider` + `model` only, fixing `400 Language model not configured` when an explicit model is selected. [#1137](https://github.com/sourcebot-dev/sourcebot/issues/1137)
+- Dropped `displayName` from `getLanguageModelKey` so the MCP `ask_codebase` tool matches models by `provider` + `model` only, fixing `400 Language model not configured` when an explicit model is selected. [#1408](https://github.com/sourcebot-dev/sourcebot/pull/1408)
 
 ## [5.0.4] - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
 - Added HTTP security headers to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
+- Dropped `displayName` from `getLanguageModelKey` so the MCP `ask_codebase` tool matches models by `provider` + `model` only, fixing `400 Language model not configured` when an explicit model is selected. [#1137](https://github.com/sourcebot-dev/sourcebot/issues/1137)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -487,8 +487,8 @@ export const getAnswerPartFromAssistantMessage = (message: SBChatMessage, isTurn
  * identifying fields, so both the full `LanguageModel` config and the
  * client-safe `LanguageModelInfo` can be keyed with it.
  */
-export const getLanguageModelKey = (model: Pick<LanguageModelInfo, 'provider' | 'model' | 'displayName'>) => {
-    return `${model.provider}-${model.model}-${model.displayName}`;
+export const getLanguageModelKey = (model: Pick<LanguageModelInfo, 'provider' | 'model'>) => {
+    return `${model.provider}-${model.model}`;
 }
 
 /**


### PR DESCRIPTION
Fixes #1137

`getLanguageModelKey` included `displayName` in the model key, but `displayName` is a cosmetic label, not an identity field. The MCP schema only exposes `{provider, model}`, so explicit model selection via the `ask_codebase` tool always produced a key mismatch.

Dropping `displayName` from the key fixes the MCP path at the root and prevents the same bug pattern from appearing in other callers.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a “Language model not configured” error when an explicit model is selected.
  * Updated model matching to use only provider + model (removed the extra name component), ensuring the chat tool selects the correct configuration consistently.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->