### PR TITLE
chore: make backend worker API URL configurable via WORKER_API_URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - [EE] Improved Ask Sourcebot prompt caching by splitting static and dynamic prompt sections and advancing cache breakpoints after every agent step instead of only after each message. [#1366](https://github.com/sourcebot-dev/sourcebot/pull/1366)
 - Refactored Ask Sourcebot user message text extraction into a shared helper that robustly handles non-text message parts. [#1371](https://github.com/sourcebot-dev/sourcebot/pull/1371)
+- Made the backend worker API address configurable via the `WORKER_API_URL` environment variable (default `http://localhost:3060`) instead of being hardcoded. [#1409](https://github.com/sourcebot-dev/sourcebot/pull/1409)
 
 ### Added
 - Added per-step token cost tracking and estimated tool call token usage to Ask Sourcebot chat history. [#1353](https://github.com/sourcebot-dev/sourcebot/pull/1353)

--- a/packages/backend/src/api.ts
+++ b/packages/backend/src/api.ts
@@ -14,7 +14,9 @@ import { SINGLE_TENANT_ORG_ID } from './constants.js';
 import z from 'zod';
 
 const logger = createLogger('api');
-const PORT = 3060;
+
+const workerApiUrl = new URL(env.WORKER_API_URL);
+const PORT = Number(workerApiUrl.port) || (workerApiUrl.protocol === "https:" ? 443 : 80);
 
 export class Api {
     private server: http.Server;

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -172,6 +172,8 @@ const options = {
         // Zoekt
         ZOEKT_WEBSERVER_URL: z.string().url().default("http://localhost:6070"),
 
+        WORKER_API_URL: z.string().url().default("http://localhost:3060"),
+
         // Auth
         AUTH_SECRET: z.string(),
         AUTH_URL: z.string().url(),

--- a/packages/web/src/features/workerApi/actions.ts
+++ b/packages/web/src/features/workerApi/actions.ts
@@ -5,9 +5,10 @@ import { unexpectedError } from "@/lib/serviceError";
 import { withAuth, withOptionalAuth } from "@/middleware/withAuth";
 import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
 import { OrgRole } from "@sourcebot/db";
+import { env } from "@sourcebot/shared";
 import z from "zod";
 
-const WORKER_API_URL = 'http://localhost:3060';
+const WORKER_API_URL = env.WORKER_API_URL;
 
 export const syncConnection = async (connectionId: number) => sew(() =>
     withAuth(({ role }) =>


### PR DESCRIPTION
The backend worker API was hardcoded to `localhost:3060` in both the worker (`api.ts`) and the web app that calls it (`workerApi/actions.ts`). This adds a single `WORKER_API_URL` env var (default `http://localhost:3060`): the web app dials it, and the worker derives its listen port from it, so the URL and port can't drift.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Changed**
  * Made the worker API address configurable through an environment variable, with a sensible default.
  * Updated the backend to determine its listening port from the configured worker API address, with fallback ports for common URL schemes.
  * Switched the web app to use the same configurable worker API address for requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->