### PR TITLE
fix(web): maintain sidebar scroll position when navigating between chats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Passed Zoekt index parameters via argv to preserve revision names with punctuation. [#1376](https://github.com/sourcebot-dev/sourcebot/pull/1376)
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
 - Added HTTP security headers to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
+- Maintained the sidebar scroll position when navigating between chats instead of resetting to the top. [#1411](https://github.com/sourcebot-dev/sourcebot/pull/1411)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
@@ -40,13 +40,17 @@ import { signOut } from "next-auth/react";
 import { useTheme } from "next-themes";
 import Link from "next/link";
 import posthog from "posthog-js";
-import { ReactNode, useEffect, useMemo, useRef, useState } from "react";
+import { ReactNode, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { KeyboardShortcutHint } from "@/app/components/keyboardShortcutHint";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
 import { WhatsNewSidebarButton } from "./whatsNewSidebarButton";
 import { UpgradeButton } from "./upgradeButton";
 import { useIsMobile } from "@/hooks/use-mobile";
+
+// Retains the sidebar's scroll position across route-driven remounts of the
+// `@sidebar` slot. Module-level so it survives remounts but resets on reload.
+let lastScrollTop = 0;
 
 interface SidebarBaseProps {
     session: Session | null;
@@ -61,12 +65,27 @@ export function SidebarBase({ session, collapsible = "icon", headerContent, chil
     const contentRef = useRef<HTMLDivElement>(null);
     const isMobile = useIsMobile();
 
+    // The sidebar lives in the `@sidebar` parallel route slot, whose catch-all
+    // segment remounts on navigation between chats. Persist the scroll position
+    // across those remounts so it isn't reset to the top each time.
+    useLayoutEffect(() => {
+        const el = contentRef.current;
+        if (!el) {
+            return;
+        }
+        el.scrollTop = lastScrollTop;
+        setIsScrolled(el.scrollTop > 0);
+    }, []);
+
     useEffect(() => {
         const el = contentRef.current;
         if (!el) {
             return;
         }
-        const handleScroll = () => setIsScrolled(el.scrollTop > 0);
+        const handleScroll = () => {
+            lastScrollTop = el.scrollTop;
+            setIsScrolled(el.scrollTop > 0);
+        };
         el.addEventListener("scroll", handleScroll);
         return () => el.removeEventListener("scroll", handleScroll);
     }, []);


### PR DESCRIPTION
Fixes SOU-1483

The sidebar lives in the `@sidebar` parallel route slot, whose catch-all segment remounts when navigating between chats (`/chat/A` → `/chat/B`). That remount reset the `SidebarContent` scroll container back to the top each time.

This persists the scroll position in a module-level variable and restores it (via `useLayoutEffect`, to avoid flicker) whenever `SidebarBase` remounts, so the sidebar stays where you left it. The value resets on a full page reload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Sidebar scroll position is now preserved when switching between chats, instead of resetting to the top.
  * The sidebar’s “scrolled” visual state is restored correctly after navigation.
* **Documentation**
  * Updated the changelog under **Unreleased** to note the sidebar scroll position fix.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->