### PR TITLE
chore: upgrade @opentelemetry/core to ^2.8.0 to address CVE-2026-54285

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Validated OAuth bearer token scopes before allowing access to the Sourcebot MCP resource server. [#1396](https://github.com/sourcebot-dev/sourcebot/pull/1396)
 - Added HTTP security headers to all web app responses. [#1407](https://github.com/sourcebot-dev/sourcebot/pull/1407)
 - Upgraded `nodemailer` to `^9.0.1`. [#1356](https://github.com/sourcebot-dev/sourcebot/pull/1356)
+- Upgraded `@opentelemetry/core` to `^2.8.0`. [#1413](https://github.com/sourcebot-dev/sourcebot/pull/1413)
 
 ## [5.0.4] - 2026-06-18
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
         "sucrase/glob": "^10.5.0",
         "rimraf@npm:5.0.10/glob": "^10.5.0",
         "@opentelemetry/resources": "2.5.1",
+        "@opentelemetry/core": "^2.8.0",
         "path-to-regexp@0.1.12": "0.1.13",
         "path-to-regexp@^8": "^8.4.0",
         "picomatch@^4": "^4.0.4",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4691,47 +4691,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@opentelemetry/core@npm:2.0.1":
-  version: 2.0.1
-  resolution: "@opentelemetry/core@npm:2.0.1"
+"@opentelemetry/core@npm:^2.8.0":
+  version: 2.8.0
+  resolution: "@opentelemetry/core@npm:2.8.0"
   dependencies:
     "@opentelemetry/semantic-conventions": "npm:^1.29.0"
   peerDependencies:
     "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/d587b1289559757d80da98039f9f57612f84f72ec608cd665dc467c7c6c5ce3a987dfcc2c63b521c7c86ce984a2552b3ead15a0dc458de1cf6bde5cdfe4ca9d8
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.2.0":
-  version: 2.2.0
-  resolution: "@opentelemetry/core@npm:2.2.0"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/f618b63f2f560d052791d2406b1411722aa4b0585031242e6906f869f0a707ffe725c4b29bf18aed1f202e1ab5dfc3a9f769c517ac8521338b33ac8c4265fba9
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.5.0":
-  version: 2.5.0
-  resolution: "@opentelemetry/core@npm:2.5.0"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/5bc67c74513036bb5a22955027382f24cff405601837546e66588ef9c87c161b7e872ed1ac63d910f88288ec1c0f00fc5ea5e750c9d63b2dabd3ab4a30fcf7b8
-  languageName: node
-  linkType: hard
-
-"@opentelemetry/core@npm:2.5.1, @opentelemetry/core@npm:^2.0.0, @opentelemetry/core@npm:^2.5.1":
-  version: 2.5.1
-  resolution: "@opentelemetry/core@npm:2.5.1"
-  dependencies:
-    "@opentelemetry/semantic-conventions": "npm:^1.29.0"
-  peerDependencies:
-    "@opentelemetry/api": ">=1.0.0 <1.10.0"
-  checksum: 10c0/cbaf36953364d1295ef2ff4587c3f99eca121c7c2dbd2553699100ccbd91017f20fb1a710ac76fad832d9762dc98ae009ce0e96ab8fb00e5b539dc401d57f217
+  checksum: 10c0/35b8a464b359a0699fcbcea8c11a883f0f634ee7638719b89fa0c0cbbaaa38c57db22e9ac19ffb15ce18014751dc7db11a26d7fb6ad6259f89a26bdc4d167e4b
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1365
Fixes SOU-1358
Fixes SOU-1359

Addresses CVE-2026-54285 (GHSA-8988-4f7v-96qf) — unbounded memory allocation in `@opentelemetry/core`'s W3C Baggage `extract()` path. The advisory affects **all versions `< 2.8.0`**.

## Why a `resolutions` override

`@opentelemetry/core` is a transitive dependency requested at several **exact pins** (`2.5.0`, `2.5.1`, `2.2.0`, `2.0.1`) and ranges (`^2.5.1`, `^2.0.0`) via Sentry, the OpenTelemetry instrumentation packages, and PostHog. A `yarn up -R @opentelemetry/core` refresh moves the caret ranges to `2.8.0` but cannot get past the exact pins (e.g. `@opentelemetry/instrumentation-http@0.211.0` pins `@opentelemetry/core@2.5.0`).

Since every requested version is in the affected range, this adds a root `resolutions` override pinning `@opentelemetry/core` to `^2.8.0`, consistent with the existing `@opentelemetry/resources` override. After the change, `yarn why @opentelemetry/core` collapses to a single `2.8.0` instance, so Dependabot alert [#235](https://github.com/sourcebot-dev/sourcebot/security/dependabot/235) will clear.

## Note on duplicate issues

SOU-1358, SOU-1359, and SOU-1365 are all the same CVE against the same package (all tied to Dependabot alert #235). Prior PRs #1340/#1341/#1343 used this identical fix but were closed as mutual duplicates, so nothing ever merged and `main` still shipped the vulnerable versions. This single PR resolves all three.

## Verification

- `yarn install` clean; `yarn why @opentelemetry/core` → single `2.8.0` instance, no `< 2.8.0` requesters remain.
- No direct `@opentelemetry/core` imports in app source (purely transitive).
- `@sourcebot/backend` (the flagged Sentry → instrumentation-http → core path) builds clean with `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a bundled telemetry-related dependency to a newer version.
  * Added a changelog entry documenting the update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->