### PR TITLE
fix(backend): decode percent-encoded repo names for generic Git URLs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintained the sidebar scroll position when navigating between chats instead of resetting to the top. [#1411](https://github.com/sourcebot-dev/sourcebot/pull/1411)
 - Upgraded `nodemailer` to `^9.0.1`. [#1356](https://github.com/sourcebot-dev/sourcebot/pull/1356)
 - Upgraded `@opentelemetry/core` to `^2.8.0`. [#1413](https://github.com/sourcebot-dev/sourcebot/pull/1413)
+- Decoded percent-encoded characters in repo names derived from generic Git URLs, so direct URLs match the file-based behavior. [#1415](https://github.com/sourcebot-dev/sourcebot/pull/1415)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/backend/src/repoCompileUtils.test.ts
+++ b/packages/backend/src/repoCompileUtils.test.ts
@@ -255,8 +255,26 @@ describe('compileGenericGitHostConfig_url', () => {
 
         expect(result.repoData).toHaveLength(1);
         expect(result.repoData[0].name).toBe('github.com/test/repo');
-        
+
         const metadata = result.repoData[0].metadata as { gitConfig?: Record<string, string> };
         expect(metadata.gitConfig!['zoekt.name']).toBe('github.com/test/repo');
+    });
+
+    test('should decode percent-encoded characters in the repo name', async () => {
+        mockedIsUrlAValidGitRepo.mockResolvedValue(true);
+
+        const config = {
+            type: 'git' as const,
+            url: 'https://github.com/test/Project%20Name%20With%20Spaces.git',
+        };
+
+        const result = await compileGenericGitHostConfig_url(config, 1);
+
+        expect(result.repoData).toHaveLength(1);
+        expect(result.repoData[0].name).toBe('github.com/test/Project Name With Spaces');
+        expect(result.repoData[0].displayName).toBe('github.com/test/Project Name With Spaces');
+
+        const metadata = result.repoData[0].metadata as { gitConfig?: Record<string, string> };
+        expect(metadata.gitConfig!['zoekt.name']).toBe('github.com/test/Project Name With Spaces');
     });
 });

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -721,9 +721,11 @@ export const compileGenericGitHostConfig_url = async (
         }
     }
 
+    // Decode URL-encoded characters (e.g., %20 -> space) to ensure consistent repo names
+    const decodedPathname = decodeURIComponent(remoteUrl.pathname);
     // @note: matches the naming here:
     // https://github.com/sourcebot-dev/zoekt/blob/main/gitindex/index.go#L293
-    const repoName = path.join(remoteUrl.host, remoteUrl.pathname.replace(/\.git$/, ''));
+    const repoName = path.join(remoteUrl.host, decodedPathname.replace(/\.git$/, ''));
 
     const repo: RepoData = {
         external_codeHostType: 'genericGitHost',


### PR DESCRIPTION
Fixes #1384

## Problem

A generic Git connection pointing directly at an HTTP(S) remote whose path contains encoded characters (e.g. `https://github.com/test/Project%20Name%20With%20Spaces.git`) stores the repo name with the encoding intact — `github.com/test/Project%20Name%20With%20Spaces` — in `name`, `displayName`, and the zoekt metadata.

`compileGenericGitHostConfig_url` derives the name from `remoteUrl.pathname` without decoding, while the file-origin path (`compileGenericGitHostConfig_file`) already calls `decodeURIComponent`. So the **same remote** produces different Sourcebot/zoekt identifiers depending on whether it's configured as a direct URL or discovered from a local repository origin.

(Re: @brendan-kellam's question on the issue — that inconsistency across the two code paths is the concrete impact.)

## Fix

Decode `remoteUrl.pathname` in `compileGenericGitHostConfig_url` before building the name, mirroring the existing file-origin behavior.

## Tests

Added a `compileGenericGitHostConfig_url` case asserting a `%20`-encoded URL yields `github.com/test/Project Name With Spaces` in `name`, `displayName`, and `zoekt.name` — matching the existing `_file` test. `tsc --noEmit` is clean for the backend package.

(Note: the repo's generic-git `_url` tests assert forward-slash-joined names and only pass on POSIX CI, since `path.join` uses the platform separator; they fail identically on Windows before this change. The decode logic itself is platform-independent.)