### PR TITLE
fix(backend): don't crash Gitea sync when a repo fetch returns a null body

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintained the sidebar scroll position when navigating between chats instead of resetting to the top. [#1411](https://github.com/sourcebot-dev/sourcebot/pull/1411)
 - Upgraded `nodemailer` to `^9.0.1`. [#1356](https://github.com/sourcebot-dev/sourcebot/pull/1356)
 - Upgraded `@opentelemetry/core` to `^2.8.0`. [#1413](https://github.com/sourcebot-dev/sourcebot/pull/1413)
+- Prevented a Gitea connection sync from crashing when a single repository fetch returns an empty response body; the repo is now skipped with a warning. [#1416](https://github.com/sourcebot-dev/sourcebot/pull/1416)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/backend/src/gitea.test.ts
+++ b/packages/backend/src/gitea.test.ts
@@ -1,0 +1,58 @@
+import { expect, test, vi, beforeEach } from 'vitest';
+
+const repoGet = vi.fn();
+
+vi.mock('gitea-js', () => ({
+    giteaApi: () => ({
+        repos: { repoGet },
+        orgs: { orgListRepos: vi.fn() },
+        users: { userListRepos: vi.fn() },
+    }),
+}));
+
+vi.mock('cross-fetch', () => ({ default: vi.fn() }));
+
+vi.mock('@sourcebot/shared', async (importOriginal) => ({
+    ...(await importOriginal<typeof import('@sourcebot/shared')>()),
+    getTokenFromConfig: vi.fn(async () => 'token'),
+}));
+
+import { getGiteaReposFromConfig } from './gitea';
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+test('a repo whose fetch returns a null body is skipped with a warning instead of crashing', async () => {
+    repoGet.mockResolvedValue({
+        data: null,
+        error: { message: 'Premature close', code: 'ERR_STREAM_PREMATURE_CLOSE' },
+    });
+
+    const result = await getGiteaReposFromConfig({
+        type: 'gitea',
+        url: 'https://gitea.example.com',
+        token: { env: 'GITEA_TOKEN' },
+        repos: ['org/broken-repo'],
+    } as never);
+
+    expect(result.repos).toHaveLength(0);
+    expect(result.warnings.some(w => w.includes('broken-repo'))).toBe(true);
+});
+
+test('a repo with a valid body is returned', async () => {
+    repoGet.mockResolvedValue({
+        data: { id: 1, full_name: 'org/good-repo' },
+        error: null,
+    });
+
+    const result = await getGiteaReposFromConfig({
+        type: 'gitea',
+        url: 'https://gitea.example.com',
+        token: { env: 'GITEA_TOKEN' },
+        repos: ['org/good-repo'],
+    } as never);
+
+    expect(result.repos).toHaveLength(1);
+    expect(result.repos[0].full_name).toBe('org/good-repo');
+});

--- a/packages/backend/src/gitea.ts
+++ b/packages/backend/src/gitea.ts
@@ -49,10 +49,9 @@ export const getGiteaReposFromConfig = async (config: GiteaConnectionConfig) => 
         allWarnings = allWarnings.concat(warnings);
     }
     
-    allRepos = allRepos.filter(repo => repo.full_name !== undefined);
     allRepos = allRepos.filter(repo => {
-        if (repo.full_name === undefined) {
-            logger.warn(`Repository with undefined full_name found: repoId=${repo.id}`);
+        if (repo === null || repo === undefined || repo.full_name === undefined) {
+            logger.warn(`Skipping Gitea repository with missing data: repoId=${repo?.id}`);
             return false;
         }
         return true;
@@ -207,6 +206,15 @@ const getRepos = async <T>(repoList: string[], api: Api<T>) => {
             const { durationMs, data: response } = await measure(() =>
                 api.repos.repoGet(owner, repoName),
             );
+
+            if (!response.data) {
+                const warning = `Failed to fetch repository ${repo}: ${response.error?.message ?? 'empty response body'}`;
+                logger.warn(warning);
+                return {
+                    type: 'warning' as const,
+                    warning
+                };
+            }
 
             logger.debug(`Found repo ${repo} in ${durationMs}ms.`);
             return {


### PR DESCRIPTION
Fixes #1404

## Problem

Syncing repositories from a (self-hosted) Gitea instance can crash the entire connection sync with:

```
Cannot read properties of null (reading 'full_name')
```

When `api.repos.repoGet()` fails while reading the response body (e.g. `ERR_STREAM_PREMATURE_CLOSE`), `gitea-js` does not throw — it resolves with `{ data: null, error: {...} }`. In `getRepos` (`packages/backend/src/gitea.ts`) that response is wrapped as `data: [response.data]`, so `null` is pushed into `allRepos`. The top-level `allRepos.filter(repo => repo.full_name !== undefined)` then dereferences `null.full_name` and fails the whole sync — one transient per-repo error takes down every repo in the connection.

## Fix

- In `getRepos`, if `response.data` is null, emit a per-repo warning (mirroring the existing 404 handling) instead of returning a null "valid" repo, so a single failed fetch is skipped and the rest of the connection still syncs.
- Harden the top-level filter to also drop `null`/`undefined` entries defensively, and collapse the redundant duplicate `full_name` filter into one.

This doesn't attempt the underlying stream workaround (the reporter's `Accept-Encoding: identity` patch) — that's a separate networking concern; this PR makes the sync resilient to the failure rather than papering over the transport.

## Tests

Added `gitea.test.ts`:
- a repo whose fetch returns a null body is skipped with a warning (previously crashed);
- a repo with a valid body is returned normally.

Both pass. `tsc --noEmit` is clean for the backend package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented Gitea sync crashes when a repository fetch returns no data.
  * Repositories with missing details are now skipped with a warning instead of causing failures.
  * Improved handling of invalid repository responses so only valid repositories are included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->