### PR TITLE
fix(web): scope file-search recents by revision

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Maintained the sidebar scroll position when navigating between chats instead of resetting to the top. [#1411](https://github.com/sourcebot-dev/sourcebot/pull/1411)
 - Upgraded `nodemailer` to `^9.0.1`. [#1356](https://github.com/sourcebot-dev/sourcebot/pull/1356)
 - Upgraded `@opentelemetry/core` to `^2.8.0`. [#1413](https://github.com/sourcebot-dev/sourcebot/pull/1413)
+- Scoped browse file-search recents by revision so recently opened files no longer leak across branches. [#1417](https://github.com/sourcebot-dev/sourcebot/pull/1417)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
+++ b/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
@@ -35,7 +35,7 @@ export const FileSearchCommandDialog = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const { navigateToPath } = useBrowseNavigation();
 
-    const [recentlyOpened, setRecentlyOpened] = useLocalStorage<FileTreeItem[]>(`recentlyOpenedFiles-${repoName}`, []);
+    const [recentlyOpened, setRecentlyOpened] = useLocalStorage<FileTreeItem[]>(`recentlyOpenedFiles-${repoName}@${revisionName ?? 'HEAD'}`, []);
 
     useHotkeys("mod+p", (event) => {
         event.preventDefault();


### PR DESCRIPTION
Fixes #1387

## Problem

The browse file-search dialog stores recently opened files under `recentlyOpenedFiles-${repoName}` — keyed by repository only. Switching branches/revisions in the same repo still shows recents from the other revision, and selecting one navigates with the current revision, which can point at a path that doesn't exist there (confusing dead-end navigation).

## Fix

`revisionName` is already available from `useBrowseParams()` in the same component, so scope the localStorage key by revision as well: `recentlyOpenedFiles-${repoName}@${revisionName ?? 'HEAD'}`. The `?? 'HEAD'` default matches how the rest of browse (`useBrowseNavigation`, `fileTreePanel`) resolves the default revision, so the default-branch recents key stays stable.

One-line change in `fileSearchCommandDialog.tsx`; `tsc --noEmit` is clean for the web package.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Recently opened files in file search are now scoped to the current revision, preventing items from showing up across branches.
  * The file search recents list now stays aligned with the active revision for a more accurate browsing experience.
* **Documentation**
  * Updated the changelog with the latest fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->