### PR TITLE
fix(ci): pass --no-workspaces-update to npm version in setup-sourcebot release

### DIFF
--- a/.github/workflows/release-setup-sourcebot.yml
+++ b/.github/workflows/release-setup-sourcebot.yml
@@ -72,7 +72,7 @@ jobs:
           # Bump packages/setupWizard/package.json only. --no-git-tag-version
           # writes the new version without creating a commit or tag (we do that
           # ourselves, with a release-specific tag, further down).
-          npm version "${{ inputs.bump_type }}" --no-git-tag-version
+          npm version "${{ inputs.bump_type }}" --no-git-tag-version --no-workspaces-update
           VERSION=$(node -p "require('./package.json').version")
           echo "Bumped setup-sourcebot to $VERSION"
           echo "version=$VERSION" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow to handle version bumps more consistently in workspace-based projects.
  * Reduced unnecessary workspace metadata updates during version calculation, helping keep release metadata cleaner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->