### PR TITLE
fix(setupWizard): add repository field for npm publish provenance

### DIFF
--- a/packages/setupWizard/package.json
+++ b/packages/setupWizard/package.json
@@ -3,6 +3,11 @@
     "version": "0.1.5",
     "description": "CLI wizard for creating a Sourcebot configuration.",
     "type": "module",
+    "repository": {
+        "type": "git",
+        "url": "git+https://github.com/sourcebot-dev/sourcebot.git",
+        "directory": "packages/setupWizard"
+    },
     "bin": "./dist/index.js",
     "scripts": {
         "build": "tsc",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added repository metadata for the setup wizard package, including version control type, source location, and package directory information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->