### PR TITLE
fix(ci): map @react-grab and element-source licenses to MIT in license audit

### DIFF
--- a/scripts/npmLicenseMap.json
+++ b/scripts/npmLicenseMap.json
@@ -1,1 +1,5 @@
-{}
+{
+    "@react-grab/cli": { "old": "UNKNOWN", "new": "MIT" },
+    "@react-grab/mcp": { "old": "UNKNOWN", "new": "MIT" },
+    "element-source": { "old": "UNKNOWN", "new": "MIT" }
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the project’s license mapping to include license information for several packages, replacing unknown entries with MIT values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->