### PR TITLE
docs: point Docker image references at docker.sourcebot.dev

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   sourcebot:
-    image: ghcr.io/sourcebot-dev/sourcebot:latest
+    image: docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
     pull_policy: always
     user: sourcebot
     restart: always

--- a/docs/docs/activating-a-subscription.mdx
+++ b/docs/docs/activating-a-subscription.mdx
@@ -29,7 +29,7 @@ If you'd like to increase the number of seats on your Sourcebot deployment you m
 docker run \
     -e SOURCEBOT_EE_LICENSE_KEY=<your-license-key> \
     /* additional args */ \
-    ghcr.io/sourcebot-dev/sourcebot:latest
+    docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 
 ## FAQ

--- a/docs/docs/configuration/config-file.mdx
+++ b/docs/docs/configuration/config-file.mdx
@@ -14,7 +14,7 @@ docker run \
     -v $(pwd)/config.json:/data/config.json \
     -e CONFIG_PATH=/data/config.json \
     ... \ # other options
-    ghcr.io/sourcebot-dev/sourcebot:latest
+    docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 
 The config file tells Sourcebot which repos to index, what language models to use, and various other settings as defined in the [schema](#config-file-schema).

--- a/docs/docs/connections/ado-cloud.mdx
+++ b/docs/docs/connections/ado-cloud.mdx
@@ -113,7 +113,7 @@ Next, provide the access [token](/docs/configuration/config-file#tokens) via an 
         docker run \
             -e ADO_TOKEN=<PAT> \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/ado-server.mdx
+++ b/docs/docs/connections/ado-server.mdx
@@ -127,7 +127,7 @@ Next, provide the access [token](/docs/configuration/config-file#tokens) via an 
         docker run \
             -e ADO_TOKEN=<PAT> \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/bitbucket-cloud.mdx
+++ b/docs/docs/connections/bitbucket-cloud.mdx
@@ -116,7 +116,7 @@ In order to index private repositories, you'll need to provide authentication cr
       docker run \
           -e BITBUCKET_TOKEN=<API_TOKEN> \
           /* additional args */ \
-          ghcr.io/sourcebot-dev/sourcebot:latest
+          docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
       ```
     </Tab>
     <Tab title="Access Token">
@@ -147,7 +147,7 @@ In order to index private repositories, you'll need to provide authentication cr
       docker run \
           -e BITBUCKET_TOKEN=<ACCESS_TOKEN> \
           /* additional args */ \
-          ghcr.io/sourcebot-dev/sourcebot:latest
+          docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
       ```
     </Tab>
     <Tab title="App Password">
@@ -184,7 +184,7 @@ In order to index private repositories, you'll need to provide authentication cr
       docker run \
           -e BITBUCKET_TOKEN=<APP_PASSWORD> \
           /* additional args */ \
-          ghcr.io/sourcebot-dev/sourcebot:latest
+          docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
       ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/bitbucket-data-center.mdx
+++ b/docs/docs/connections/bitbucket-data-center.mdx
@@ -118,7 +118,7 @@ In order to index private repositories, you'll need to provide a [HTTP Access To
         docker run \
             -e BITBUCKET_TOKEN=<ACCESS_TOKEN> \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
     <Tab title="Project / repository token">
@@ -151,7 +151,7 @@ In order to index private repositories, you'll need to provide a [HTTP Access To
         docker run \
             -e BITBUCKET_TOKEN=<ACCESS_TOKEN> \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/gitea.mdx
+++ b/docs/docs/connections/gitea.mdx
@@ -107,7 +107,7 @@ Next, provide the access token via an environment variable [token](/docs/configu
         docker run \
             -e GITEA_TOKEN=<PAT> \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/gitlab.mdx
+++ b/docs/docs/connections/gitlab.mdx
@@ -143,7 +143,7 @@ Next, provide the PAT via an environment variable [token](/docs/configuration/co
             docker run \
                 -e GITLAB_TOKEN=<PAT> \
                 /* additional args */ \
-                ghcr.io/sourcebot-dev/sourcebot:latest
+                docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Tab>
 </Tabs>

--- a/docs/docs/connections/local-repos.mdx
+++ b/docs/docs/connections/local-repos.mdx
@@ -35,7 +35,7 @@ To get Sourcebot to index these repositories:
         docker run \
             -v $(pwd)/repos:/repos:ro \
             /* additional args */ \
-            ghcr.io/sourcebot-dev/sourcebot:latest
+            docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
         ```
     </Step>
 

--- a/docs/docs/features/agents/review-agent.mdx
+++ b/docs/docs/features/agents/review-agent.mdx
@@ -56,7 +56,7 @@ If you have multiple models configured, set `REVIEW_AGENT_MODEL` to the `display
         ```yaml
         services:
             sourcebot:
-                image: ghcr.io/sourcebot-dev/sourcebot:latest
+                image: docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
                 pull_policy: always
                 container_name: sourcebot
                 ports:
@@ -112,7 +112,7 @@ If you have multiple models configured, set `REVIEW_AGENT_MODEL` to the `display
         ```yaml
         services:
             sourcebot:
-                image: ghcr.io/sourcebot-dev/sourcebot:latest
+                image: docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
                 pull_policy: always
                 container_name: sourcebot
                 ports:

--- a/docs/docs/features/permission-syncing.mdx
+++ b/docs/docs/features/permission-syncing.mdx
@@ -24,7 +24,7 @@ Permission syncing can be enabled by setting the `PERMISSION_SYNC_ENABLED` envir
 docker run \
     -e PERMISSION_SYNC_ENABLED=true \
     /* additional args */ \
-    ghcr.io/sourcebot-dev/sourcebot:latest
+    docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 
 <Warning>

--- a/docs/docs/misc/telemetry.mdx
+++ b/docs/docs/misc/telemetry.mdx
@@ -12,7 +12,7 @@ If you'd like to disable all telemetry, you can do so by setting the environment
 docker run \
   -e SOURCEBOT_TELEMETRY_DISABLED=true \
   /* additional args */ \
-  ghcr.io/sourcebot-dev/sourcebot:latest
+  docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 
 If you disabled telemetry correctly, you'll see the following log when starting Sourcebot:

--- a/docs/docs/upgrade/v4-to-v5-guide.mdx
+++ b/docs/docs/upgrade/v4-to-v5-guide.mdx
@@ -106,7 +106,7 @@ pg_restore -U postgres -d postgres --no-owner ./sourcebot.dump
 docker run \
   -e DATABASE_URL='postgresql://your-user:your-password@your-postgres-host:5432/postgres' \
   # ... your other flags
-  ghcr.io/sourcebot-dev/sourcebot:latest
+  docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 </Expandable>
 
@@ -123,7 +123,7 @@ Redis only holds transient job-queue data, so there is nothing to migrate. You j
 docker run \
   -e REDIS_URL='redis://your-redis-host:6379' \
   # ... your other flags
-  ghcr.io/sourcebot-dev/sourcebot:latest
+  docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 </Expandable>
 
@@ -164,7 +164,7 @@ docker run \
   -e SOURCEBOT_ENCRYPTION_KEY='<value from .secret>' \
   -e AUTH_SECRET='<value from .authjs-secret>' \
   # ... your other flags
-  ghcr.io/sourcebot-dev/sourcebot:latest
+  docker.sourcebot.dev/sourcebot-dev/sourcebot:latest
 ```
 
 3. Delete the plaintext files from the data volume so the secrets are no longer stored on disk:
@@ -279,7 +279,7 @@ helm upgrade sourcebot sourcebot/sourcebot \
 If you'd rather not upgrade to v5, you can keep using v4 indefinitely by pinning your deployment to the final v4 release:
 
 ```bash
-ghcr.io/sourcebot-dev/sourcebot:v4.17.4
+docker.sourcebot.dev/sourcebot-dev/sourcebot:v4.17.4
 ```
 
 ## Troubleshooting


### PR DESCRIPTION
Replaces `ghcr.io/sourcebot-dev/sourcebot` with `docker.sourcebot.dev/sourcebot-dev/sourcebot` across user-facing pull references: `docker-compose.yml` and the docs install/run examples (connections, upgrade guide, telemetry, subscription, review-agent, permission-syncing, config-file).

**Scope:** pull references only. The CI publish pipeline (`_build.yml`, `_merge.yml`, `release-prod.yml`, `vulnerability-triage.yml`) still logs in and pushes to `ghcr.io` and is intentionally unchanged. Third-party references (`ghcr.io/devcontainers/*`, vendored `ghcr.io/sourcegraph/zoekt`) are left as-is.

> Assumes `docker.sourcebot.dev/sourcebot-dev/sourcebot` is live and serving the image (proxy/CNAME in front of ghcr.io).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and sample compose image strings only; no application or CI publish logic changes in this diff.
> 
> **Overview**
> Self-hosters are steered to **`docker.sourcebot.dev/sourcebot-dev/sourcebot`** for pulls instead of **`ghcr.io/sourcebot-dev/sourcebot`**. The official **`docker-compose.yml`** `sourcebot` service image is updated the same way.
> 
> Docs examples that end with a `docker run` image (config file, connections, subscription, telemetry, permission syncing, review agent, v4→v5 upgrade—including the **v4.17.4** pin) are updated to the new registry path. **CI publish targets and other third-party `ghcr.io` references are out of scope** for this diff.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 14e9e44a28018527503e24c49f2f0cac13ad5e9a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Docker commands and configuration examples to use the Sourcebot container image from the new registry.
  * Updated setup instructions across subscription activation, repository connections, authentication, telemetry, permission syncing, and agent configuration.
  * Updated v4-to-v5 upgrade commands, including version-pinned image references.

* **Chores**
  * Updated the default container image used by the Docker Compose configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->