### PR TITLE
feat(web): enable Sentry node and browser profiling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added image attachments to Ask Sourcebot, letting users attach images to a chat message when the selected model supports image input. [#1375](https://github.com/sourcebot-dev/sourcebot/pull/1375)
 - Added deployment system resource stats (CPU cores + cgroup quota, host + container memory, disk, load average) to the service ping, so resource issues can be diagnosed more quickly. [#1424](https://github.com/sourcebot-dev/sourcebot/pull/1424)
 - Added a `robots.txt` that disallows crawlers, with an allowlist for link-preview bots so shared links keep their OpenGraph previews. [#1426](https://github.com/sourcebot-dev/sourcebot/pull/1426)
-- Added Sentry node and browser profiling to the web app. [#1431](https://github.com/sourcebot-dev/sourcebot/pull/1431)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added image attachments to Ask Sourcebot, letting users attach images to a chat message when the selected model supports image input. [#1375](https://github.com/sourcebot-dev/sourcebot/pull/1375)
 - Added deployment system resource stats (CPU cores + cgroup quota, host + container memory, disk, load average) to the service ping, so resource issues can be diagnosed more quickly. [#1424](https://github.com/sourcebot-dev/sourcebot/pull/1424)
 - Added a `robots.txt` that disallows crawlers, with an allowlist for link-preview bots so shared links keep their OpenGraph previews. [#1426](https://github.com/sourcebot-dev/sourcebot/pull/1426)
+- Added Sentry node and browser profiling to the web app. [#1431](https://github.com/sourcebot-dev/sourcebot/pull/1431)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/packages/web/next.config.mjs
+++ b/packages/web/next.config.mjs
@@ -104,6 +104,13 @@ const nextConfig = {
                         key: "Content-Security-Policy",
                         value: "frame-ancestors 'self'",
                     },
+                    // Opts the document into the JS Self-Profiling API, which Sentry's
+                    // browser profiling integration needs in order to start a profiler.
+                    // @see: https://docs.sentry.io/platforms/javascript/guides/nextjs/profiling/browser-profiling/
+                    {
+                        key: "Document-Policy",
+                        value: "js-profiling",
+                    },
                 ],
             },
         ];

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -102,6 +102,7 @@
     "@replit/codemirror-lang-svelte": "^6.0.0",
     "@replit/codemirror-vim": "^6.2.1",
     "@sentry/nextjs": "^10.40.0",
+    "@sentry/profiling-node": "^10.40.0",
     "@shopify/lang-jsonc": "^1.0.0",
     "@sourcebot/codemirror-lang-tcl": "^1.0.13",
     "@sourcebot/db": "workspace:*",

--- a/packages/web/src/instrumentation-client.ts
+++ b/packages/web/src/instrumentation-client.ts
@@ -12,11 +12,14 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-
+        integrations: [
+            Sentry.browserProfilingIntegration(),
+        ],
         tracesSampleRate: 1.0,
-
-        // Setting this option to true will print useful information to the console while you're setting up Sentry.
-        debug: false,
+        // Evaluated once per `Sentry.init()`, i.e. once per page load.
+        profileSessionSampleRate: 1.0,
+        // Profile only while a sampled root span is active, rather than continuously.
+        profileLifecycle: 'trace',
     });
 } else {
     console.debug("[client] Sentry was not initialized");

--- a/packages/web/src/sentry.server.config.ts
+++ b/packages/web/src/sentry.server.config.ts
@@ -3,6 +3,7 @@
 // https://docs.sentry.io/platforms/javascript/guides/nextjs/
 
 import * as Sentry from "@sentry/nextjs";
+import { nodeProfilingIntegration } from "@sentry/profiling-node";
 import { createLogger } from "@sourcebot/shared";
 
 const logger = createLogger('sentry-server-config');
@@ -11,11 +12,14 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-
+        integrations: [
+            nodeProfilingIntegration(),
+        ],
         tracesSampleRate: 1.0,
-
-        // Setting this option to true will print useful information to the console while you're setting up Sentry.
-        debug: false,
+        // Evaluated once per `Sentry.init()`, i.e. once per server process.
+        profileSessionSampleRate: 1.0,
+        // Profile only while a sampled root span is active, rather than continuously.
+        profileLifecycle: 'trace',
     });
 } else {
     logger.debug("[server] Sentry was not initialized");

--- a/yarn.lock
+++ b/yarn.lock
@@ -9380,6 +9380,7 @@ __metadata:
     "@replit/codemirror-lang-svelte": "npm:^6.0.0"
     "@replit/codemirror-vim": "npm:^6.2.1"
     "@sentry/nextjs": "npm:^10.40.0"
+    "@sentry/profiling-node": "npm:^10.40.0"
     "@shopify/lang-jsonc": "npm:^1.0.0"
     "@sourcebot/codemirror-lang-tcl": "npm:^1.0.13"
     "@sourcebot/db": "workspace:*"


### PR DESCRIPTION
Enables Sentry profiling in the web app, on both the server and the browser.

## Changes

- Added `@sentry/profiling-node` to `packages/web`.
- `sentry.server.config.ts`: registered `nodeProfilingIntegration()`.
- `instrumentation-client.ts`: registered `Sentry.browserProfilingIntegration()`.
- Both set `profileSessionSampleRate: 1.0` and `profileLifecycle: 'trace'`, so a profiler runs only while a sampled root span is active rather than continuously.
- `next.config.mjs`: added a `Document-Policy: js-profiling` response header, which browser profiling requires in order to opt the document into the JS Self-Profiling API.

## Notes

**Version pinning.** `@sentry/profiling-node` is pinned to `^10.40.0` to match `@sentry/nextjs`, rather than the latest `10.64.0`. It depends on `@sentry/core` and `@sentry/node` at *exact* versions, so a newer minor would install a second copy of the SDK alongside the one `@sentry/nextjs` pulls in, and the profiler would register against a different global carrier and silently emit nothing. Verified the tree still resolves to a single `@sentry/core@10.40.0`. Moving to `10.64.0` would need a coordinated bump of `@sentry/nextjs` (web) and `@sentry/node` + `@sentry/profiling-node` (backend) together.

**No `serverExternalPackages` entry needed.** `@sentry/profiling-node` loads a native `.node` addon through a `require()` whose path is computed at runtime, which normally means it has to be marked external. Next.js already ships it in its built-in external list (`next/dist/lib/server-external-packages.jsonc`), so no config is required. Confirmed by building with and without an explicit entry: `instrumentation.js` hashed identically and the file trace was unchanged.

**`browserTracingIntegration` is not listed explicitly.** `@sentry/nextjs` pushes its own App Router-aware version into the default integrations, and passing `integrations` as an array merges with the defaults rather than replacing them. Listing the generic one would shadow it.

## Verification

- Ran the node profiler against a capturing transport: emits `["profile_chunk", "transaction"]` for a sampled span, confirming the native addon loads and `profileLifecycle: 'trace'` behaves as configured. With the option omitted (SDK default `'manual'`) only `["transaction"]` is emitted.
- `next build` passes, and `.next/standalone` traces the profiler plus all 28 prebuilt binaries, including the two `linux-*-musl-137` ones the `node:24-alpine` runtime image needs.
- Typecheck and lint clean on the touched files.

## Follow-up worth considering

Server-side `profileSessionSampleRate: 1.0` profiles every process. `app.sourcebot.dev` runs a single web replica whose event loop already saturates under `/browse` render bursts, so it may be worth dialing this down on the server. Browser profiling is client-side and costs nothing there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Server profiling uses a native addon at 100% session sampling alongside full trace sampling, which can add CPU/overhead on hot paths; changes are observability-only, not auth or data handling.
> 
> **Overview**
> Turns on **Sentry performance profiling** for the Next.js web app on both the **server** and **client**, tied to sampled traces instead of always-on profiling.
> 
> Server init registers **`nodeProfilingIntegration()`** (new **`@sentry/profiling-node`**, version-matched to **`@sentry/nextjs`**) with **`profileSessionSampleRate: 1.0`** and **`profileLifecycle: 'trace'`**. Client init adds **`browserProfilingIntegration()`** with the same profiling options. **`debug: false`** is dropped from both inits.
> 
> **`next.config.mjs`** adds a global **`Document-Policy: js-profiling`** header so browser profiling can use the JS Self-Profiling API.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a992a8064d9162d86239b6a12609bb7a2db05cca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added enhanced performance monitoring for web sessions.
  - Enabled browser and server-side profiling to provide deeper insight into application performance.
  - Expanded monitoring coverage across all application routes for more consistent diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->