### PR TITLE
feat: show not-found UI when an Ask GitHub repo doesn't exist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added image attachments to Ask Sourcebot, letting users attach images to a chat message when the selected model supports image input. [#1375](https://github.com/sourcebot-dev/sourcebot/pull/1375)
 - Added deployment system resource stats (CPU cores + cgroup quota, host + container memory, disk, load average) to the service ping, so resource issues can be diagnosed more quickly. [#1424](https://github.com/sourcebot-dev/sourcebot/pull/1424)
 - Added a `robots.txt` that disallows crawlers, with an allowlist for link-preview bots so shared links keep their OpenGraph previews. [#1426](https://github.com/sourcebot-dev/sourcebot/pull/1426)
-- [EE] Added a "repository not found" page to the experimental Ask GitHub repo flow (`/askgh`) shown when the repository doesn't exist on GitHub, instead of surfacing a generic error. [#1432](https://github.com/sourcebot-dev/sourcebot/pull/1432)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Added image attachments to Ask Sourcebot, letting users attach images to a chat message when the selected model supports image input. [#1375](https://github.com/sourcebot-dev/sourcebot/pull/1375)
 - Added deployment system resource stats (CPU cores + cgroup quota, host + container memory, disk, load average) to the service ping, so resource issues can be diagnosed more quickly. [#1424](https://github.com/sourcebot-dev/sourcebot/pull/1424)
 - Added a `robots.txt` that disallows crawlers, with an allowlist for link-preview bots so shared links keep their OpenGraph previews. [#1426](https://github.com/sourcebot-dev/sourcebot/pull/1426)
+- [EE] Added a "repository not found" page to the experimental Ask GitHub repo flow (`/askgh`) shown when the repository doesn't exist on GitHub, instead of surfacing a generic error. [#1432](https://github.com/sourcebot-dev/sourcebot/pull/1432)
 
 ### Fixed
 - Send anonymous server-side PostHog events as personless so unauthenticated requests don't inflate person counts. [#1367](https://github.com/sourcebot-dev/sourcebot/pull/1367)

--- a/packages/backend/src/api.ts
+++ b/packages/backend/src/api.ts
@@ -9,6 +9,7 @@ import { AccountPermissionSyncer } from './ee/accountPermissionSyncer.js';
 import { PromClient } from './promClient.js';
 import { RepoIndexManager } from './repoIndexManager.js';
 import { createGitHubRepoRecord } from './repoCompileUtils.js';
+import { isNotFound } from './errors.js';
 import { Octokit } from '@octokit/rest';
 import { SINGLE_TENANT_ORG_ID } from './constants.js';
 import z from 'zod';
@@ -150,10 +151,19 @@ export class Api {
         }
 
         const octokit = new Octokit();
-        const response = await octokit.rest.repos.get({
-            owner: parsed.data.owner,
-            repo: parsed.data.repo,
-        });
+        let response;
+        try {
+            response = await octokit.rest.repos.get({
+                owner: parsed.data.owner,
+                repo: parsed.data.repo,
+            });
+        } catch (error) {
+            if (isNotFound(error)) {
+                res.status(404).json({ error: 'Repository not found on GitHub' });
+                return;
+            }
+            throw error;
+        }
 
         const record = createGitHubRepoRecord({
             repo: response.data,

--- a/packages/backend/src/errors.ts
+++ b/packages/backend/src/errors.ts
@@ -27,4 +27,5 @@ const getStatus = (err: unknown): number | null => {
 
 export const isUnauthorized = (err: unknown): boolean => getStatus(err) === 401;
 export const isForbidden = (err: unknown): boolean => getStatus(err) === 403;
+export const isNotFound = (err: unknown): boolean => getStatus(err) === 404;
 export const isGone = (err: unknown): boolean => getStatus(err) === 410;

--- a/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/repoNotFound.tsx
+++ b/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/repoNotFound.tsx
@@ -1,0 +1,31 @@
+import { FileQuestion } from "lucide-react";
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+interface Props {
+    owner: string;
+    repo: string;
+}
+
+export function RepoNotFound({ owner, repo }: Props) {
+    return (
+        <div className="flex flex-col items-center justify-center min-h-screen p-4">
+            <FileQuestion className="w-12 h-12 text-muted-foreground mb-4" />
+            <h2 className="text-2xl font-semibold mb-2">
+                Repository not found
+            </h2>
+            <p className="text-muted-foreground text-center max-w-md">
+                We couldn&apos;t find{" "}
+                <span className="font-medium text-foreground">{owner}/{repo}</span>{" "}
+                on GitHub. It may not exist, or it might be private.
+            </p>
+            <Link
+                href="/"
+                className={cn(buttonVariants({ variant: "outline" }), "mt-6")}
+            >
+                Go back home
+            </Link>
+        </div>
+    );
+}

--- a/packages/web/src/app/(app)/askgh/[owner]/[repo]/page.tsx
+++ b/packages/web/src/app/(app)/askgh/[owner]/[repo]/page.tsx
@@ -1,10 +1,12 @@
 import { addGithubRepo } from "@/features/workerApi/actions";
 import { isServiceError } from "@/lib/utils";
-import { ServiceErrorException } from "@/lib/serviceError";
+import { ServiceError, ServiceErrorException } from "@/lib/serviceError";
+import { ErrorCode } from "@/lib/errorCodes";
 import { __unsafePrisma } from "@/prisma";
 import { getRepoInfo } from "./api";
 import { CustomSlateEditor } from "@/features/chat/customSlateEditor";
 import { RepoIndexedGuard } from "./components/repoIndexedGuard";
+import { RepoNotFound } from "./components/repoNotFound";
 import { LandingPage } from "./components/landingPage";
 import { getConfiguredLanguageModelsInfo } from "@/features/chat/utils.server";
 import { auth } from "@/auth";
@@ -27,7 +29,7 @@ export default async function GitHubRepoPage(props: PageProps) {
         return <ChatEntitlementMessage source="chat" returnPath={`/askgh/${owner}/${repo}`} />;
     }
     
-    const repoId = await (async () => {
+    const repoIdOrError = await (async (): Promise<number | ServiceError> => {
         // 1. Look up repo by owner/repo
         const displayName = `${owner}/${repo}`;
         const existingRepo = await __unsafePrisma.repo.findFirst({
@@ -46,11 +48,21 @@ export default async function GitHubRepoPage(props: PageProps) {
         const response = await addGithubRepo(owner, repo);
 
         if (isServiceError(response)) {
-            throw new ServiceErrorException(response);
+            return response;
         }
 
         return response.repoId;
     })();
+
+    if (isServiceError(repoIdOrError)) {
+        if (repoIdOrError.errorCode === ErrorCode.REPOSITORY_NOT_FOUND) {
+            return <RepoNotFound owner={owner} repo={repo} />;
+        }
+
+        throw new ServiceErrorException(repoIdOrError);
+    }
+
+    const repoId = repoIdOrError;
 
     const repoInfo = await getRepoInfo(repoId)
     const languageModels = await getConfiguredLanguageModelsInfo()

--- a/packages/web/src/features/workerApi/actions.ts
+++ b/packages/web/src/features/workerApi/actions.ts
@@ -1,7 +1,7 @@
 'use server';
 
 import { sew } from "@/middleware/sew";
-import { unexpectedError } from "@/lib/serviceError";
+import { repositoryNotFound, unexpectedError } from "@/lib/serviceError";
 import { withAuth, withOptionalAuth } from "@/middleware/withAuth";
 import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
 import { OrgRole } from "@sourcebot/db";
@@ -95,6 +95,9 @@ export const addGithubRepo = async (owner: string, repo: string) => sew(() =>
         });
 
         if (!response.ok) {
+            if (response.status === 404) {
+                return repositoryNotFound(`${owner}/${repo}`);
+            }
             return unexpectedError('Failed to add GitHub repo');
         }
 

--- a/packages/web/src/lib/serviceError.ts
+++ b/packages/web/src/lib/serviceError.ts
@@ -103,6 +103,14 @@ export const notFound = (message?: string): ServiceError => {
     }
 }
 
+export const repositoryNotFound = (repository: string): ServiceError => {
+    return {
+        statusCode: StatusCodes.NOT_FOUND,
+        errorCode: ErrorCode.REPOSITORY_NOT_FOUND,
+        message: `Repository "${repository}" was not found`,
+    }
+}
+
 export const userNotFound = (): ServiceError => {
     return {
         statusCode: StatusCodes.NOT_FOUND,


### PR DESCRIPTION
## Summary

When a repository doesn't exist on GitHub, the experimental Ask GitHub repo page (`/askgh/[owner]/[repo]`) previously threw a `ServiceErrorException`, surfacing the generic error boundary. It now renders a dedicated **"Repository not found"** page instead. Other failures (worker down, unexpected errors) still throw as before.

## The problem

The old code couldn't tell "repo doesn't exist" apart from any other failure. The backend threw the Octokit 404 into Express's default handler (→ HTTP 500), and the `addGithubRepo` action collapsed every non-OK response into a generic `unexpectedError`. So a dedicated not-found signal is plumbed through the stack.

## Changes

**Backend** (`packages/backend/src/`)
- `errors.ts` — added `isNotFound(err)` alongside the existing `isUnauthorized`/`isForbidden`/`isGone`, reusing the same `getStatus` helper.
- `api.ts` — `experimental_addGithubRepo` wraps the `octokit.rest.repos.get()` call in try/catch: a 404 returns `res.status(404)`, anything else re-throws (unchanged behavior).

**Web** (`packages/web/src/`)
- `lib/serviceError.ts` — added a `repositoryNotFound(repository)` helper using the already-defined `ErrorCode.REPOSITORY_NOT_FOUND` (previously an unused enum member).
- `features/workerApi/actions.ts` — `addGithubRepo` maps a 404 response to `repositoryNotFound(...)`; all other failures stay `unexpectedError`.
- `app/(app)/askgh/[owner]/[repo]/page.tsx` — returns the `ServiceError` from the repo-resolution block instead of throwing inside the IIFE; the page renders `<RepoNotFound>` when `errorCode === REPOSITORY_NOT_FOUND`, and only throws `ServiceErrorException` for everything else.
- `app/(app)/askgh/[owner]/[repo]/components/repoNotFound.tsx` — new server component styled to match `repoIndexedGuard.tsx`.

## Verification

- `tsc --noEmit` clean on both `@sourcebot/backend` and `@sourcebot/web` (no new errors in changed files).
- ESLint clean on all changed/new web files.
- Backend `errors.test.ts` passes (32/32).

Not driven end-to-end against a live stack (needs Postgres/Redis/worker/web + a real GitHub call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Experimental Ask GitHub UX and error mapping only; no auth, billing, or core indexing behavior changes beyond clearer 404 handling.
> 
> **Overview**
> Ask GitHub (`/askgh/[owner]/[repo]`) now shows a dedicated **Repository not found** page when GitHub has no such repo, instead of hitting the generic error boundary.
> 
> The worker **`experimental/add-github-repo`** path maps Octokit **404** to HTTP **404** via new **`isNotFound`**; **`addGithubRepo`** turns that into **`repositoryNotFound`** (`ErrorCode.REPOSITORY_NOT_FOUND`). The page resolves repo id as **`number | ServiceError`** and renders **`RepoNotFound`** only for that code; other failures still throw **`ServiceErrorException`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8323ed6948f0bc9ff3d44f56bdd743267b5c61d1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an experimental “Repository not found” page for Ask GitHub when a requested repository does not exist.
  * The page identifies the missing repository and provides a link back to the home page.

* **Bug Fixes**
  * GitHub repository lookup failures now return a clear not-found message instead of a generic error.
  * Other unexpected errors continue to be handled normally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->