### PR TITLE
fix(web): lazy-load search code preview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Fixed connector setup dialogs to add scrolling when connector setup content goes out of view.
 - Fixed Gitea sync failing with `ERR_STREAM_PREMATURE_CLOSE` by forcing identity encoding on the Gitea API fetch and guarding against null repository responses. [#1405](https://github.com/sourcebot-dev/sourcebot/pull/1405)
 - [EE] Fixed Ask connector MCP tools with provider-invalid names failing to run by sanitizing model-facing tool names while preserving raw names in the UI.
+- Lazy-loaded the search result code preview and pre-warmed common language parsers to improve initial search page load performance. [#1433](https://github.com/sourcebot-dev/sourcebot/pull/1433)
 
 ## [5.0.4] - 2026-06-18
 

--- a/packages/web/src/app/(app)/search/components/searchResultsPage.tsx
+++ b/packages/web/src/app/(app)/search/components/searchResultsPage.tsx
@@ -15,13 +15,14 @@ import { RepositoryInfo, SearchResultFile, SearchStats } from "@/features/search
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useNonEmptyQueryParam } from "@/hooks/useNonEmptyQueryParam";
 import { useSearchHistory } from "@/hooks/useSearchHistory";
+import { getCodeParserByLanguageName } from "@/lib/codeHighlight";
 import { ServiceErrorException } from "@/lib/serviceError";
 import { SearchQueryParams } from "@/lib/types";
 import { createPathWithQueryParams } from "@/lib/utils";
 import { InfoCircledIcon } from "@radix-ui/react-icons";
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { AlertTriangleIcon, BugIcon, FilterIcon, RefreshCwIcon } from "lucide-react";
-import { Session } from "next-auth";
+import dynamic from "next/dynamic";
 import { useRouter } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
@@ -29,10 +30,26 @@ import { ImperativePanelHandle } from "react-resizable-panels";
 import { CopyIconButton } from "../../components/copyIconButton";
 import { SearchBar } from "../../components/searchBar";
 import { useStreamedSearch } from "../useStreamedSearch";
-import { CodePreviewPanel } from "./codePreviewPanel";
 import { FilterPanel } from "./filterPanel";
 import { useFilteredMatches } from "./filterPanel/useFilterMatches";
 import { SearchResultsPanel, SearchResultsPanelHandle } from "./searchResultsPanel";
+
+const CodePreviewPanel = dynamic(
+    () => import("./codePreviewPanel").then(module => ({ default: module.CodePreviewPanel })),
+    { ssr: false },
+);
+
+const commonSearchResultLanguages = [
+    "TypeScript",
+    "JavaScript",
+    "Python",
+    "Go",
+    "Rust",
+    "Java",
+    "C++",
+    "C#",
+    "JSON",
+];
 
 interface SearchResultsPageProps {
     searchQuery: string;
@@ -53,6 +70,12 @@ export const SearchResultsPage = ({
     const { setSearchHistory } = useSearchHistory();
     const { toast } = useToast();
     const captureEvent = useCaptureEvent();
+
+    useEffect(() => {
+        void Promise.allSettled(
+            commonSearchResultLanguages.map(getCodeParserByLanguageName),
+        );
+    }, []);
 
     // Encodes the number of matches to return in the search response.
     const _maxMatchCount = parseInt(useNonEmptyQueryParam(SearchQueryParams.matches) ?? `${defaultMaxMatchCount}`);


### PR DESCRIPTION
## Summary

- lazy-load `CodePreviewPanel` so CodeMirror is excluded from the initial search-page module graph
- pre-warm common language parser chunks when the search results page mounts
- remove an unused `Session` import from the touched component

## Validation

- `yarn workspace @sourcebot/web eslint src/app/\\(app\\)/search/components/searchResultsPage.tsx src/lib/codeHighlight.ts`
- `yarn workspace @sourcebot/web tsc --noEmit` *(blocked by pre-existing type errors in unrelated test fixtures)*
- `yarn workspace @sourcebot/web build` *(Turbopack compilation stalled without output and was stopped)*

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only bundle-splitting and background parser prefetch on the search UI; no auth, API, or data-path changes.
> 
> **Overview**
> Improves **initial search page load** by deferring heavy editor/highlighting code until it is needed, while still warming likely language parsers in the background.
> 
> `CodePreviewPanel` is now loaded with **`next/dynamic`** (`ssr: false`) instead of a static import, so **CodeMirror and the preview panel** stay out of the first paint bundle until a user opens a file preview. On mount, the page **pre-fetches Lezer parsers** for a fixed list of common languages (TypeScript, JavaScript, Python, Go, Rust, Java, C++, C#, JSON) via `getCodeParserByLanguageName`, so opening a preview is less likely to wait on parser chunks. An unused **`Session`** import was removed from the search results page. **CHANGELOG** documents the performance fix ([#1433](https://github.com/sourcebot-dev/sourcebot/pull/1433)).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4a5c1a7f0d61fdf4289ab221c82ccf5ed267b024. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved initial search page loading by loading code previews on demand.
  - Preloaded common programming-language parsers to make code previews appear faster.
- **Documentation**
  - Added an unreleased changelog entry documenting the search performance improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->