### PR TITLE
fix: show error state when repository status fails to load

### DIFF
--- a/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/repoIndexedGuard.tsx
+++ b/packages/web/src/app/(app)/askgh/[owner]/[repo]/components/repoIndexedGuard.tsx
@@ -1,9 +1,10 @@
 'use client';
 
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { ServiceError } from "@/lib/serviceError";
 import { unwrapServiceError } from "@/lib/utils";
 import { useQuery } from "@tanstack/react-query";
-import { Loader2 } from "lucide-react";
+import { AlertCircle, Loader2 } from "lucide-react";
 import { usePrevious } from "@uidotdev/usehooks";
 import { useEffect } from "react";
 import { useBrowserNotification } from "@/hooks/useBrowserNotification";
@@ -61,8 +62,17 @@ export function RepoIndexedGuard({ initialRepoInfo, children }: Props) {
     }, [previousIsIndexed, repoInfo.isIndexed, repoInfo.displayName, repoInfo.name, repoInfo.imageUrl, showNotification]);
 
     if (isError) {
-        // todo
-        return null;
+        return (
+            <div className="flex min-h-[400px] items-center justify-center p-4">
+                <Alert variant="destructive" className="max-w-lg">
+                    <AlertCircle className="h-4 w-4 text-destructive" />
+                    <AlertTitle>Unable to load repository status</AlertTitle>
+                    <AlertDescription>
+                         Please refresh the page or try again shortly.
+                    </AlertDescription>
+                </Alert>
+            </div>
+        );
     }
 
     if (!repoInfo.isIndexed) {


### PR DESCRIPTION
## What changed

Replaced the placeholder `return null` error branch in `RepoIndexedGuard` with an inline error state using the shared `Alert` component.

This provides users with feedback when the repository status request fails instead of rendering a blank page.

## Testing

Verified the component builds successfully.

Confirmed the change does not affect the existing loading, polling, or notification behavior.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only error handling in AskGH; no changes to API calls, auth, or indexing logic.
> 
> **Overview**
> When the `repo-status` query in **`RepoIndexedGuard`** fails, users now see a centered destructive **`Alert`** (“Unable to load repository status”) instead of a blank page from the previous `return null` placeholder.
> 
> Imports add the shared **`Alert`** components and **`AlertCircle`** icon; indexing spinner, polling, and ready notifications are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0879eff45960f81bb9aa4242e758d667d8e8eee7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added a visible error alert when repository information cannot be loaded.
  * The alert advises refreshing the page or trying again shortly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->