### PR TITLE
fix(worker): capture API route errors in Sentry

### DIFF
--- a/packages/backend/src/api.ts
+++ b/packages/backend/src/api.ts
@@ -1,7 +1,8 @@
 import { PrismaClient, RepoIndexingJobType } from '@sourcebot/db';
+import * as Sentry from '@sentry/node';
 import { hasEntitlement } from './entitlements.js';
 import { createLogger, doesIdpSupportPermissionSyncing, env } from '@sourcebot/shared';
-import express, { Request, Response } from 'express';
+import express, { NextFunction, Request, Response } from 'express';
 import 'express-async-errors';
 import * as http from "http";
 import { ConnectionManager } from './connectionManager.js';
@@ -44,6 +45,11 @@ export class Api {
         app.post('/api/index-repo', this.indexRepo.bind(this));
         app.post('/api/trigger-account-permission-sync', this.triggerAccountPermissionSync.bind(this));
         app.post(`/api/experimental/add-github-repo`, this.experimental_addGithubRepo.bind(this));
+
+        app.use((error: unknown, _req: Request, _res: Response, next: NextFunction) => {
+            Sentry.captureException(error);
+            next(error);
+        });
 
         this.server = app.listen(PORT, () => {
             logger.debug(`API server is running on port ${PORT}`);


### PR DESCRIPTION
## Summary

- capture unhandled worker API route exceptions in Sentry
- delegate captured errors to the existing Express error handler

## Testing

- `yarn workspace @sourcebot/backend build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability-only middleware; errors are still forwarded with `next(error)` and do not alter API logic or responses.
> 
> **Overview**
> Adds Express error middleware on the worker API so **unhandled route exceptions** are reported via `Sentry.captureException` before `next(error)` continues the normal error-handling path (with `express-async-errors` for async handlers).
> 
> No changes to route behavior or response shapes—only observability for failures on `/api/*` and `/metrics`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e4ac8d10da4e0ee5f3c6184e10f2cac387849282. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error monitoring by capturing unexpected server errors.
  * Preserved standard error handling so failures continue through the normal processing flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->