### PR TITLE
fix(worker): use Ask GitHub PAT for repository auth

### DIFF
--- a/packages/backend/src/utils.test.ts
+++ b/packages/backend/src/utils.test.ts
@@ -1,8 +1,9 @@
 import { expect, test, describe, vi, beforeEach, afterEach } from 'vitest';
-import { arraysEqualShallow, fetchWithRetry } from './utils';
-import { isRemotePath } from '@sourcebot/shared';
+import { arraysEqualShallow, fetchWithRetry, getAuthCredentialsForRepo } from './utils';
+import { env, isRemotePath } from '@sourcebot/shared';
 import { Logger } from 'winston';
 import { RequestError } from '@octokit/request-error';
+import type { RepoWithConnections } from './types';
 
 vi.mock('@sentry/node', () => ({
     captureException: vi.fn(),
@@ -14,6 +15,33 @@ const createMockLogger = (): Logger => ({
     info: vi.fn(),
     debug: vi.fn(),
 } as unknown as Logger);
+
+describe('getAuthCredentialsForRepo', () => {
+    const originalAskGithubToken = env.EXPERIMENT_ASK_GH_GITHUB_TOKEN;
+
+    afterEach(() => {
+        env.EXPERIMENT_ASK_GH_GITHUB_TOKEN = originalAskGithubToken;
+    });
+
+    test('uses the Ask GitHub PAT before other GitHub credentials', async () => {
+        env.EXPERIMENT_ASK_GH_GITHUB_TOKEN = 'github-pat-token';
+        const repo = {
+            displayName: 'codemirror/dev',
+            external_codeHostType: 'github',
+            external_codeHostUrl: 'https://github.com',
+            cloneUrl: 'https://github.com/codemirror/dev.git',
+            connections: [],
+        } as RepoWithConnections;
+
+        const credentials = await getAuthCredentialsForRepo(repo);
+
+        expect(credentials).toEqual({
+            hostUrl: 'https://github.com',
+            token: 'github-pat-token',
+            cloneUrlWithToken: 'https://x-access-token:github-pat-token@github.com/codemirror/dev.git',
+        });
+    });
+});
 
 test('should return true for identical arrays', () => {
     expect(arraysEqualShallow([1, 2, 3], [1, 2, 3])).toBe(true);

--- a/packages/backend/src/utils.ts
+++ b/packages/backend/src/utils.ts
@@ -1,7 +1,7 @@
 import { Logger } from "winston";
 import { RepoAuthCredentials, RepoWithConnections } from "./types.js";
 import path from 'path';
-import { getTokenFromConfig } from "@sourcebot/shared";
+import { env, getTokenFromConfig } from "@sourcebot/shared";
 import * as Sentry from "@sentry/node";
 import { GithubConnectionConfig, GitlabConnectionConfig, GiteaConnectionConfig, BitbucketConnectionConfig, AzureDevOpsConnectionConfig } from '@sourcebot/schemas/v3/connection.type';
 import { GithubAppManager } from "./ee/githubAppManager.js";
@@ -115,6 +115,23 @@ export const fetchWithRetry = async <T>(
 // may have their own token. This method will just pick the first connection that has a token (if one exists) and uses that. This
 // may technically cause syncing to fail if that connection's token just so happens to not have access to the repo it's referencing.
 export const getAuthCredentialsForRepo = async (repo: RepoWithConnections, logger?: Logger): Promise<RepoAuthCredentials | undefined> => {
+    if (repo.external_codeHostType === 'github' && env.EXPERIMENT_ASK_GH_GITHUB_TOKEN) {
+        logger?.debug(`Using Ask GitHub PAT for service auth for repo ${repo.displayName} hosted at ${repo.external_codeHostUrl}`);
+
+        const token = env.EXPERIMENT_ASK_GH_GITHUB_TOKEN;
+        return {
+            hostUrl: repo.external_codeHostUrl,
+            token,
+            cloneUrlWithToken: createGitCloneUrlWithToken(
+                repo.cloneUrl,
+                {
+                    username: 'x-access-token',
+                    password: token,
+                }
+            ),
+        };
+    }
+
     // If we have github apps configured we assume that we must use them for github service auth
     if (repo.external_codeHostType === 'github' && await hasEntitlement('github-app') && GithubAppManager.getInstance().appsConfigured()) {
         logger?.debug(`Using GitHub App for service auth for repo ${repo.displayName} hosted at ${repo.external_codeHostUrl}`);

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -363,6 +363,7 @@ const options = {
         EXPERIMENT_SELF_SERVE_REPO_INDEXING_GITHUB_TOKEN: z.string().optional(),
         PERMISSION_SYNC_REPO_DRIVEN_ENABLED: booleanSchema.default('true'),
         EXPERIMENT_ASK_GH_ENABLED: booleanSchema.default('false'),
+        EXPERIMENT_ASK_GH_GITHUB_TOKEN: z.string().optional(),
 
         // Used as the key for AES-256-CBC encryption (@see shared/src/crypto.ts).
         // The key is read as ASCII (1 char = 1 byte), so AES-256's 32-byte key


### PR DESCRIPTION
## Summary

- add `EXPERIMENT_ASK_GH_GITHUB_TOKEN` as an optional server environment variable
- prefer the configured Ask GitHub PAT before GitHub App and connection credential resolution
- inject the PAT only for GitHub clone URLs

## Test plan

- `yarn workspace @sourcebot/backend test --run src/utils.test.ts`
- `yarn workspace @sourcebot/backend build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how GitHub service credentials are chosen for clone/sync when the experimental PAT is set, which can override GitHub App and connection tokens cluster-wide; scope is limited to opt-in env configuration.
> 
> **Overview**
> Adds optional **`EXPERIMENT_ASK_GH_GITHUB_TOKEN`** and, when set, makes **`getAuthCredentialsForRepo`** return that PAT for GitHub repos **before** GitHub App installation tokens or per-connection credentials. Clone URLs use the standard `x-access-token` embedded-auth form.
> 
> A unit test asserts this precedence even when the repo has no connections. Worker flows that already call `getAuthCredentialsForRepo` (e.g. repo indexing and permission sync) will automatically use the PAT when the env is configured.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9efa34597095f9d9122bd8737ff60233956f9175. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added experimental support for using a dedicated GitHub token when accessing GitHub repositories.
  * Authenticated clone URLs are generated automatically when the feature is enabled.

* **Tests**
  * Added coverage verifying GitHub authentication credentials and clone URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->