### PR TITLE
feat(web): add Book a Call button to sidebar and docs navbar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -232,7 +232,7 @@
         "primary": {
             "type": "button",
             "label": "Book a Call",
-            "href": "https://calendly.com/michael-sourcebot/sourcebot-demo?utm_source=docs"
+            "href": "https://calendly.com/michael-sourcebot/sourcebot-call?utm_source=docs"
         }
     },
     "footer": {

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -231,8 +231,8 @@
     "navbar": {
         "primary": {
             "type": "button",
-            "label": "GitHub",
-            "href": "https://github.com/sourcebot-dev/sourcebot"
+            "label": "Book a Call",
+            "href": "https://calendly.com/michael-sourcebot/sourcebot-demo?utm_source=docs"
         }
     },
     "footer": {

--- a/packages/web/src/app/(app)/@sidebar/components/bookACallSidebarButton.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/bookACallSidebarButton.tsx
@@ -5,7 +5,7 @@ import {
 } from "@/components/ui/sidebar"
 import { Phone } from "lucide-react"
 
-const BOOK_A_CALL_BASE_URL = "https://calendly.com/michael-sourcebot/sourcebot-demo"
+const BOOK_A_CALL_BASE_URL = "https://calendly.com/michael-sourcebot/sourcebot-call"
 
 interface BookACallSidebarButtonProps {
     // When the deployment is the public "ask GitHub" app, attribute bookings

--- a/packages/web/src/app/(app)/@sidebar/components/bookACallSidebarButton.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/bookACallSidebarButton.tsx
@@ -1,0 +1,32 @@
+import {
+    SidebarMenu,
+    SidebarMenuButton,
+    SidebarMenuItem,
+} from "@/components/ui/sidebar"
+import { Phone } from "lucide-react"
+
+const BOOK_A_CALL_BASE_URL = "https://calendly.com/michael-sourcebot/sourcebot-demo"
+
+interface BookACallSidebarButtonProps {
+    // When the deployment is the public "ask GitHub" app, attribute bookings
+    // to `public-app` so they can be told apart from self-hosted instances.
+    isAskGhEnabled: boolean
+}
+
+export function BookACallSidebarButton({ isAskGhEnabled }: BookACallSidebarButtonProps) {
+    const utmSource = isAskGhEnabled ? "public-app" : "app"
+    const href = `${BOOK_A_CALL_BASE_URL}?utm_source=${utmSource}`
+
+    return (
+        <SidebarMenu>
+            <SidebarMenuItem>
+                <SidebarMenuButton asChild tooltip="Book a Call">
+                    <a href={href} target="_blank" rel="noopener noreferrer">
+                        <Phone className="h-4 w-4" />
+                        <span>Book a Call</span>
+                    </a>
+                </SidebarMenuButton>
+            </SidebarMenuItem>
+        </SidebarMenu>
+    )
+}

--- a/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/index.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/index.tsx
@@ -14,6 +14,7 @@ import { RepoVisitHistory } from "./repoVisitHistory";
 import { getAuthContext, withAuth } from "@/middleware/withAuth";
 import { sew } from "@/middleware/sew";
 import { hasEntitlement, isValidLicenseActive } from "@/lib/entitlements";
+import { env } from "@sourcebot/shared";
 
 const SIDEBAR_CHAT_LIMIT = 30;
 export const SIDEBAR_REPO_VISITS_LIMIT = 10;
@@ -57,6 +58,7 @@ export async function DefaultSidebar() {
             session={session}
             collapsible="icon"
             isValidLicenseActive={licenseActive}
+            isAskGhEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
             headerContent={
                 <Nav
                     isSettingsNotificationVisible={isSettingsNotificationVisible}

--- a/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/index.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/index.tsx
@@ -6,6 +6,7 @@ import { SidebarBase } from "../sidebarBase";
 import { Nav } from "./nav";
 import { SettingsSidebarHeader } from "./header";
 import { isValidLicenseActive } from "@/lib/entitlements";
+import { env } from "@sourcebot/shared";
 
 export async function SettingsSidebar() {
     const session = await auth();
@@ -22,6 +23,7 @@ export async function SettingsSidebar() {
             session={session}
             collapsible="none"
             isValidLicenseActive={licenseActive}
+            isAskGhEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
             headerContent={<SettingsSidebarHeader />}
         >
             <Nav groups={sidebarNavGroups} />

--- a/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
@@ -45,6 +45,7 @@ import { KeyboardShortcutHint } from "@/app/components/keyboardShortcutHint";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Separator } from "@/components/ui/separator";
 import { WhatsNewSidebarButton } from "./whatsNewSidebarButton";
+import { BookACallSidebarButton } from "./bookACallSidebarButton";
 import { UpgradeButton } from "./upgradeButton";
 import { useIsMobile } from "@/hooks/use-mobile";
 
@@ -58,9 +59,10 @@ interface SidebarBaseProps {
     headerContent: ReactNode;
     children: ReactNode;
     isValidLicenseActive: boolean;
+    isAskGhEnabled: boolean;
 }
 
-export function SidebarBase({ session, collapsible = "icon", headerContent, children, isValidLicenseActive }: SidebarBaseProps) {
+export function SidebarBase({ session, collapsible = "icon", headerContent, children, isValidLicenseActive, isAskGhEnabled }: SidebarBaseProps) {
     const [isScrolled, setIsScrolled] = useState(false);
     const contentRef = useRef<HTMLDivElement>(null);
     const isMobile = useIsMobile();
@@ -118,6 +120,7 @@ export function SidebarBase({ session, collapsible = "icon", headerContent, chil
                         <CollapseSidebarButton />
                     }
                     <WhatsNewSidebarButton />
+                    <BookACallSidebarButton isAskGhEnabled={isAskGhEnabled} />
                     {session ? (
                         <MeControlDropdownMenu session={session} />
                     ) : (


### PR DESCRIPTION
SOU-1450
SOU-1449

<img width="325" height="280" alt="image" src="https://github.com/user-attachments/assets/2314b2f0-009e-43f5-9ae9-cf576b1debbb" />

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only navigation to external Calendly URLs; no auth, data, or business-logic changes.
> 
> **Overview**
> Adds **Book a Call** CTAs that link to Calendly so users can schedule sales/support calls from the product and docs.
> 
> In the web app, a new sidebar footer control opens Calendly in a new tab. The link includes `utm_source=app` for self-hosted deployments and `utm_source=public-app` when `EXPERIMENT_ASK_GH_ENABLED` is on, so bookings from the public Ask GitHub experience can be distinguished. Both the main and settings sidebars pass that flag into `SidebarBase`.
> 
> On the docs site, the navbar **primary** button is switched from GitHub to **Book a Call** with `utm_source=docs`. Footer social links to GitHub are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fed01fb4a76bca3bf1cdbdb6e1657923cf147d33. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added “Book a Call” buttons to the documentation navigation and application sidebar.
  * Links open Calendly in a new browser tab and include relevant source tracking.
* **Updates**
  * Replaced the documentation navbar’s GitHub link with the new booking call-to-action.
  * Added the booking option to both standard and settings sidebar layouts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->