### PR TITLE
feat(web): add Idira SSO support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added an optional `webUrl` field to the GitLab connection config, used to build links to repositories in the GitLab web UI when the API host differs from the browsable host. [#1457](https://github.com/sourcebot-dev/sourcebot/pull/1457)
+- [EE] Added Idira SSO support through OpenID Connect. [#1459](https://github.com/sourcebot-dev/sourcebot/pull/1459)
 
 ### Fixed
 - Prevented focus rings in workspace connector dialogs from being clipped. [#1457](https://github.com/sourcebot-dev/sourcebot/pull/1457)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added an optional `webUrl` field to the GitLab connection config, used to build links to repositories in the GitLab web UI when the API host differs from the browsable host. [#1457](https://github.com/sourcebot-dev/sourcebot/pull/1457)
 - [EE] Added Idira SSO support through OpenID Connect. [#1459](https://github.com/sourcebot-dev/sourcebot/pull/1459)
 - Added an optional `webUrl` field to the GitLab connection config, used to build links to repositories in the GitLab web UI when the API host differs from the browsable host. [#1458](https://github.com/sourcebot-dev/sourcebot/pull/1458)
 

--- a/docs/docs/configuration/idp.mdx
+++ b/docs/docs/configuration/idp.mdx
@@ -601,6 +601,57 @@ A JumpCloud connection can be used for [authentication](/docs/configuration/auth
 </Steps>
 </Accordion>
 
+### Idira
+
+[Idira custom OpenID Connect application documentation](https://docs.cyberark.com/manage/latest/en/content/identity/applications/appscustom/openidaddconfigapp.htm)
+
+An Idira connection can be used for [authentication](/docs/configuration/auth). Sourcebot uses Idira's OpenID Connect support to authenticate users.
+
+<Accordion title="instructions">
+<Steps>
+    <Step title="Create an OpenID Connect application in Idira">
+        In the Idira Admin Portal, go to **Manage > Identities > Web apps**, add the custom **OpenID Connect** application, and configure its Trust settings.
+
+        When configuring the application:
+        - Add `<sourcebot_url>/api/auth/callback/idira` to the **Authorized Redirect URIs** (ex. https://sourcebot.coolcorp.com/api/auth/callback/idira)
+        - Keep exact redirect URI matching enabled
+        - Grant the users, groups, or roles that should be able to sign in permission to run the application
+
+        From the application's Trust page, note the `CLIENT_ID` and `ISSUER`. Generate a client secret and store it securely. Idira displays the secret only until you confirm that you have saved it.
+    </Step>
+    <Step title="Define environment variables">
+        Provide the client id, secret, and issuer URL to Sourcebot using environment variables. These variables can be named whatever you like
+        (ex. `IDIRA_IDENTITY_PROVIDER_CLIENT_ID`, `IDIRA_IDENTITY_PROVIDER_CLIENT_SECRET`, and `IDIRA_IDENTITY_PROVIDER_ISSUER`).
+    </Step>
+    <Step title="Define the identity provider config">
+        Add the Idira provider to the `identityProviders` object in the [config file](/docs/configuration/config-file):
+
+        ```json wrap icon="code"
+        {
+            "$schema": "https://raw.githubusercontent.com/sourcebot-dev/sourcebot/main/schemas/v3/index.json",
+            "identityProviders": {
+                "idira": {
+                    "provider": "idira",
+                    "purpose": "sso",
+                    "clientId": {
+                        "env": "IDIRA_IDENTITY_PROVIDER_CLIENT_ID"
+                    },
+                    "clientSecret": {
+                        "env": "IDIRA_IDENTITY_PROVIDER_CLIENT_SECRET"
+                    },
+                    "issuer": {
+                        "env": "IDIRA_IDENTITY_PROVIDER_ISSUER"
+                    }
+                }
+            }
+        }
+        ```
+
+        If you use a custom identity provider id instead of `idira`, use that id in the callback URL as described in [multiple identity providers](#configuring-multiple-providers-of-the-same-type).
+    </Step>
+</Steps>
+</Accordion>
+
 ### Google Cloud IAP
 
 [Google Cloud IAP Documentation](https://cloud.google.com/iap/docs)
@@ -688,5 +739,3 @@ Each provider keeps the same fields documented above. The only differences are:
 <Note>
 Each instance needs its own OAuth client (its own `clientId` and `clientSecret`) registered with the matching callback URL.
 </Note>
-
-

--- a/docs/snippets/schemas/v3/identityProvider.schema.mdx
+++ b/docs/snippets/schemas/v3/identityProvider.schema.mdx
@@ -991,6 +991,119 @@
         "issuer"
       ]
     },
+    "IdiraIdentityProviderConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "const": "idira"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+        },
+        "purpose": {
+          "const": "sso"
+        },
+        "clientId": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "clientSecret": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "issuer": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "provider",
+        "purpose",
+        "clientId",
+        "clientSecret",
+        "issuer"
+      ]
+    },
     "BitbucketServerIdentityProviderConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -1975,6 +2088,119 @@
         "displayName": {
           "type": "string",
           "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+        },
+        "purpose": {
+          "const": "sso"
+        },
+        "clientId": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "clientSecret": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "issuer": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "provider",
+        "purpose",
+        "clientId",
+        "clientSecret",
+        "issuer"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "const": "idira"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
         },
         "purpose": {
           "const": "sso"

--- a/docs/snippets/schemas/v3/index.schema.mdx
+++ b/docs/snippets/schemas/v3/index.schema.mdx
@@ -5962,6 +5962,119 @@
                     "issuer"
                   ]
                 },
+                "IdiraIdentityProviderConfig": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "provider": {
+                      "const": "idira"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+                    },
+                    "purpose": {
+                      "const": "sso"
+                    },
+                    "clientId": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "clientSecret": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "issuer": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "purpose",
+                    "clientId",
+                    "clientSecret",
+                    "issuer"
+                  ]
+                },
                 "BitbucketServerIdentityProviderConfig": {
                   "type": "object",
                   "additionalProperties": false,
@@ -6946,6 +7059,119 @@
                     "displayName": {
                       "type": "string",
                       "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+                    },
+                    "purpose": {
+                      "const": "sso"
+                    },
+                    "clientId": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "clientSecret": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "issuer": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "purpose",
+                    "clientId",
+                    "clientSecret",
+                    "issuer"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "provider": {
+                      "const": "idira"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
                     },
                     "purpose": {
                       "const": "sso"
@@ -8145,6 +8371,119 @@
                   "issuer"
                 ]
               },
+              "IdiraIdentityProviderConfig": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "provider": {
+                    "const": "idira"
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+                  },
+                  "purpose": {
+                    "const": "sso"
+                  },
+                  "clientId": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "clientSecret": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "issuer": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "provider",
+                  "purpose",
+                  "clientId",
+                  "clientSecret",
+                  "issuer"
+                ]
+              },
               "BitbucketServerIdentityProviderConfig": {
                 "type": "object",
                 "additionalProperties": false,
@@ -9129,6 +9468,119 @@
                   "displayName": {
                     "type": "string",
                     "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+                  },
+                  "purpose": {
+                    "const": "sso"
+                  },
+                  "clientId": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "clientSecret": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "issuer": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "provider",
+                  "purpose",
+                  "clientId",
+                  "clientSecret",
+                  "issuer"
+                ]
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "provider": {
+                    "const": "idira"
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
                   },
                   "purpose": {
                     "const": "sso"

--- a/packages/schemas/src/v3/identityProvider.schema.ts
+++ b/packages/schemas/src/v3/identityProvider.schema.ts
@@ -990,6 +990,119 @@ const schema = {
         "issuer"
       ]
     },
+    "IdiraIdentityProviderConfig": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "const": "idira"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+        },
+        "purpose": {
+          "const": "sso"
+        },
+        "clientId": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "clientSecret": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "issuer": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "provider",
+        "purpose",
+        "clientId",
+        "clientSecret",
+        "issuer"
+      ]
+    },
     "BitbucketServerIdentityProviderConfig": {
       "type": "object",
       "additionalProperties": false,
@@ -1974,6 +2087,119 @@ const schema = {
         "displayName": {
           "type": "string",
           "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+        },
+        "purpose": {
+          "const": "sso"
+        },
+        "clientId": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "clientSecret": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        },
+        "issuer": {
+          "anyOf": [
+            {
+              "type": "object",
+              "properties": {
+                "env": {
+                  "type": "string",
+                  "description": "The name of the environment variable that contains the token."
+                }
+              },
+              "required": [
+                "env"
+              ],
+              "additionalProperties": false
+            },
+            {
+              "type": "object",
+              "properties": {
+                "googleCloudSecret": {
+                  "type": "string",
+                  "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                }
+              },
+              "required": [
+                "googleCloudSecret"
+              ],
+              "additionalProperties": false
+            }
+          ]
+        }
+      },
+      "required": [
+        "provider",
+        "purpose",
+        "clientId",
+        "clientSecret",
+        "issuer"
+      ]
+    },
+    {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "const": "idira"
+        },
+        "displayName": {
+          "type": "string",
+          "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
         },
         "purpose": {
           "const": "sso"

--- a/packages/schemas/src/v3/identityProvider.type.ts
+++ b/packages/schemas/src/v3/identityProvider.type.ts
@@ -11,6 +11,7 @@ export type IdentityProviderConfig =
   | AuthentikIdentityProviderConfig
   | BitbucketCloudIdentityProviderConfig
   | JumpCloudIdentityProviderConfig
+  | IdiraIdentityProviderConfig
   | BitbucketServerIdentityProviderConfig;
 
 export interface GitHubIdentityProviderConfig {
@@ -373,6 +374,53 @@ export interface JumpCloudIdentityProviderConfig {
   provider: "jumpcloud";
   /**
    * Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'.
+   */
+  displayName?: string;
+  purpose: "sso";
+  clientId:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  clientSecret:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  issuer:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+}
+export interface IdiraIdentityProviderConfig {
+  provider: "idira";
+  /**
+   * Optional human-readable label shown on the login screen. Defaults to 'Idira'.
    */
   displayName?: string;
   purpose: "sso";

--- a/packages/schemas/src/v3/index.schema.ts
+++ b/packages/schemas/src/v3/index.schema.ts
@@ -5961,6 +5961,119 @@ const schema = {
                     "issuer"
                   ]
                 },
+                "IdiraIdentityProviderConfig": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "provider": {
+                      "const": "idira"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+                    },
+                    "purpose": {
+                      "const": "sso"
+                    },
+                    "clientId": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "clientSecret": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "issuer": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "purpose",
+                    "clientId",
+                    "clientSecret",
+                    "issuer"
+                  ]
+                },
                 "BitbucketServerIdentityProviderConfig": {
                   "type": "object",
                   "additionalProperties": false,
@@ -6945,6 +7058,119 @@ const schema = {
                     "displayName": {
                       "type": "string",
                       "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+                    },
+                    "purpose": {
+                      "const": "sso"
+                    },
+                    "clientId": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "clientSecret": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    },
+                    "issuer": {
+                      "anyOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "env": {
+                              "type": "string",
+                              "description": "The name of the environment variable that contains the token."
+                            }
+                          },
+                          "required": [
+                            "env"
+                          ],
+                          "additionalProperties": false
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "googleCloudSecret": {
+                              "type": "string",
+                              "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                            }
+                          },
+                          "required": [
+                            "googleCloudSecret"
+                          ],
+                          "additionalProperties": false
+                        }
+                      ]
+                    }
+                  },
+                  "required": [
+                    "provider",
+                    "purpose",
+                    "clientId",
+                    "clientSecret",
+                    "issuer"
+                  ]
+                },
+                {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "provider": {
+                      "const": "idira"
+                    },
+                    "displayName": {
+                      "type": "string",
+                      "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
                     },
                     "purpose": {
                       "const": "sso"
@@ -8144,6 +8370,119 @@ const schema = {
                   "issuer"
                 ]
               },
+              "IdiraIdentityProviderConfig": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "provider": {
+                    "const": "idira"
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+                  },
+                  "purpose": {
+                    "const": "sso"
+                  },
+                  "clientId": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "clientSecret": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "issuer": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "provider",
+                  "purpose",
+                  "clientId",
+                  "clientSecret",
+                  "issuer"
+                ]
+              },
               "BitbucketServerIdentityProviderConfig": {
                 "type": "object",
                 "additionalProperties": false,
@@ -9128,6 +9467,119 @@ const schema = {
                   "displayName": {
                     "type": "string",
                     "description": "Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'."
+                  },
+                  "purpose": {
+                    "const": "sso"
+                  },
+                  "clientId": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "clientSecret": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  },
+                  "issuer": {
+                    "anyOf": [
+                      {
+                        "type": "object",
+                        "properties": {
+                          "env": {
+                            "type": "string",
+                            "description": "The name of the environment variable that contains the token."
+                          }
+                        },
+                        "required": [
+                          "env"
+                        ],
+                        "additionalProperties": false
+                      },
+                      {
+                        "type": "object",
+                        "properties": {
+                          "googleCloudSecret": {
+                            "type": "string",
+                            "description": "The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets"
+                          }
+                        },
+                        "required": [
+                          "googleCloudSecret"
+                        ],
+                        "additionalProperties": false
+                      }
+                    ]
+                  }
+                },
+                "required": [
+                  "provider",
+                  "purpose",
+                  "clientId",
+                  "clientSecret",
+                  "issuer"
+                ]
+              },
+              {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "provider": {
+                    "const": "idira"
+                  },
+                  "displayName": {
+                    "type": "string",
+                    "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
                   },
                   "purpose": {
                     "const": "sso"

--- a/packages/schemas/src/v3/index.type.ts
+++ b/packages/schemas/src/v3/index.type.ts
@@ -41,6 +41,7 @@ export type IdentityProviderConfig =
   | AuthentikIdentityProviderConfig
   | BitbucketCloudIdentityProviderConfig
   | JumpCloudIdentityProviderConfig
+  | IdiraIdentityProviderConfig
   | BitbucketServerIdentityProviderConfig;
 
 export interface SourcebotConfig {
@@ -1713,6 +1714,53 @@ export interface JumpCloudIdentityProviderConfig {
   provider: "jumpcloud";
   /**
    * Optional human-readable label shown on the login screen. Defaults to 'JumpCloud'.
+   */
+  displayName?: string;
+  purpose: "sso";
+  clientId:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  clientSecret:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+  issuer:
+    | {
+        /**
+         * The name of the environment variable that contains the token.
+         */
+        env: string;
+      }
+    | {
+        /**
+         * The resource name of a Google Cloud secret. Must be in the format `projects/<project-id>/secrets/<secret-name>/versions/<version-id>`. See https://cloud.google.com/secret-manager/docs/creating-and-accessing-secrets
+         */
+        googleCloudSecret: string;
+      };
+}
+export interface IdiraIdentityProviderConfig {
+  provider: "idira";
+  /**
+   * Optional human-readable label shown on the login screen. Defaults to 'Idira'.
    */
   displayName?: string;
   purpose: "sso";

--- a/packages/web/public/idira.svg
+++ b/packages/web/public/idira.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 19.7 22.8">
+  <path fill="#265bff" d="M9.9 18.1v4.7L0 17.1V5.7L9.9 0l9.8 5.7-4 2.3-5.8-3.3L4 8v6.8l5.9 3.3Z"/>
+  <path fill="#265bff" d="m9.9 18.1 5.8-3.3V8l-5.9 3.4.1 6.7Z"/>
+</svg>

--- a/packages/web/src/app/login/components/loginForm.tsx
+++ b/packages/web/src/app/login/components/loginForm.tsx
@@ -60,6 +60,8 @@ export const LoginForm = ({ callbackUrl, error, context, isAnonymousAccessEnable
                 return "wa_login_with_microsoft_entra_id" as const;
             case "jumpcloud":
                 return "wa_login_with_jumpcloud" as const;
+            case "idira":
+                return "wa_login_with_idira" as const;
             default:
                 return "wa_login_with_github" as const; // fallback
         }

--- a/packages/web/src/ee/features/sso/sso.ts
+++ b/packages/web/src/ee/features/sso/sso.ts
@@ -162,6 +162,26 @@ export const getEEIdentityProviders = async (): Promise<IdentityProvider[]> => {
             });
         }
 
+        if (idpConfig.provider === "idira") {
+            const clientId = await getTokenFromConfig(idpConfig.clientId);
+            const clientSecret = await getTokenFromConfig(idpConfig.clientSecret);
+            const issuer = (await getTokenFromConfig(idpConfig.issuer)).replace(/\/+$/, '');
+            providers.push({
+                __provider: createIdiraProvider({
+                    id,
+                    clientId,
+                    clientSecret,
+                    issuer,
+                    allowDangerousEmailAccountLinking: env.AUTH_EE_ALLOW_EMAIL_ACCOUNT_LINKING === 'true',
+                }),
+                id,
+                type: idpConfig.provider,
+                displayName: idpConfig.displayName,
+                purpose: idpConfig.purpose,
+                issuerUrl: issuer,
+            });
+        }
+
         if (idpConfig.provider === "bitbucket-server") {
             const clientId = await getTokenFromConfig(idpConfig.clientId);
             const clientSecret = await getTokenFromConfig(idpConfig.clientSecret);
@@ -402,6 +422,36 @@ const createJumpCloudProvider = (id: string, clientId: string, clientSecret: str
         allowDangerousEmailAccountLinking: env.AUTH_EE_ALLOW_EMAIL_ACCOUNT_LINKING === 'true',
     } as Provider;
 }
+
+type CreateIdiraProviderOptions = {
+    id: string;
+    clientId: string;
+    clientSecret: string;
+    issuer: string;
+    allowDangerousEmailAccountLinking: boolean;
+};
+
+const createIdiraProvider = ({
+    id,
+    clientId,
+    clientSecret,
+    issuer,
+    allowDangerousEmailAccountLinking,
+}: CreateIdiraProviderOptions): Provider => ({
+    id,
+    name: "Idira",
+    type: "oidc",
+    clientId,
+    clientSecret,
+    issuer,
+    checks: ["pkce", "state"],
+    authorization: {
+        params: {
+            scope: "openid profile email",
+        },
+    },
+    allowDangerousEmailAccountLinking,
+} as Provider);
 
 const createGCPIAPProvider = (id: string, audience: string): Provider => {
     return Credentials({

--- a/packages/web/src/ee/features/sso/sso.ts
+++ b/packages/web/src/ee/features/sso/sso.ts
@@ -199,7 +199,7 @@ export const getEEIdentityProviders = async (): Promise<IdentityProvider[]> => {
     }
 
     if (Object.keys(identityProviders).length === 0) {
-        if (env.AUTH_EE_GCP_IAP_ENABLED && env.AUTH_EE_GCP_IAP_AUDIENCE) {
+        if (env.AUTH_EE_GCP_IAP_ENABLED === 'true' && env.AUTH_EE_GCP_IAP_AUDIENCE) {
             providers.push({
                 __provider: createGCPIAPProvider('gcp-iap', env.AUTH_EE_GCP_IAP_AUDIENCE),
                 type: "gcp-iap",

--- a/packages/web/src/ee/features/sso/sso.ts
+++ b/packages/web/src/ee/features/sso/sso.ts
@@ -199,7 +199,7 @@ export const getEEIdentityProviders = async (): Promise<IdentityProvider[]> => {
     }
 
     if (Object.keys(identityProviders).length === 0) {
-        if (env.AUTH_EE_GCP_IAP_ENABLED === 'true' && env.AUTH_EE_GCP_IAP_AUDIENCE) {
+        if (env.AUTH_EE_GCP_IAP_ENABLED && env.AUTH_EE_GCP_IAP_AUDIENCE) {
             providers.push({
                 __provider: createGCPIAPProvider('gcp-iap', env.AUTH_EE_GCP_IAP_AUDIENCE),
                 type: "gcp-iap",

--- a/packages/web/src/lib/posthogEvents.ts
+++ b/packages/web/src/lib/posthogEvents.ts
@@ -143,6 +143,7 @@ export type PosthogEventMap = {
     wa_login_with_keycloak: {},
     wa_login_with_microsoft_entra_id: {},
     wa_login_with_jumpcloud: {},
+    wa_login_with_idira: {},
     wa_login_with_magic_link: {},
     wa_login_with_credentials: {},
     //////////////////////////////////////////////////////////////////

--- a/packages/web/src/lib/utils.ts
+++ b/packages/web/src/lib/utils.ts
@@ -13,6 +13,7 @@ import keycloakLogo from "@/public/keycloak.svg";
 import microsoftLogo from "@/public/microsoft_entra.svg";
 import authentikLogo from "@/public/authentik.svg";
 import jumpcloudLogo from "@/public/jumpcloud.svg";
+import idiraLogo from "@/public/idira.svg";
 import { ServiceError } from "./serviceError";
 import { ConnectionType } from "@sourcebot/db";
 import { CodeHostType } from "@sourcebot/db";
@@ -153,6 +154,15 @@ export const getAuthProviderInfo = (providerType: string): AuthProviderInfo => {
                 displayName: "JumpCloud",
                 icon: {
                     src: jumpcloudLogo,
+                },
+            };
+        case "idira":
+            return {
+                id: "idira",
+                name: "Idira",
+                displayName: "Idira",
+                icon: {
+                    src: idiraLogo,
                 },
             };
         case "credentials":

--- a/schemas/v3/identityProvider.json
+++ b/schemas/v3/identityProvider.json
@@ -278,6 +278,32 @@
             },
             "required": ["provider", "purpose", "clientId", "clientSecret", "issuer"]
         },
+        "IdiraIdentityProviderConfig": {
+            "type": "object",
+            "additionalProperties": false,
+            "properties": {
+                "provider": {
+                    "const": "idira"
+                },
+                "displayName": {
+                    "type": "string",
+                    "description": "Optional human-readable label shown on the login screen. Defaults to 'Idira'."
+                },
+                "purpose": {
+                    "const": "sso"
+                },
+                "clientId": {
+                    "$ref": "./shared.json#/definitions/Token"
+                },
+                "clientSecret": {
+                    "$ref": "./shared.json#/definitions/Token"
+                },
+                "issuer": {
+                    "$ref": "./shared.json#/definitions/Token"
+                }
+            },
+            "required": ["provider", "purpose", "clientId", "clientSecret", "issuer"]
+        },
         "BitbucketServerIdentityProviderConfig": {
             "type": "object",
             "additionalProperties": false,
@@ -342,6 +368,9 @@
         },
         {
             "$ref": "#/definitions/JumpCloudIdentityProviderConfig"
+        },
+        {
+            "$ref": "#/definitions/IdiraIdentityProviderConfig"
         },
         {
             "$ref": "#/definitions/BitbucketServerIdentityProviderConfig"


### PR DESCRIPTION
Fixes SOU-1520

## Summary
- add Idira as an enterprise OIDC identity provider
- add Idira configuration schemas, generated reference documentation, and setup instructions
- add Idira login branding and login telemetry

## Validation
- yarn workspace @sourcebot/schemas build
- focused ESLint for the affected web files
- git diff --check

## Notes
- An Idira test tenant was not available, so the end-to-end OIDC flow was not exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication and OIDC login flows; behavior mirrors other SSO providers but was not validated end-to-end without an Idira tenant.
> 
> **Overview**
> Adds **Idira** as an enterprise SSO identity provider using OpenID Connect, alongside existing OIDC IdPs such as JumpCloud.
> 
> Runtime wiring registers `idira` in EE SSO when `identityProviders` includes `provider: "idira"` with `clientId`, `clientSecret`, and `issuer` (env or Google Cloud Secret). Issuer URLs are trimmed of trailing slashes. The Auth.js provider uses PKCE/state and requests `openid profile email`; optional email account linking follows `AUTH_EE_ALLOW_EMAIL_ACCOUNT_LINKING`.
> 
> Config and docs add `IdiraIdentityProviderConfig` to v3 schemas (source + generated MDX), setup steps in `idp.mdx` (callback `/api/auth/callback/idira`), and an Unreleased changelog entry. The login UI gets Idira branding (`idira.svg`), a `wa_login_with_idira` analytics event, and provider display metadata in `utils.ts`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07c5be2f318a1cad919e29dfba356e777b0a5441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Enterprise SSO support for Idira via OpenID Connect (OIDC).
  * Added Idira as a supported identity provider with required configuration for `clientId`, `clientSecret`, and `issuer` (via environment variables or Google Cloud Secret references).
  * Added Idira branding in the login flow and a new login analytics event for Idira.
* **Documentation**
  * Documented Idira IdP setup and added Idira to the v3 identity provider configuration schemas.
* **Bug Fixes**
  * Normalize Idira issuer URLs by removing trailing slashes before use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->