### PR TITLE
docs: point MCP server examples at the public app.sourcebot.dev deployment

### DIFF
--- a/docs/docs/features/mcp-server.mdx
+++ b/docs/docs/features/mcp-server.mdx
@@ -27,6 +27,10 @@ You can read more about the options in the [authorization](#authorization) secti
     If [anonymous access](https://docs.sourcebot.dev/docs/configuration/auth/access-settings#anonymous-access) is enabled on your Sourcebot instance, no OAuth token or API key is required. You can connect directly to the MCP endpoint without any authorization.
 </Note>
 
+<Note>
+    The examples below add the MCP server and connect it to Sourcebot's public deployment at [app.sourcebot.dev](https://app.sourcebot.dev). Replace the URL with your own Sourcebot deployment as needed.
+</Note>
+
 <AccordionGroup>
 <Accordion title="Claude Code">
         [Claude Code MCP docs](https://code.claude.com/docs/en/mcp#connect-claude-code-to-tools-via-mcp)
@@ -38,18 +42,18 @@ You can read more about the options in the [authorization](#authorization) secti
                 <LicenseKeyRequired feature="OAuth" />
 
                 ```sh
-                claude mcp add --transport http sourcebot https://sb.example.com/api/mcp
+                claude mcp add --transport http sourcebot https://app.sourcebot.dev/api/mcp
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. Claude Code will automatically handle the OAuth 2.0 authorization flow the first time you connect.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. Claude Code will automatically handle the OAuth 2.0 authorization flow the first time you connect.
             </Tab>
             <Tab title="API Key">
                 ```sh
-                claude mcp add --transport http sourcebot https://sb.example.com/api/mcp \
+                claude mcp add --transport http sourcebot https://app.sourcebot.dev/api/mcp \
                   --header "Authorization: Bearer <key>"
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
             </Tab>
         </Tabs>
     </Accordion>
@@ -70,13 +74,13 @@ You can read more about the options in the [authorization](#authorization) secti
                     "mcpServers": {
                         "sourcebot": {
                             "type": "http",
-                            "url": "https://sb.example.com/api/mcp"
+                            "url": "https://app.sourcebot.dev/api/mcp"
                         }
                     }
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. Cursor will automatically handle the OAuth 2.0 authorization flow the first time you connect.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. Cursor will automatically handle the OAuth 2.0 authorization flow the first time you connect.
             </Tab>
             <Tab title="API Key">
                 ```json
@@ -84,7 +88,7 @@ You can read more about the options in the [authorization](#authorization) secti
                     "mcpServers": {
                         "sourcebot": {
                             "type": "http",
-                            "url": "https://sb.example.com/api/mcp",
+                            "url": "https://app.sourcebot.dev/api/mcp",
                             "headers": {
                                 "Authorization": "Bearer <key>"
                             }
@@ -93,7 +97,7 @@ You can read more about the options in the [authorization](#authorization) secti
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
             </Tab>
         </Tabs>
     </Accordion>
@@ -112,13 +116,13 @@ You can read more about the options in the [authorization](#authorization) secti
                     "servers": {
                         "sourcebot": {
                             "type": "http",
-                            "url": "https://sb.example.com/api/mcp"
+                            "url": "https://app.sourcebot.dev/api/mcp"
                         }
                     }
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. VS Code will automatically handle the OAuth 2.0 authorization flow the first time you connect.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. VS Code will automatically handle the OAuth 2.0 authorization flow the first time you connect.
             </Tab>
             <Tab title="API Key">
                 ```json
@@ -126,7 +130,7 @@ You can read more about the options in the [authorization](#authorization) secti
                     "servers": {
                         "sourcebot": {
                             "type": "http",
-                            "url": "https://sb.example.com/api/mcp",
+                            "url": "https://app.sourcebot.dev/api/mcp",
                             "headers": {
                                 "Authorization": "Bearer <key>"
                             }
@@ -135,7 +139,7 @@ You can read more about the options in the [authorization](#authorization) secti
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
             </Tab>
         </Tabs>
     </Accordion>
@@ -151,10 +155,10 @@ You can read more about the options in the [authorization](#authorization) secti
 
                 ```toml
                 [mcp_servers.sourcebot]
-                url = "https://sb.example.com/api/mcp"
+                url = "https://app.sourcebot.dev/api/mcp"
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. Then run the following to authenticate:
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. Then run the following to authenticate:
 
                 ```sh
                 codex mcp login sourcebot
@@ -163,11 +167,11 @@ You can read more about the options in the [authorization](#authorization) secti
             <Tab title="API Key">
                 ```toml
                 [mcp_servers.sourcebot]
-                url = "https://sb.example.com/api/mcp"
+                url = "https://app.sourcebot.dev/api/mcp"
                 bearer_token_env_var = "SOURCEBOT_API_KEY"
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, then set your API key as an environment variable:
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, then set your API key as an environment variable:
 
                 ```sh
                 export SOURCEBOT_API_KEY=<key>
@@ -193,13 +197,13 @@ You can read more about the options in the [authorization](#authorization) secti
                     "mcp": {
                         "sourcebot": {
                             "type": "remote",
-                            "url": "https://sb.example.com/api/mcp"
+                            "url": "https://app.sourcebot.dev/api/mcp"
                         }
                     }
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. OpenCode will automatically handle the OAuth 2.0 authorization flow the first time you connect. You can also manually trigger it with:
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. OpenCode will automatically handle the OAuth 2.0 authorization flow the first time you connect. You can also manually trigger it with:
 
                 ```sh
                 opencode mcp auth sourcebot
@@ -212,7 +216,7 @@ You can read more about the options in the [authorization](#authorization) secti
                     "mcp": {
                         "sourcebot": {
                             "type": "remote",
-                            "url": "https://sb.example.com/api/mcp",
+                            "url": "https://app.sourcebot.dev/api/mcp",
                             "oauth": false,
                             "headers": {
                                 "Authorization": "Bearer <key>"
@@ -222,7 +226,7 @@ You can read more about the options in the [authorization](#authorization) secti
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
             </Tab>
         </Tabs>
     </Accordion>
@@ -242,20 +246,20 @@ You can read more about the options in the [authorization](#authorization) secti
                 {
                     "mcpServers": {
                         "sourcebot": {
-                            "serverUrl": "https://sb.example.com/api/mcp"
+                            "serverUrl": "https://app.sourcebot.dev/api/mcp"
                         }
                     }
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted. Windsurf will automatically handle the OAuth 2.0 authorization flow the first time you connect.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted. Windsurf will automatically handle the OAuth 2.0 authorization flow the first time you connect.
             </Tab>
             <Tab title="API Key">
                 ```json
                 {
                     "mcpServers": {
                         "sourcebot": {
-                            "serverUrl": "https://sb.example.com/api/mcp",
+                            "serverUrl": "https://app.sourcebot.dev/api/mcp",
                             "headers": {
                                 "Authorization": "Bearer <key>"
                             }
@@ -264,7 +268,7 @@ You can read more about the options in the [authorization](#authorization) secti
                 }
                 ```
 
-                Replace `https://sb.example.com` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
+                Replace `https://app.sourcebot.dev` with wherever your Sourcebot instance is hosted, and `<key>` with an API key generated in **Settings → API Keys**.
             </Tab>
         </Tabs>
     </Accordion>


### PR DESCRIPTION
## Summary

The MCP server docs used a `sb.example.com` placeholder in every client example, which doesn't resolve to anything. This swaps all of them to `app.sourcebot.dev` so the examples connect to our public Sourcebot deployment out of the box, and adds a short note near the top telling readers to replace the URL with their own deployment as needed.

- Replaced all 24 `sb.example.com` occurrences in `docs/docs/features/mcp-server.mdx` with `app.sourcebot.dev` (code snippets and the per-example "Replace ..." lines).
- Added a note above the client examples:
  > The examples below add the MCP server and connect it to Sourcebot's public deployment at app.sourcebot.dev. Replace the URL with your own Sourcebot deployment as needed.

Docs-only change, so no CHANGELOG entry.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only URL and copy updates with no runtime, auth, or API behavior changes.
> 
> **Overview**
> MCP client setup docs now use **`https://app.sourcebot.dev/api/mcp`** instead of the non-resolving **`sb.example.com`** placeholder in every snippet and “Replace …” line (Claude Code, Cursor, VS Code, Codex, OpenCode, Windsurf; OAuth and API key tabs).
> 
> A **Note** above the accordion examples states that samples target the public deployment at [app.sourcebot.dev](https://app.sourcebot.dev) and that readers should swap in their own instance URL when self-hosting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7c1c0abd802758f686443fbd42040f57f43a0921. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated MCP server setup examples to use Sourcebot’s public deployment URL.
  * Clarified that users should replace the example URL with their own Sourcebot deployment address.
  * Refreshed setup instructions for Claude Code, Cursor, VS Code, Codex, OpenCode, and Windsurf.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->