### PR TITLE
chore: reduce Sentry span sampling outside development

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- Reduced Sentry error event sampling to 10% outside development. [#1475](https://github.com/sourcebot-dev/sourcebot/pull/1475)
+- Reduced Sentry span sampling to 10% outside development. [#1475](https://github.com/sourcebot-dev/sourcebot/pull/1475)
 
 ## [5.1.3] - 2026-07-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Reduced Sentry error event sampling to 10% outside development. [#1475](https://github.com/sourcebot-dev/sourcebot/pull/1475)
+
 ## [5.1.3] - 2026-07-20
 
 ### Added

--- a/packages/backend/src/instrument.ts
+++ b/packages/backend/src/instrument.ts
@@ -12,6 +12,7 @@ if (!!env.NEXT_PUBLIC_SENTRY_BACKEND_DSN && !!env.NEXT_PUBLIC_SENTRY_ENVIRONMENT
         // to the version for builds that don't pass a commit SHA.
         release: env.NEXT_PUBLIC_BUILD_COMMIT_SHA ?? SOURCEBOT_VERSION,
         environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+        sampleRate: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
     });
 } else {
     logger.debug("Sentry was not initialized");

--- a/packages/backend/src/instrument.ts
+++ b/packages/backend/src/instrument.ts
@@ -12,7 +12,7 @@ if (!!env.NEXT_PUBLIC_SENTRY_BACKEND_DSN && !!env.NEXT_PUBLIC_SENTRY_ENVIRONMENT
         // to the version for builds that don't pass a commit SHA.
         release: env.NEXT_PUBLIC_BUILD_COMMIT_SHA ?? SOURCEBOT_VERSION,
         environment: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        sampleRate: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
+        tracesSampleRate: env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
     });
 } else {
     logger.debug("Sentry was not initialized");

--- a/packages/web/src/instrumentation-client.ts
+++ b/packages/web/src/instrumentation-client.ts
@@ -12,11 +12,10 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         integrations: [
             Sentry.browserProfilingIntegration(),
         ],
-        tracesSampleRate: 1.0,
+        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         // Evaluated once per `Sentry.init()`, i.e. once per page load.
         profileSessionSampleRate: 1.0,
         // Profile only while a sampled root span is active, rather than continuously.

--- a/packages/web/src/instrumentation-client.ts
+++ b/packages/web/src/instrumentation-client.ts
@@ -12,6 +12,7 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         integrations: [
             Sentry.browserProfilingIntegration(),
         ],

--- a/packages/web/src/sentry.edge.config.ts
+++ b/packages/web/src/sentry.edge.config.ts
@@ -9,6 +9,7 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
 
         tracesSampleRate: 1.0,
 

--- a/packages/web/src/sentry.edge.config.ts
+++ b/packages/web/src/sentry.edge.config.ts
@@ -9,9 +9,8 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
 
-        tracesSampleRate: 1.0,
+        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,

--- a/packages/web/src/sentry.server.config.ts
+++ b/packages/web/src/sentry.server.config.ts
@@ -12,6 +12,7 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
+        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         integrations: [
             nodeProfilingIntegration(),
         ],

--- a/packages/web/src/sentry.server.config.ts
+++ b/packages/web/src/sentry.server.config.ts
@@ -12,11 +12,10 @@ if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SEN
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        sampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         integrations: [
             nodeProfilingIntegration(),
         ],
-        tracesSampleRate: 1.0,
+        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
         // Evaluated once per `Sentry.init()`, i.e. once per server process.
         profileSessionSampleRate: 1.0,
         // Profile only while a sampled root span is active, rather than continuously.


### PR DESCRIPTION
Fixes SOU-1557

## Summary
- retain 100% Sentry span sampling in development
- sample 10% of spans in the browser, Next.js server and edge runtimes, and backend worker in every other environment
- leave Sentry error event sampling unchanged

## Testing
- `yarn workspace @sourcebot/web exec eslint src/instrumentation-client.ts src/sentry.server.config.ts src/sentry.edge.config.ts`
- `yarn workspace @sourcebot/backend exec tsc --noEmit`
- `yarn workspace @sourcebot/web exec tsc --noEmit --skipLibCheck --target es2022 --module esnext --moduleResolution bundler src/instrumentation-client.ts src/sentry.edge.config.ts src/sentry.server.config.ts`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Adjusted Sentry performance/error capture sampling to use 100% in development and 10% outside development.
  * Applied consistently across backend, web client, server, and edge Sentry initialization.
* **Documentation**
  * Updated the changelog to reflect the environment-based sampling change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->