### PR TITLE
fix: surface permission sync issues requiring user action

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `tar` to `^7.5.20`. [#1474](https://github.com/sourcebot-dev/sourcebot/pull/1474)
 - [EE] Preserved cached repository permissions when OAuth token refresh fails because of a transient code host outage. [#1481](https://github.com/sourcebot-dev/sourcebot/pull/1481)
 - [EE] Classified code host permission sync failures by provider context before clearing cached repository permissions. [#1482](https://github.com/sourcebot-dev/sourcebot/pull/1482)
+- [EE] Added action-required warnings and guided recovery when permission syncing clears cached repository access. [#1484](https://github.com/sourcebot-dev/sourcebot/pull/1484)
 
 ### Changed
 - Reduced Sentry span sampling to 10% outside development. [#1475](https://github.com/sourcebot-dev/sourcebot/pull/1475)

--- a/packages/backend/src/ee/accountPermissionSyncer.test.ts
+++ b/packages/backend/src/ee/accountPermissionSyncer.test.ts
@@ -129,8 +129,8 @@ describe('classifyPermissionSyncFailure', () => {
 });
 
 describe('permission sync issue lifecycle', () => {
-    test('atomically records a reauthentication issue when invalid_grant clears permissions', async () => {
-        const error = tokenRefreshError('invalid_grant', 400);
+    test('atomically records a reauthentication issue when the refresh token is rejected', async () => {
+        const error = tokenRefreshError('refresh_token_rejected', 400);
         const { db, job, syncer } = createSyncerHarness(error);
 
         await expect(syncer.runJob(job)).rejects.toBe(error);
@@ -149,7 +149,7 @@ describe('permission sync issue lifecycle', () => {
     });
 
     test('records an issue when permissions were already cleared by an earlier attempt', async () => {
-        const error = tokenRefreshError('invalid_grant', 400);
+        const error = tokenRefreshError('refresh_token_rejected', 400);
         const { db, job, syncer } = createSyncerHarness(error, 0);
 
         await expect(syncer.runJob(job)).rejects.toBe(error);

--- a/packages/backend/src/ee/accountPermissionSyncer.test.ts
+++ b/packages/backend/src/ee/accountPermissionSyncer.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, test } from 'vitest';
-import { classifyPermissionSyncFailure } from './accountPermissionSyncer.js';
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    hasEntitlement: vi.fn(),
+}));
+
+vi.mock('../entitlements.js', () => ({
+    hasEntitlement: mocks.hasEntitlement,
+}));
+
+import { AccountPermissionSyncer, classifyPermissionSyncFailure } from './accountPermissionSyncer.js';
 import {
     PermissionSyncUpstreamError,
     type PermissionSyncUpstreamErrorKind,
@@ -20,6 +29,49 @@ const upstreamError = (
     kind,
     provider: 'github',
     operation: 'list_accessible_repositories',
+});
+
+const createSyncerHarness = (syncError?: Error, permissionCount = 95) => {
+    const account = {
+        id: 'account_1',
+        providerId: 'bitbucket-server',
+        user: { email: 'user@example.com' },
+    };
+    const db = {
+        accountPermissionSyncJob: {
+            update: vi.fn().mockResolvedValue({ account }),
+        },
+        accountToRepoPermission: {
+            deleteMany: vi.fn().mockResolvedValue({ count: permissionCount }),
+        },
+        account: {
+            update: vi.fn().mockResolvedValue(account),
+        },
+        $transaction: vi.fn((queries: Array<Promise<unknown>>) => Promise.all(queries)),
+    };
+    const syncAccountPermissions = syncError
+        ? vi.fn().mockRejectedValue(syncError)
+        : vi.fn().mockResolvedValue(undefined);
+    const syncer = Object.create(AccountPermissionSyncer.prototype) as {
+        db: typeof db;
+        syncAccountPermissions: typeof syncAccountPermissions;
+        runJob(job: { data: { jobId: string } }): Promise<void>;
+        onJobCompleted(job: { data: { jobId: string } }): Promise<void>;
+    };
+    syncer.db = db;
+    syncer.syncAccountPermissions = syncAccountPermissions;
+
+    return {
+        account,
+        db,
+        job: { data: { jobId: 'job_1' } },
+        syncer,
+    };
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.hasEntitlement.mockResolvedValue(true);
 });
 
 describe('classifyPermissionSyncFailure', () => {
@@ -73,5 +125,81 @@ describe('classifyPermissionSyncFailure', () => {
         expect(classifyPermissionSyncFailure(error)).toEqual({
             action: 'preserve_permissions',
         });
+    });
+});
+
+describe('permission sync issue lifecycle', () => {
+    test('atomically records a reauthentication issue when invalid_grant clears permissions', async () => {
+        const error = tokenRefreshError('invalid_grant', 400);
+        const { db, job, syncer } = createSyncerHarness(error);
+
+        await expect(syncer.runJob(job)).rejects.toBe(error);
+
+        expect(db.accountToRepoPermission.deleteMany).toHaveBeenCalledWith({
+            where: { accountId: 'account_1' },
+        });
+        expect(db.account.update).toHaveBeenCalledWith({
+            where: { id: 'account_1' },
+            data: {
+                permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
+                permissionSyncIssueAt: expect.any(Date),
+            },
+        });
+        expect(db.$transaction).toHaveBeenCalledOnce();
+    });
+
+    test('records an issue when permissions were already cleared by an earlier attempt', async () => {
+        const error = tokenRefreshError('invalid_grant', 400);
+        const { db, job, syncer } = createSyncerHarness(error, 0);
+
+        await expect(syncer.runJob(job)).rejects.toBe(error);
+
+        expect(db.account.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
+            }),
+        }));
+        expect(db.$transaction).toHaveBeenCalledOnce();
+    });
+
+    test('records an insufficient-scope issue for scope failures', async () => {
+        const error = upstreamError('insufficient_scope');
+        const { db, job, syncer } = createSyncerHarness(error);
+
+        await expect(syncer.runJob(job)).rejects.toBe(error);
+
+        expect(db.account.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                permissionSyncIssue: 'INSUFFICIENT_SCOPE',
+            }),
+        }));
+    });
+
+    test('does not record an issue or clear permissions for a transient refresh failure', async () => {
+        const error = tokenRefreshError('transient', 500);
+        const { db, job, syncer } = createSyncerHarness(error);
+
+        await expect(syncer.runJob(job)).rejects.toBe(error);
+
+        expect(db.accountToRepoPermission.deleteMany).not.toHaveBeenCalled();
+        expect(db.account.update).not.toHaveBeenCalled();
+        expect(db.$transaction).not.toHaveBeenCalled();
+    });
+
+    test('clears the action-required issue after a successful permission sync', async () => {
+        const { db, job, syncer } = createSyncerHarness();
+
+        await syncer.onJobCompleted(job);
+
+        expect(db.accountPermissionSyncJob.update).toHaveBeenCalledWith(expect.objectContaining({
+            data: expect.objectContaining({
+                account: {
+                    update: expect.objectContaining({
+                        permissionSyncIssue: null,
+                        permissionSyncIssueAt: null,
+                    }),
+                },
+            }),
+        }));
     });
 });

--- a/packages/backend/src/ee/accountPermissionSyncer.ts
+++ b/packages/backend/src/ee/accountPermissionSyncer.ts
@@ -1,5 +1,11 @@
 import * as Sentry from "@sentry/node";
-import { PrismaClient, AccountPermissionSyncJobStatus, Account, PermissionSyncSource} from "@sourcebot/db";
+import {
+    PrismaClient,
+    AccountPermissionSyncIssue,
+    AccountPermissionSyncJobStatus,
+    Account,
+    PermissionSyncSource,
+} from "@sourcebot/db";
 import { env, createLogger, getIdentityProviderConfig, PERMISSION_SYNC_SUPPORTED_IDENTITY_PROVIDERS } from "@sourcebot/shared";
 import { hasEntitlement } from "../entitlements.js";
 import { ensureFreshAccountToken, TokenRefreshError } from "./tokenRefresh.js";
@@ -46,10 +52,22 @@ export type PermissionCleanupDecision =
         action: 'preserve_permissions';
     };
 
-const PERMISSION_CLEANUP_REASON_MESSAGES: Record<PermissionCleanupReason, string> = {
-    oauth_refresh_token_rejected: 'OAuth refresh token rejection',
-    upstream_credential_rejected: 'upstream credential rejection',
-    upstream_insufficient_scope: 'insufficient OAuth scope',
+const PERMISSION_CLEANUP_DETAILS: Record<PermissionCleanupReason, {
+    message: string;
+    issue: AccountPermissionSyncIssue;
+}> = {
+    oauth_refresh_token_rejected: {
+        message: 'OAuth refresh token rejection',
+        issue: AccountPermissionSyncIssue.REAUTHENTICATION_REQUIRED,
+    },
+    upstream_credential_rejected: {
+        message: 'upstream credential rejection',
+        issue: AccountPermissionSyncIssue.REAUTHENTICATION_REQUIRED,
+    },
+    upstream_insufficient_scope: {
+        message: 'insufficient OAuth scope',
+        issue: AccountPermissionSyncIssue.INSUFFICIENT_SCOPE,
+    },
 };
 
 export const classifyPermissionSyncFailure = (error: unknown): PermissionCleanupDecision => {
@@ -238,12 +256,21 @@ export class AccountPermissionSyncer {
             const cleanupDecision = classifyPermissionSyncFailure(error);
 
             if (cleanupDecision.action === 'clear_permissions') {
-                const { count } = await this.db.accountToRepoPermission.deleteMany({
-                    where: { accountId: account.id },
-                });
+                const details = PERMISSION_CLEANUP_DETAILS[cleanupDecision.reason];
+                const [{ count }] = await this.db.$transaction([
+                    this.db.accountToRepoPermission.deleteMany({
+                        where: { accountId: account.id },
+                    }),
+                    this.db.account.update({
+                        where: { id: account.id },
+                        data: {
+                            permissionSyncIssue: details.issue,
+                            permissionSyncIssueAt: new Date(),
+                        },
+                    }),
+                ]);
                 const message = error instanceof Error ? error.message : String(error);
-                const reason = PERMISSION_CLEANUP_REASON_MESSAGES[cleanupDecision.reason];
-                logger.warn(`Cleared ${count} permission row(s) for account ${account.id} (user ${account.user.email ?? 'unknown'}) — fail-closed cleanup triggered by ${reason}: ${message}`);
+                logger.warn(`Cleared ${count} permission row(s) for account ${account.id} (user ${account.user.email ?? 'unknown'}) — fail-closed cleanup triggered by ${details.message}: ${message}`);
             }
             throw error;
         }
@@ -451,6 +478,8 @@ export class AccountPermissionSyncer {
                 account: {
                     update: {
                         permissionSyncedAt: new Date(),
+                        permissionSyncIssue: null,
+                        permissionSyncIssueAt: null,
                     },
                 },
                 completedAt: new Date(),

--- a/packages/db/prisma/migrations/20260722144824_add_account_permission_sync_issue/migration.sql
+++ b/packages/db/prisma/migrations/20260722144824_add_account_permission_sync_issue/migration.sql
@@ -1,0 +1,7 @@
+-- CreateEnum
+CREATE TYPE "AccountPermissionSyncIssue" AS ENUM ('REAUTHENTICATION_REQUIRED', 'INSUFFICIENT_SCOPE');
+
+-- AlterTable
+ALTER TABLE "Account"
+ADD COLUMN "permissionSyncIssue" "AccountPermissionSyncIssue",
+ADD COLUMN "permissionSyncIssueAt" TIMESTAMP(3);

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -562,6 +562,11 @@ enum PermissionSyncSource {
   REPO_DRIVEN
 }
 
+enum AccountPermissionSyncIssue {
+  REAUTHENTICATION_REQUIRED
+  INSUFFICIENT_SCOPE
+}
+
 model AccountToRepoPermission {
   createdAt DateTime @default(now())
 
@@ -607,7 +612,12 @@ model Account {
   permissionSyncJobs AccountPermissionSyncJob[]
   permissionSyncedAt DateTime?
 
-  /// Set when an OAuth token refresh fails and the account needs to be re-linked by the user.
+  /// Set when permission syncing fails closed and user action is required.
+  /// Cleared after a subsequent permission sync completes successfully.
+  permissionSyncIssue   AccountPermissionSyncIssue?
+  permissionSyncIssueAt DateTime?
+
+  /// Last OAuth token refresh failure, retained for diagnostics.
   /// Cleared when the user successfully re-authenticates.
   tokenRefreshErrorMessage String?
 

--- a/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
+++ b/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
@@ -110,6 +110,7 @@ describe('resolveActiveBanner', () => {
                     providerType: 'bitbucket-server',
                     reason: 'REAUTHENTICATION_REQUIRED',
                     occurredAt: NOW.toISOString(),
+                    isSyncing: false,
                 }],
             }));
             expect(result?.id).toBe('permissionSync');

--- a/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
+++ b/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
@@ -78,6 +78,7 @@ const makeContext = (overrides: Partial<BannerContext> = {}): BannerContext => (
     offlineLicense: null,
     hasPermissionSyncEntitlement: false,
     hasPendingFirstSync: false,
+    permissionSyncIssues: [],
     dismissals: {},
     today: TODAY,
     now: NOW,
@@ -98,6 +99,21 @@ describe('resolveActiveBanner', () => {
                 hasPendingFirstSync: true,
             }));
             expect(result?.id).toBe('permissionSync');
+        });
+
+        test('shows permission sync banner when an account requires reauthentication', () => {
+            const result = resolveActiveBanner(makeContext({
+                hasPermissionSyncEntitlement: true,
+                permissionSyncIssues: [{
+                    accountId: 'account_1',
+                    providerId: 'bitbucket-server',
+                    providerType: 'bitbucket-server',
+                    reason: 'REAUTHENTICATION_REQUIRED',
+                    occurredAt: NOW.toISOString(),
+                }],
+            }));
+            expect(result?.id).toBe('permissionSync');
+            expect(result?.dismissible).toBe(false);
         });
 
         test('license expired outranks permission sync', () => {

--- a/packages/web/src/app/(app)/components/banners/bannerResolver.tsx
+++ b/packages/web/src/app/(app)/components/banners/bannerResolver.tsx
@@ -15,6 +15,7 @@ import { InvoicePastDueBanner } from "./invoicePastDueBanner";
 import { ServicePingFailedBanner } from "./servicePingFailedBanner";
 import { TrialBanner } from "./trialBanner";
 import { UpgradeAvailableBanner } from "./upgradeAvailableBanner";
+import type { PermissionSyncStatusResponse } from "@/app/api/(server)/ee/permissionSyncStatus/api";
 
 // Mirrors the value in `lighthouse: lambda/serviceError.ts` and the gating
 // constant in `packages/shared/src/entitlements.ts`.
@@ -28,6 +29,7 @@ export interface BannerContext {
     offlineLicense: OfflineLicenseMetadata | null;
     hasPermissionSyncEntitlement: boolean;
     hasPendingFirstSync: boolean;
+    permissionSyncIssues: PermissionSyncStatusResponse['issues'];
     dismissals: Partial<Record<BannerId, string>>;
     today: string;
     now: Date;
@@ -155,14 +157,23 @@ function buildCandidates(ctx: BannerContext): BannerDescriptor[] {
         });
     }
 
-    if (ctx.hasPermissionSyncEntitlement && ctx.hasPendingFirstSync) {
+    if (
+        ctx.hasPermissionSyncEntitlement &&
+        (ctx.hasPendingFirstSync || ctx.permissionSyncIssues.length > 0)
+    ) {
         banners.push({
             id: 'permissionSync',
             priority: BannerPriority.PERMISSION_SYNC,
             dismissible: false,
             audience: 'everyone',
             render: (props) => (
-                <PermissionSyncBanner {...props} initialHasPendingFirstSync={true} />
+                <PermissionSyncBanner
+                    {...props}
+                    initialStatus={{
+                        hasPendingFirstSync: ctx.hasPendingFirstSync,
+                        issues: ctx.permissionSyncIssues,
+                    }}
+                />
             ),
         });
     }

--- a/packages/web/src/app/(app)/components/banners/permissionSyncBanner.test.tsx
+++ b/packages/web/src/app/(app)/components/banners/permissionSyncBanner.test.tsx
@@ -56,7 +56,7 @@ afterEach(() => {
 });
 
 describe('PermissionSyncBanner', () => {
-    test('explains that repository access was disabled when reauthentication is required', () => {
+    test('prompts the user to review linked accounts when reauthentication is required', () => {
         renderBanner({
             hasPendingFirstSync: false,
             issues: [{
@@ -65,16 +65,17 @@ describe('PermissionSyncBanner', () => {
                 providerType: 'bitbucket-server',
                 reason: 'REAUTHENTICATION_REQUIRED',
                 occurredAt: '2026-07-22T12:00:00.000Z',
+                isSyncing: false,
             }],
         });
 
         expect(screen.getByText('Repository access from Bitbucket Server needs attention.')).toBeTruthy();
-        expect(screen.getByText(/Private repository access has been disabled until you reconnect/)).toBeTruthy();
+        expect(screen.getByText(/Review your linked accounts to restore access to private repositories/)).toBeTruthy();
         expect(screen.getByRole('link', { name: 'Review linked accounts' }).getAttribute('href'))
             .toBe('/settings/linked-accounts');
     });
 
-    test('provides scope-specific remediation', () => {
+    test('uses the same remediation when additional scope is required', () => {
         renderBanner({
             hasPendingFirstSync: false,
             issues: [{
@@ -83,16 +84,33 @@ describe('PermissionSyncBanner', () => {
                 providerType: 'github',
                 reason: 'INSUFFICIENT_SCOPE',
                 occurredAt: null,
+                isSyncing: false,
             }],
         });
 
-        expect(screen.getByText(/required OAuth scope was not granted/)).toBeTruthy();
-        expect(screen.getByText(/until you reauthorize/)).toBeTruthy();
+        expect(screen.getByText(/Review your linked accounts to restore access to private repositories/)).toBeTruthy();
     });
 
     test('retains the existing initial-sync progress state', () => {
         renderBanner({ hasPendingFirstSync: true, issues: [] });
 
         expect(screen.getByText(/Syncing repository access with Sourcebot/)).toBeTruthy();
+    });
+
+    test('shows syncing while recovering an account with an unresolved issue', () => {
+        renderBanner({
+            hasPendingFirstSync: false,
+            issues: [{
+                accountId: 'account_1',
+                providerId: 'bitbucket-server-corp',
+                providerType: 'bitbucket-server',
+                reason: 'REAUTHENTICATION_REQUIRED',
+                occurredAt: '2026-07-22T12:00:00.000Z',
+                isSyncing: true,
+            }],
+        });
+
+        expect(screen.getByText(/Syncing repository access with Sourcebot/)).toBeTruthy();
+        expect(screen.queryByText(/needs attention/)).toBeNull();
     });
 });

--- a/packages/web/src/app/(app)/components/banners/permissionSyncBanner.test.tsx
+++ b/packages/web/src/app/(app)/components/banners/permissionSyncBanner.test.tsx
@@ -1,0 +1,98 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { PermissionSyncStatusResponse } from '@/app/api/(server)/ee/permissionSyncStatus/api';
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('@/app/api/(client)/client', () => ({
+    getPermissionSyncStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/utils', () => ({
+    cn: (...classes: Array<string | false | undefined>) => classes.filter(Boolean).join(' '),
+    getAuthProviderInfo: () => ({ displayName: 'Bitbucket Server' }),
+    unwrapServiceError: (value: unknown) => value,
+}));
+
+vi.mock('./bannerShell', () => ({
+    BannerShell: ({ title, description, action }: {
+        title: ReactNode;
+        description?: ReactNode;
+        action?: ReactNode;
+    }) => (
+        <div>
+            <div>{title}</div>
+            <div>{description}</div>
+            <div>{action}</div>
+        </div>
+    ),
+}));
+
+const { PermissionSyncBanner } = await import('./permissionSyncBanner');
+
+const renderBanner = (initialStatus: PermissionSyncStatusResponse) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <PermissionSyncBanner
+                id="permissionSync"
+                dismissible={false}
+                role="MEMBER"
+                now={new Date('2026-07-22T12:00:00Z')}
+                initialStatus={initialStatus}
+            />
+        </QueryClientProvider>,
+    );
+};
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('PermissionSyncBanner', () => {
+    test('explains that repository access was disabled when reauthentication is required', () => {
+        renderBanner({
+            hasPendingFirstSync: false,
+            issues: [{
+                accountId: 'account_1',
+                providerId: 'bitbucket-server-corp',
+                providerType: 'bitbucket-server',
+                reason: 'REAUTHENTICATION_REQUIRED',
+                occurredAt: '2026-07-22T12:00:00.000Z',
+            }],
+        });
+
+        expect(screen.getByText('Repository access from Bitbucket Server needs attention.')).toBeTruthy();
+        expect(screen.getByText(/Private repository access has been disabled until you reconnect/)).toBeTruthy();
+        expect(screen.getByRole('link', { name: 'Review linked accounts' }).getAttribute('href'))
+            .toBe('/settings/linked-accounts');
+    });
+
+    test('provides scope-specific remediation', () => {
+        renderBanner({
+            hasPendingFirstSync: false,
+            issues: [{
+                accountId: 'account_1',
+                providerId: 'github',
+                providerType: 'github',
+                reason: 'INSUFFICIENT_SCOPE',
+                occurredAt: null,
+            }],
+        });
+
+        expect(screen.getByText(/required OAuth scope was not granted/)).toBeTruthy();
+        expect(screen.getByText(/until you reauthorize/)).toBeTruthy();
+    });
+
+    test('retains the existing initial-sync progress state', () => {
+        renderBanner({ hasPendingFirstSync: true, issues: [] });
+
+        expect(screen.getByText(/Syncing repository access with Sourcebot/)).toBeTruthy();
+    });
+});

--- a/packages/web/src/app/(app)/components/banners/permissionSyncBanner.tsx
+++ b/packages/web/src/app/(app)/components/banners/permissionSyncBanner.tsx
@@ -1,52 +1,86 @@
 'use client';
 
-import { Loader2, Info } from "lucide-react";
+import { AlertTriangle, Info, Loader2 } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { unwrapServiceError } from "@/lib/utils";
+import { getAuthProviderInfo, unwrapServiceError } from "@/lib/utils";
 import { getPermissionSyncStatus } from "@/app/api/(client)/client";
 import { useRouter } from "next/navigation";
 import { useEffect } from "react";
 import { usePrevious } from "@uidotdev/usehooks";
 import { BannerShell } from "./bannerShell";
 import type { BannerProps } from "./types";
+import type { PermissionSyncStatusResponse } from "@/app/api/(server)/ee/permissionSyncStatus/api";
+import { Button } from "@/components/ui/button";
+import Link from "next/link";
 
 const POLL_INTERVAL_MS = 5000;
+const ISSUE_POLL_INTERVAL_MS = 30000;
 
 interface PermissionSyncBannerProps extends BannerProps {
-    initialHasPendingFirstSync: boolean;
+    initialStatus: PermissionSyncStatusResponse;
 }
 
-export function PermissionSyncBanner({ id, dismissible, initialHasPendingFirstSync }: PermissionSyncBannerProps) {
+export function PermissionSyncBanner({ id, dismissible, initialStatus }: PermissionSyncBannerProps) {
     const router = useRouter();
 
-    const { data: hasPendingFirstSync, isError, isPending } = useQuery({
+    const { data: status, isError, isPending } = useQuery({
         queryKey: ["permissionSyncStatus"],
         queryFn: () => unwrapServiceError(getPermissionSyncStatus()),
-        select: (data) => {
-            return data.hasPendingFirstSync;
-        },
         refetchInterval: (query) => {
-            const hasPendingFirstSync = query.state.data?.hasPendingFirstSync;
-            return hasPendingFirstSync ? POLL_INTERVAL_MS : false;
+            if (query.state.data?.hasPendingFirstSync) {
+                return POLL_INTERVAL_MS;
+            }
+            return query.state.data?.issues.length ? ISSUE_POLL_INTERVAL_MS : false;
         },
-        initialData: {
-            hasPendingFirstSync: initialHasPendingFirstSync,
-        }
+        initialData: initialStatus,
     });
 
-    const previousHasPendingFirstSync = usePrevious(hasPendingFirstSync);
+    const previousHasPendingFirstSync = usePrevious(status.hasPendingFirstSync);
+    const previousIssueCount = usePrevious(status.issues.length);
 
     useEffect(() => {
-        if (previousHasPendingFirstSync === true && hasPendingFirstSync === false) {
+        const initialSyncCompleted =
+            previousHasPendingFirstSync === true && status.hasPendingFirstSync === false;
+        const issueResolved = previousIssueCount !== undefined &&
+            previousIssueCount > 0 && status.issues.length === 0;
+        if (initialSyncCompleted || issueResolved) {
             router.refresh();
         }
-    }, [hasPendingFirstSync, previousHasPendingFirstSync, router]);
+    }, [status.hasPendingFirstSync, status.issues.length, previousHasPendingFirstSync, previousIssueCount, router]);
 
     if (isError || isPending) {
         return null;
     }
 
-    if (!hasPendingFirstSync) {
+    const issue = status.issues[0];
+    if (issue) {
+        const providerName = status.issues.length === 1
+            ? getAuthProviderInfo(issue.providerType).displayName
+            : `${status.issues.length} code hosts`;
+        const requiresAdditionalScope = status.issues.some(({ reason }) => reason === 'INSUFFICIENT_SCOPE');
+        const description = status.issues.length > 1
+            ? "Sourcebot could not verify permissions for multiple linked accounts. Private repository access has been disabled until you review and reauthorize the affected accounts."
+            : requiresAdditionalScope
+                ? "Sourcebot could not verify your repository permissions because the required OAuth scope was not granted. Private repository access has been disabled until you reauthorize the affected account."
+                : "Sourcebot could not verify your repository permissions. Private repository access has been disabled until you reconnect the affected account.";
+
+        return (
+            <BannerShell
+                id={id}
+                dismissible={dismissible}
+                icon={<AlertTriangle className="h-4 w-4 mt-0.5" />}
+                title={`Repository access from ${providerName} needs attention.`}
+                description={description}
+                action={(
+                    <Button asChild variant="outline" size="sm">
+                        <Link href="/settings/linked-accounts">Review linked accounts</Link>
+                    </Button>
+                )}
+            />
+        );
+    }
+
+    if (!status.hasPendingFirstSync) {
         return null;
     }
 

--- a/packages/web/src/app/(app)/components/banners/permissionSyncBanner.tsx
+++ b/packages/web/src/app/(app)/components/banners/permissionSyncBanner.tsx
@@ -14,7 +14,6 @@ import { Button } from "@/components/ui/button";
 import Link from "next/link";
 
 const POLL_INTERVAL_MS = 5000;
-const ISSUE_POLL_INTERVAL_MS = 30000;
 
 interface PermissionSyncBannerProps extends BannerProps {
     initialStatus: PermissionSyncStatusResponse;
@@ -27,10 +26,10 @@ export function PermissionSyncBanner({ id, dismissible, initialStatus }: Permiss
         queryKey: ["permissionSyncStatus"],
         queryFn: () => unwrapServiceError(getPermissionSyncStatus()),
         refetchInterval: (query) => {
-            if (query.state.data?.hasPendingFirstSync) {
-                return POLL_INTERVAL_MS;
-            }
-            return query.state.data?.issues.length ? ISSUE_POLL_INTERVAL_MS : false;
+            const status = query.state.data;
+            return status?.hasPendingFirstSync || status?.issues.length
+                ? POLL_INTERVAL_MS
+                : false;
         },
         initialData: initialStatus,
     });
@@ -52,17 +51,29 @@ export function PermissionSyncBanner({ id, dismissible, initialStatus }: Permiss
         return null;
     }
 
+    const hasActiveRecoverySync = status.issues.some(issue => issue.isSyncing);
+    if (status.hasPendingFirstSync || hasActiveRecoverySync) {
+        return (
+            <BannerShell
+                id={id}
+                dismissible={dismissible}
+                icon={<Info className="h-4 w-4 mt-0.5" />}
+                title={
+                    <span className="flex items-center gap-2">
+                        Syncing repository access with Sourcebot.
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                    </span>
+                }
+                description="Sourcebot is syncing what repositories you have access to from a code host. This may take a minute."
+            />
+        );
+    }
+
     const issue = status.issues[0];
     if (issue) {
         const providerName = status.issues.length === 1
             ? getAuthProviderInfo(issue.providerType).displayName
             : `${status.issues.length} code hosts`;
-        const requiresAdditionalScope = status.issues.some(({ reason }) => reason === 'INSUFFICIENT_SCOPE');
-        const description = status.issues.length > 1
-            ? "Sourcebot could not verify permissions for multiple linked accounts. Private repository access has been disabled until you review and reauthorize the affected accounts."
-            : requiresAdditionalScope
-                ? "Sourcebot could not verify your repository permissions because the required OAuth scope was not granted. Private repository access has been disabled until you reauthorize the affected account."
-                : "Sourcebot could not verify your repository permissions. Private repository access has been disabled until you reconnect the affected account.";
 
         return (
             <BannerShell
@@ -70,7 +81,7 @@ export function PermissionSyncBanner({ id, dismissible, initialStatus }: Permiss
                 dismissible={dismissible}
                 icon={<AlertTriangle className="h-4 w-4 mt-0.5" />}
                 title={`Repository access from ${providerName} needs attention.`}
-                description={description}
+                description="Sourcebot could not verify your repository permissions. Review your linked accounts to restore access to private repositories."
                 action={(
                     <Button asChild variant="outline" size="sm">
                         <Link href="/settings/linked-accounts">Review linked accounts</Link>
@@ -80,22 +91,5 @@ export function PermissionSyncBanner({ id, dismissible, initialStatus }: Permiss
         );
     }
 
-    if (!status.hasPendingFirstSync) {
-        return null;
-    }
-
-    return (
-        <BannerShell
-            id={id}
-            dismissible={dismissible}
-            icon={<Info className="h-4 w-4 mt-0.5" />}
-            title={
-                <span className="flex items-center gap-2">
-                    Syncing repository access with Sourcebot.
-                    <Loader2 className="h-4 w-4 animate-spin" />
-                </span>
-            }
-            description="Sourcebot is syncing what repositories you have access to from a code host. This may take a minute."
-        />
-    );
+    return null;
 }

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -165,6 +165,10 @@ export default async function Layout(props: LayoutProps) {
         permissionSyncStatus !== null && !isServiceError(permissionSyncStatus)
             ? permissionSyncStatus.hasPendingFirstSync
             : false;
+    const permissionSyncIssues =
+        permissionSyncStatus !== null && !isServiceError(permissionSyncStatus)
+            ? permissionSyncStatus.issues
+            : [];
 
     const offlineLicense = getOfflineLicenseMetadata();
     const license = offlineLicense
@@ -198,6 +202,7 @@ export default async function Layout(props: LayoutProps) {
                                                     offlineLicense={offlineLicense}
                                                     hasPermissionSyncEntitlement={hasPermissionSyncEntitlement}
                                                     hasPendingFirstSync={hasPendingFirstSync}
+                                                    permissionSyncIssues={permissionSyncIssues}
                                                     currentVersion={SOURCEBOT_VERSION}
                                                     latestVersion={latestVersion}
                                                 />

--- a/packages/web/src/app/api/(server)/ee/accountPermissionSyncJobStatus/api.test.ts
+++ b/packages/web/src/app/api/(server)/ee/accountPermissionSyncJobStatus/api.test.ts
@@ -1,0 +1,40 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as unknown,
+}));
+
+vi.mock('@/middleware/withAuth', () => ({
+    withAuth: vi.fn((callback: (context: unknown) => unknown) => callback(mocks.authContext)),
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({ error: vi.fn() }),
+}));
+
+const { getAccountSyncStatus } = await import('./api');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe('getAccountSyncStatus', () => {
+    test.each(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED'] as const)(
+        'returns the underlying %s job status',
+        async (status) => {
+            const findFirst = vi.fn().mockResolvedValue({ status });
+            mocks.authContext = {
+                user: { id: 'user_1' },
+                prisma: { accountPermissionSyncJob: { findFirst } },
+            };
+
+            await expect(getAccountSyncStatus('job_1')).resolves.toEqual({ status });
+            expect(findFirst).toHaveBeenCalledWith({
+                where: {
+                    id: 'job_1',
+                    account: { userId: 'user_1' },
+                },
+            });
+        },
+    );
+});

--- a/packages/web/src/app/api/(server)/ee/accountPermissionSyncJobStatus/api.ts
+++ b/packages/web/src/app/api/(server)/ee/accountPermissionSyncJobStatus/api.ts
@@ -6,7 +6,7 @@ import { AccountPermissionSyncJobStatus } from "@sourcebot/db";
 import { sew } from "@/middleware/sew";
 
 export interface AccountSyncStatusResponse {
-    isSyncing: boolean;
+    status: AccountPermissionSyncJobStatus;
 }
 
 export const getAccountSyncStatus = async (jobId: string): Promise<AccountSyncStatusResponse | ServiceError> =>
@@ -20,12 +20,5 @@ export const getAccountSyncStatus = async (jobId: string): Promise<AccountSyncSt
 
         if (!job) return notFound();
 
-        const activeStatuses: AccountPermissionSyncJobStatus[] = [
-            AccountPermissionSyncJobStatus.PENDING,
-            AccountPermissionSyncJobStatus.IN_PROGRESS,
-        ];
-
-        const isSyncing = activeStatuses.includes(job.status);
-
-        return { isSyncing } satisfies AccountSyncStatusResponse;
+        return { status: job.status } satisfies AccountSyncStatusResponse;
     }));

--- a/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.test.ts
+++ b/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.test.ts
@@ -50,7 +50,7 @@ describe('getPermissionSyncStatus', () => {
                 permissionSyncedAt: new Date('2026-07-01T00:00:00Z'),
                 permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
                 permissionSyncIssueAt: new Date('2026-07-22T12:00:00Z'),
-                permissionSyncJobs: [{ status: 'FAILED' }],
+                permissionSyncJobs: [{ status: 'PENDING' }],
             },
         ]);
         mocks.authContext = {
@@ -66,6 +66,7 @@ describe('getPermissionSyncStatus', () => {
                 providerType: 'bitbucket-server',
                 reason: 'REAUTHENTICATION_REQUIRED',
                 occurredAt: '2026-07-22T12:00:00.000Z',
+                isSyncing: true,
             }],
         });
         expect(findMany).toHaveBeenCalledWith(expect.objectContaining({
@@ -92,7 +93,7 @@ describe('getPermissionSyncStatus', () => {
         };
 
         await expect(getPermissionSyncStatus()).resolves.toMatchObject({
-            issues: [{ reason: 'INSUFFICIENT_SCOPE', occurredAt: null }],
+            issues: [{ reason: 'INSUFFICIENT_SCOPE', occurredAt: null, isSyncing: false }],
         });
     });
 });

--- a/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.test.ts
+++ b/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.test.ts
@@ -1,0 +1,98 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as unknown,
+    getEntitlements: vi.fn(),
+}));
+
+vi.mock('@/middleware/withAuth', () => ({
+    withAuth: vi.fn((callback: (context: unknown) => unknown) => callback(mocks.authContext)),
+}));
+
+vi.mock('@/lib/entitlements', () => ({
+    getEntitlements: mocks.getEntitlements,
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({ error: vi.fn() }),
+    env: { PERMISSION_SYNC_ENABLED: 'true' },
+    PERMISSION_SYNC_SUPPORTED_IDENTITY_PROVIDERS: [
+        'github',
+        'gitlab',
+        'bitbucket-cloud',
+        'bitbucket-server',
+    ],
+}));
+
+const { getPermissionSyncStatus } = await import('./api');
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    mocks.getEntitlements.mockResolvedValue(['permission-syncing']);
+});
+
+describe('getPermissionSyncStatus', () => {
+    test('returns pending first-sync state and structured account issues for the authenticated user', async () => {
+        const findMany = vi.fn().mockResolvedValue([
+            {
+                id: 'account_pending',
+                providerId: 'github',
+                providerType: 'github',
+                permissionSyncedAt: null,
+                permissionSyncIssue: null,
+                permissionSyncIssueAt: null,
+                permissionSyncJobs: [{ status: 'PENDING' }],
+            },
+            {
+                id: 'account_action_required',
+                providerId: 'bitbucket-server-corp',
+                providerType: 'bitbucket-server',
+                permissionSyncedAt: new Date('2026-07-01T00:00:00Z'),
+                permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
+                permissionSyncIssueAt: new Date('2026-07-22T12:00:00Z'),
+                permissionSyncJobs: [{ status: 'FAILED' }],
+            },
+        ]);
+        mocks.authContext = {
+            user: { id: 'user_1' },
+            prisma: { account: { findMany } },
+        };
+
+        await expect(getPermissionSyncStatus()).resolves.toEqual({
+            hasPendingFirstSync: true,
+            issues: [{
+                accountId: 'account_action_required',
+                providerId: 'bitbucket-server-corp',
+                providerType: 'bitbucket-server',
+                reason: 'REAUTHENTICATION_REQUIRED',
+                occurredAt: '2026-07-22T12:00:00.000Z',
+            }],
+        });
+        expect(findMany).toHaveBeenCalledWith(expect.objectContaining({
+            where: expect.objectContaining({ userId: 'user_1' }),
+        }));
+    });
+
+    test('returns an issue even when the account has no issue timestamp', async () => {
+        mocks.authContext = {
+            user: { id: 'user_1' },
+            prisma: {
+                account: {
+                    findMany: vi.fn().mockResolvedValue([{
+                        id: 'account_1',
+                        providerId: 'gitlab',
+                        providerType: 'gitlab',
+                        permissionSyncedAt: new Date('2026-07-01T00:00:00Z'),
+                        permissionSyncIssue: 'INSUFFICIENT_SCOPE',
+                        permissionSyncIssueAt: null,
+                        permissionSyncJobs: [{ status: 'FAILED' }],
+                    }]),
+                },
+            },
+        };
+
+        await expect(getPermissionSyncStatus()).resolves.toMatchObject({
+            issues: [{ reason: 'INSUFFICIENT_SCOPE', occurredAt: null }],
+        });
+    });
+});

--- a/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.ts
+++ b/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.ts
@@ -4,18 +4,25 @@ import { ServiceError } from "@/lib/serviceError";
 import { withAuth } from "@/middleware/withAuth";
 import { getEntitlements } from "@/lib/entitlements";
 import { env, PERMISSION_SYNC_SUPPORTED_IDENTITY_PROVIDERS } from "@sourcebot/shared";
-import { AccountPermissionSyncJobStatus } from "@sourcebot/db";
+import { AccountPermissionSyncJobStatus, type AccountPermissionSyncIssue } from "@sourcebot/db";
 import { StatusCodes } from "http-status-codes";
 import { ErrorCode } from "@/lib/errorCodes";
 import { sew } from "@/middleware/sew";
 
 export interface PermissionSyncStatusResponse {
     hasPendingFirstSync: boolean;
+    issues: Array<{
+        accountId: string;
+        providerId: string;
+        providerType: string;
+        reason: AccountPermissionSyncIssue;
+        occurredAt: string | null;
+    }>;
 }
 
 /**
- * Returns whether a user has a account that has it's permissions
- * synced for the first time.
+ * Returns initial-sync progress and action-required permission sync issues
+ * for the authenticated user's linked accounts.
  */
 export const getPermissionSyncStatus = async (): Promise<PermissionSyncStatusResponse | ServiceError> => sew(async () =>
     withAuth(async ({ prisma, user }) => {
@@ -34,7 +41,13 @@ export const getPermissionSyncStatus = async (): Promise<PermissionSyncStatusRes
                 userId: user.id,
                 providerType: { in: PERMISSION_SYNC_SUPPORTED_IDENTITY_PROVIDERS }
             },
-            include: {
+            select: {
+                id: true,
+                providerId: true,
+                providerType: true,
+                permissionSyncedAt: true,
+                permissionSyncIssue: true,
+                permissionSyncIssueAt: true,
                 permissionSyncJobs: {
                     orderBy: { createdAt: 'desc' },
                     take: 1,
@@ -54,8 +67,16 @@ export const getPermissionSyncStatus = async (): Promise<PermissionSyncStatusRes
                 // has not yet been scheduled for a new account, we consider
                 // accounts with no permission sync jobs as having a pending first sync.
                 (account.permissionSyncJobs.length === 0 || (account.permissionSyncJobs.length > 0 && activeStatuses.includes(account.permissionSyncJobs[0].status)))
-            )
+            );
 
-        return { hasPendingFirstSync } satisfies PermissionSyncStatusResponse;
+        const issues = accounts.flatMap(account => account.permissionSyncIssue === null ? [] : [{
+            accountId: account.id,
+            providerId: account.providerId,
+            providerType: account.providerType,
+            reason: account.permissionSyncIssue,
+            occurredAt: account.permissionSyncIssueAt?.toISOString() ?? null,
+        }]);
+
+        return { hasPendingFirstSync, issues } satisfies PermissionSyncStatusResponse;
     })
 )

--- a/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.ts
+++ b/packages/web/src/app/api/(server)/ee/permissionSyncStatus/api.ts
@@ -17,6 +17,7 @@ export interface PermissionSyncStatusResponse {
         providerType: string;
         reason: AccountPermissionSyncIssue;
         occurredAt: string | null;
+        isSyncing: boolean;
     }>;
 }
 
@@ -75,6 +76,7 @@ export const getPermissionSyncStatus = async (): Promise<PermissionSyncStatusRes
             providerType: account.providerType,
             reason: account.permissionSyncIssue,
             occurredAt: account.permissionSyncIssueAt?.toISOString() ?? null,
+            isSyncing: account.permissionSyncJobs.some(job => activeStatuses.includes(job.status)),
         }]);
 
         return { hasPendingFirstSync, issues } satisfies PermissionSyncStatusResponse;

--- a/packages/web/src/auth.ts
+++ b/packages/web/src/auth.ts
@@ -4,7 +4,7 @@ import NextAuth, { DefaultSession, Session, User as AuthJsUser } from "next-auth
 import Credentials from "next-auth/providers/credentials"
 import EmailProvider from "next-auth/providers/nodemailer";
 import { __unsafePrisma } from "@/prisma";
-import { env, getSMTPConnectionURL } from "@sourcebot/shared";
+import { createLogger, env, getSMTPConnectionURL } from "@sourcebot/shared";
 import { User } from '@sourcebot/db';
 import 'next-auth/jwt';
 import type { Provider } from "next-auth/providers";
@@ -23,8 +23,10 @@ import { captureEvent } from '@/lib/posthog';
 import { isEmailCodeLoginEnabled, isCredentialsLoginEnabled } from '@sourcebot/shared'
 import { onCreateUser } from './features/membership/onCreateUser';
 import { setSentryUser } from './lib/sentryUser';
+import { requestAccountPermissionSync } from './features/workerApi/client.server';
 
 export const runtime = 'nodejs';
+const logger = createLogger('auth');
 
 export type IdentityProvider = {
     /** Provider type (e.g., 'github', 'gitlab') — used to pick icon / display defaults. */
@@ -203,7 +205,7 @@ const nextAuthResult = NextAuth(async () => ({
             ) {
                 const issuerUrl = await getIssuerUrlForProviderId(account.provider);
 
-                await __unsafePrisma.account.update({
+                const updatedAccount = await __unsafePrisma.account.update({
                     where: {
                         providerId_providerAccountId: {
                             providerId: account.provider,
@@ -221,7 +223,21 @@ const nextAuthResult = NextAuth(async () => ({
                         // Clear any token refresh error since the user has successfully re-authenticated.
                         tokenRefreshErrorMessage: null,
                     })
-                })
+                });
+
+                if (
+                    updatedAccount.permissionSyncIssue !== null &&
+                    env.PERMISSION_SYNC_ENABLED === 'true'
+                ) {
+                    try {
+                        if (await hasEntitlement('permission-syncing')) {
+                            await requestAccountPermissionSync(updatedAccount.id);
+                        }
+                    } catch (error) {
+                        const message = error instanceof Error ? error.message : String(error);
+                        logger.error(`Failed to schedule permission sync after reauthentication for account ${updatedAccount.id}: ${message}`);
+                    }
+                }
             }
 
             if (user.id) {

--- a/packages/web/src/ee/features/sso/actions.ts
+++ b/packages/web/src/ee/features/sso/actions.ts
@@ -4,7 +4,7 @@ import { sew } from "@/middleware/sew";
 import { OPTIONAL_PROVIDERS_LINK_SKIPPED_COOKIE_NAME } from "@/lib/constants";
 import { withAuth } from "@/middleware/withAuth";
 import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
-import { OrgRole } from "@sourcebot/db";
+import { OrgRole, type AccountPermissionSyncIssue } from "@sourcebot/db";
 import { hasEntitlement } from "@/lib/entitlements";
 import { createLogger, doesIdpSupportPermissionSyncing, env, getIdentityProviderConfig, getIdentityProviderConfigs } from "@sourcebot/shared";
 import { cookies } from "next/headers";
@@ -22,7 +22,7 @@ export type LinkedAccount = {
     // Present when isLinked = true
     accountId?: string;
     providerAccountId?: string;
-    error?: string;
+    permissionSyncIssue?: AccountPermissionSyncIssue;
     // From config (only meaningful for account_linking providers)
     isAccountLinkingProvider: boolean;
     required: boolean;
@@ -40,7 +40,7 @@ export const getLinkedAccounts = async () => sew(() =>
                     providerType: true,
                     providerId: true,
                     providerAccountId: true,
-                    tokenRefreshErrorMessage: true,
+                    permissionSyncIssue: true,
                 },
             });
 
@@ -62,7 +62,7 @@ export const getLinkedAccounts = async () => sew(() =>
                     isLinked: true,
                     accountId: account.id,
                     providerAccountId: account.providerAccountId,
-                    error: account.tokenRefreshErrorMessage ?? undefined,
+                    permissionSyncIssue: account.permissionSyncIssue ?? undefined,
                     isAccountLinkingProvider: isAccountLinking,
                     required: isAccountLinking ? (providerConfig?.accountLinkingRequired ?? false) : false,
                     supportsPermissionSync: permissionSyncEnabled && doesIdpSupportPermissionSyncing(account.providerType),
@@ -118,4 +118,3 @@ export const skipOptionalProvidersLink = async () => sew(async () => {
     });
     return true;
 });
-

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
@@ -1,5 +1,6 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
 import { afterEach, describe, expect, test, vi } from 'vitest';
 import type { LinkedAccount } from '@/ee/features/sso/actions';
 
@@ -25,6 +26,13 @@ vi.mock('@/features/workerApi/actions', () => ({
 
 vi.mock('@/app/api/(client)/client', () => ({
     getAccountSyncStatus: vi.fn(),
+}));
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
 }));
 
 vi.mock('@/lib/utils', () => ({
@@ -74,7 +82,7 @@ describe('LinkedAccountProviderCard permission sync health', () => {
         expect(screen.queryByText('Needs attention')).toBeNull();
     });
 
-    test('shows reconnect guidance when repository permissions were cleared', () => {
+    test('shows reconnect guidance instead of permission refresh when repository permissions were cleared', () => {
         renderCard({
             ...linkedAccount,
             permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
@@ -83,6 +91,8 @@ describe('LinkedAccountProviderCard permission sync health', () => {
         expect(screen.getByText('Needs attention')).toBeTruthy();
         expect(screen.getByText('Reconnect this account to restore repository access.')).toBeTruthy();
         expect(screen.queryByText('Connected')).toBeNull();
+        expect(screen.getByText('Reconnect Account')).toBeTruthy();
+        expect(screen.queryByText('Refresh Permissions')).toBeNull();
     });
 
     test('shows scope-specific guidance when the OAuth grant is insufficient', () => {

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
@@ -1,0 +1,96 @@
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import type { LinkedAccount } from '@/ee/features/sso/actions';
+
+vi.mock('next/navigation', () => ({
+    useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+vi.mock('next-auth/react', () => ({
+    signIn: vi.fn(),
+}));
+
+vi.mock('@/components/hooks/use-toast', () => ({
+    useToast: () => ({ toast: vi.fn() }),
+}));
+
+vi.mock('@/ee/features/sso/actions', () => ({
+    unlinkLinkedAccountProvider: vi.fn(),
+}));
+
+vi.mock('@/features/workerApi/actions', () => ({
+    triggerAccountPermissionSync: vi.fn(),
+}));
+
+vi.mock('@/app/api/(client)/client', () => ({
+    getAccountSyncStatus: vi.fn(),
+}));
+
+vi.mock('@/lib/utils', () => ({
+    cn: (...classes: Array<string | false | undefined>) => classes.filter(Boolean).join(' '),
+    getAuthProviderInfo: () => ({ displayName: 'Bitbucket Server', icon: null }),
+    isServiceError: () => false,
+    unwrapServiceError: (value: unknown) => value,
+}));
+
+vi.mock('./providerIcon', () => ({
+    ProviderIcon: () => <div data-testid="provider-icon" />,
+}));
+
+const { LinkedAccountProviderCard } = await import('./linkedAccountProviderCard');
+
+const linkedAccount: LinkedAccount = {
+    providerId: 'bitbucket-server-corp',
+    providerType: 'bitbucket-server',
+    isLinked: true,
+    accountId: 'account_1',
+    providerAccountId: 'user_1',
+    isAccountLinkingProvider: true,
+    required: false,
+    supportsPermissionSync: true,
+};
+
+const renderCard = (account: LinkedAccount) => {
+    const queryClient = new QueryClient({
+        defaultOptions: { queries: { retry: false } },
+    });
+    return render(
+        <QueryClientProvider client={queryClient}>
+            <LinkedAccountProviderCard linkedAccount={account} />
+        </QueryClientProvider>,
+    );
+};
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('LinkedAccountProviderCard permission sync health', () => {
+    test('shows a healthy linked account as connected', () => {
+        renderCard(linkedAccount);
+
+        expect(screen.getByText('Connected')).toBeTruthy();
+        expect(screen.queryByText('Needs attention')).toBeNull();
+    });
+
+    test('shows reconnect guidance when repository permissions were cleared', () => {
+        renderCard({
+            ...linkedAccount,
+            permissionSyncIssue: 'REAUTHENTICATION_REQUIRED',
+        });
+
+        expect(screen.getByText('Needs attention')).toBeTruthy();
+        expect(screen.getByText('Reconnect this account to restore repository access.')).toBeTruthy();
+        expect(screen.queryByText('Connected')).toBeNull();
+    });
+
+    test('shows scope-specific guidance when the OAuth grant is insufficient', () => {
+        renderCard({
+            ...linkedAccount,
+            permissionSyncIssue: 'INSUFFICIENT_SCOPE',
+        });
+
+        expect(screen.getByText('Additional permissions are required to restore repository access.')).toBeTruthy();
+    });
+});

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.test.tsx
@@ -1,11 +1,18 @@
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
-import { cleanup, render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
 import type { ReactNode } from 'react';
-import { afterEach, describe, expect, test, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import type { LinkedAccount } from '@/ee/features/sso/actions';
 
+const mocks = vi.hoisted(() => ({
+    getAccountSyncStatus: vi.fn(),
+    refresh: vi.fn(),
+    toast: vi.fn(),
+    triggerAccountPermissionSync: vi.fn(),
+}));
+
 vi.mock('next/navigation', () => ({
-    useRouter: () => ({ refresh: vi.fn() }),
+    useRouter: () => ({ refresh: mocks.refresh }),
 }));
 
 vi.mock('next-auth/react', () => ({
@@ -13,7 +20,7 @@ vi.mock('next-auth/react', () => ({
 }));
 
 vi.mock('@/components/hooks/use-toast', () => ({
-    useToast: () => ({ toast: vi.fn() }),
+    useToast: () => ({ toast: mocks.toast }),
 }));
 
 vi.mock('@/ee/features/sso/actions', () => ({
@@ -21,18 +28,20 @@ vi.mock('@/ee/features/sso/actions', () => ({
 }));
 
 vi.mock('@/features/workerApi/actions', () => ({
-    triggerAccountPermissionSync: vi.fn(),
+    triggerAccountPermissionSync: mocks.triggerAccountPermissionSync,
 }));
 
 vi.mock('@/app/api/(client)/client', () => ({
-    getAccountSyncStatus: vi.fn(),
+    getAccountSyncStatus: mocks.getAccountSyncStatus,
 }));
 
 vi.mock('@/components/ui/dropdown-menu', () => ({
     DropdownMenu: ({ children }: { children: ReactNode }) => <div>{children}</div>,
     DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
     DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
-    DropdownMenuItem: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+    DropdownMenuItem: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+        <button onClick={onClick}>{children}</button>
+    ),
 }));
 
 vi.mock('@/lib/utils', () => ({
@@ -74,6 +83,10 @@ afterEach(() => {
     cleanup();
 });
 
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
 describe('LinkedAccountProviderCard permission sync health', () => {
     test('shows a healthy linked account as connected', () => {
         renderCard(linkedAccount);
@@ -102,5 +115,39 @@ describe('LinkedAccountProviderCard permission sync health', () => {
         });
 
         expect(screen.getByText('Additional permissions are required to restore repository access.')).toBeTruthy();
+    });
+
+    test('shows a success toast only when permission sync completes', async () => {
+        mocks.triggerAccountPermissionSync.mockResolvedValue({ jobId: 'job_1' });
+        mocks.getAccountSyncStatus.mockResolvedValue({ status: 'COMPLETED' });
+        renderCard(linkedAccount);
+
+        fireEvent.click(screen.getByRole('button', { name: /Refresh Permissions/ }));
+
+        await waitFor(() => {
+            expect(mocks.toast).toHaveBeenCalledWith({
+                description: '✅ Permissions refreshed for Bitbucket Server.',
+            });
+        });
+        expect(mocks.refresh).toHaveBeenCalledOnce();
+    });
+
+    test('shows an error toast when permission sync fails', async () => {
+        mocks.triggerAccountPermissionSync.mockResolvedValue({ jobId: 'job_1' });
+        mocks.getAccountSyncStatus.mockResolvedValue({ status: 'FAILED' });
+        renderCard(linkedAccount);
+
+        fireEvent.click(screen.getByRole('button', { name: /Refresh Permissions/ }));
+
+        await waitFor(() => {
+            expect(mocks.toast).toHaveBeenCalledWith({
+                description: '❌ Failed to refresh permissions for Bitbucket Server. Please try again.',
+                variant: 'destructive',
+            });
+        });
+        expect(mocks.toast).not.toHaveBeenCalledWith(expect.objectContaining({
+            description: expect.stringContaining('✅'),
+        }));
+        expect(mocks.refresh).toHaveBeenCalledOnce();
     });
 });

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
@@ -174,7 +174,8 @@ export function LinkedAccountProviderCard({
                                         {reconnectLabel}
                                     </DropdownMenuItem>
                                 )}
-                                {linkedAccount.supportsPermissionSync &&
+                                {!needsAttention &&
+                                    linkedAccount.supportsPermissionSync &&
                                     linkedAccount.accountId && (
                                         <DropdownMenuItem onClick={handleRefreshPermissions}>
                                             <RefreshCw className="h-4 w-4 mr-2" />

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
@@ -52,18 +52,37 @@ export function LinkedAccountProviderCard({
         queryKey: ["accountSyncStatus", syncJobId],
         queryFn: () => unwrapServiceError(getAccountSyncStatus(syncJobId!)),
         enabled: !!syncJobId,
-        refetchInterval: 1000,
+        refetchInterval: (query) => {
+            const status = query.state.data?.status;
+            return status === 'PENDING' || status === 'IN_PROGRESS' ? 1000 : false;
+        },
     });
 
-    const isSyncing = !!syncJobId && (syncStatusData?.isSyncing ?? true);
+    const syncJobStatus = syncStatusData?.status;
+    const isSyncing = !!syncJobId && (
+        syncJobStatus === undefined ||
+        syncJobStatus === 'PENDING' ||
+        syncJobStatus === 'IN_PROGRESS'
+    );
 
     useEffect(() => {
-        if (syncJobId && syncStatusData !== undefined && !syncStatusData.isSyncing) {
+        if (!syncJobId || syncJobStatus === undefined) {
+            return;
+        }
+
+        if (syncJobStatus === 'COMPLETED') {
             setSyncJobId(null);
             toast({ description: `✅ Permissions refreshed for ${displayName}.` });
             router.refresh();
+        } else if (syncJobStatus === 'FAILED') {
+            setSyncJobId(null);
+            toast({
+                description: `❌ Failed to refresh permissions for ${displayName}. Please try again.`,
+                variant: "destructive",
+            });
+            router.refresh();
         }
-    }, [syncJobId, syncStatusData, displayName, toast, router]);
+    }, [syncJobId, syncJobStatus, displayName, toast, router]);
 
     const handleConnect = () => {
         signIn(linkedAccount.providerId, { redirectTo: callbackUrl ?? window.location.href });

--- a/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
+++ b/packages/web/src/ee/features/sso/components/linkedAccountProviderCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useState } from "react";
-import { getAuthProviderInfo, unwrapServiceError } from "@/lib/utils";
+import { cn, getAuthProviderInfo, unwrapServiceError } from "@/lib/utils";
 import { AlertCircle, ArrowUpRight, ChevronDown, RefreshCw, Unlink } from "lucide-react";
 import { ProviderIcon } from "./providerIcon";
 import { LinkedAccount } from "@/ee/features/sso/actions";
@@ -40,6 +40,13 @@ export function LinkedAccountProviderCard({
 
     const providerInfo = getAuthProviderInfo(linkedAccount.providerType);
     const displayName = linkedAccount.displayName ?? providerInfo.displayName;
+    const needsAttention = linkedAccount.permissionSyncIssue !== undefined;
+    const issueDescription = linkedAccount.permissionSyncIssue === 'INSUFFICIENT_SCOPE'
+        ? 'Additional permissions are required to restore repository access.'
+        : 'Reconnect this account to restore repository access.';
+    const reconnectLabel = linkedAccount.permissionSyncIssue === 'INSUFFICIENT_SCOPE'
+        ? 'Reauthorize Account'
+        : 'Reconnect Account';
 
     const { data: syncStatusData } = useQuery({
         queryKey: ["accountSyncStatus", syncJobId],
@@ -86,7 +93,9 @@ export function LinkedAccountProviderCard({
     };
 
     const handleRefreshPermissions = async () => {
-        if (!linkedAccount.accountId) return;
+        if (!linkedAccount.accountId) {
+            return;
+        }
         try {
             const result = await triggerAccountPermissionSync(linkedAccount.accountId);
             if (isServiceError(result)) {
@@ -128,10 +137,10 @@ export function LinkedAccountProviderCard({
                                 {linkedAccount.providerAccountId}
                             </span>
                         )}
-                        {linkedAccount.error && (
-                            <span className="text-xs text-destructive flex items-center gap-1">
+                        {needsAttention && (
+                            <span className="text-xs text-amber-600 dark:text-amber-400 flex items-center gap-1">
                                 <AlertCircle className="h-3 w-3" />
-                                Token refresh failed — please reconnect
+                                {issueDescription}
                             </span>
                         )}
                     </div>
@@ -142,18 +151,36 @@ export function LinkedAccountProviderCard({
                         <DropdownMenu>
                             <DropdownMenuTrigger asChild>
                                 <LoadingButton variant="ghost" size="sm" loading={isBusy} className="gap-1.5">
-                                    {!isBusy && <span className="h-2 w-2 rounded-full bg-green-500" />}
-                                    {isDisconnecting ? "Disconnecting..." : isSyncing ? "Syncing..." : "Connected"}
+                                    {!isBusy && (
+                                        <span className={cn(
+                                            "h-2 w-2 rounded-full",
+                                            needsAttention ? "bg-amber-500" : "bg-green-500",
+                                        )} />
+                                    )}
+                                    {isDisconnecting
+                                        ? "Disconnecting..."
+                                        : isSyncing
+                                            ? "Syncing..."
+                                            : needsAttention
+                                                ? "Needs attention"
+                                                : "Connected"}
                                     <ChevronDown className="h-3.5 w-3.5 text-muted-foreground" />
                                 </LoadingButton>
                             </DropdownMenuTrigger>
                             <DropdownMenuContent align="end">
-                                {linkedAccount.supportsPermissionSync && linkedAccount.accountId && (
-                                    <DropdownMenuItem onClick={handleRefreshPermissions}>
-                                        <RefreshCw className="h-4 w-4 mr-2" />
-                                        Refresh Permissions
+                                {needsAttention && (
+                                    <DropdownMenuItem onClick={handleConnect}>
+                                        <ArrowUpRight className="h-4 w-4 mr-2" />
+                                        {reconnectLabel}
                                     </DropdownMenuItem>
                                 )}
+                                {linkedAccount.supportsPermissionSync &&
+                                    linkedAccount.accountId && (
+                                        <DropdownMenuItem onClick={handleRefreshPermissions}>
+                                            <RefreshCw className="h-4 w-4 mr-2" />
+                                            Refresh Permissions
+                                        </DropdownMenuItem>
+                                    )}
                                 <DropdownMenuItem
                                     onClick={handleDisconnect}
                                     className="text-destructive focus:text-destructive"

--- a/packages/web/src/features/workerApi/actions.ts
+++ b/packages/web/src/features/workerApi/actions.ts
@@ -7,6 +7,7 @@ import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
 import { OrgRole } from "@sourcebot/db";
 import { env } from "@sourcebot/shared";
 import z from "zod";
+import { requestAccountPermissionSync } from "./client.server";
 
 const WORKER_API_URL = env.WORKER_API_URL;
 
@@ -63,23 +64,11 @@ export const indexRepo = async (repoId: number) => sew(() =>
 export const triggerAccountPermissionSync = async (accountId: string) => sew(() =>
     withAuth(({ role }) =>
         withMinimumOrgRole(role, OrgRole.MEMBER, async () => {
-            const response = await fetch(`${WORKER_API_URL}/api/trigger-account-permission-sync`, {
-                method: 'POST',
-                body: JSON.stringify({ accountId }),
-                headers: {
-                    'Content-Type': 'application/json',
-                },
-            });
-
-            if (!response.ok) {
+            try {
+                return await requestAccountPermissionSync(accountId);
+            } catch {
                 return unexpectedError('Failed to trigger account permission sync');
             }
-
-            const data = await response.json();
-            const schema = z.object({
-                jobId: z.string(),
-            });
-            return schema.parse(data);
         })
     )
 );

--- a/packages/web/src/features/workerApi/client.server.test.ts
+++ b/packages/web/src/features/workerApi/client.server.test.ts
@@ -1,0 +1,38 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+vi.mock('server-only', () => ({}));
+vi.mock('@sourcebot/shared', () => ({
+    env: { WORKER_API_URL: 'http://worker.example.com' },
+}));
+
+const { requestAccountPermissionSync } = await import('./client.server');
+
+beforeEach(() => {
+    vi.unstubAllGlobals();
+});
+
+describe('requestAccountPermissionSync', () => {
+    test('schedules an account permission sync with the worker', async () => {
+        const fetchMock = vi.fn().mockResolvedValue(new Response(
+            JSON.stringify({ jobId: 'job_1' }),
+            { status: 200 },
+        ));
+        vi.stubGlobal('fetch', fetchMock);
+
+        await expect(requestAccountPermissionSync('account_1')).resolves.toEqual({ jobId: 'job_1' });
+        expect(fetchMock).toHaveBeenCalledWith(
+            'http://worker.example.com/api/trigger-account-permission-sync',
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({ accountId: 'account_1' }),
+            }),
+        );
+    });
+
+    test('rejects when the worker does not accept the sync request', async () => {
+        vi.stubGlobal('fetch', vi.fn().mockResolvedValue(new Response(null, { status: 503 })));
+
+        await expect(requestAccountPermissionSync('account_1'))
+            .rejects.toThrow('Worker rejected account permission sync with HTTP 503.');
+    });
+});

--- a/packages/web/src/features/workerApi/client.server.ts
+++ b/packages/web/src/features/workerApi/client.server.ts
@@ -1,0 +1,26 @@
+import 'server-only';
+
+import { env } from '@sourcebot/shared';
+import { z } from 'zod';
+
+const accountPermissionSyncResponseSchema = z.object({
+    jobId: z.string(),
+});
+const WORKER_REQUEST_TIMEOUT_MS = 5000;
+
+export const requestAccountPermissionSync = async (accountId: string): Promise<{ jobId: string }> => {
+    const response = await fetch(`${env.WORKER_API_URL}/api/trigger-account-permission-sync`, {
+        method: 'POST',
+        body: JSON.stringify({ accountId }),
+        headers: {
+            'Content-Type': 'application/json',
+        },
+        signal: AbortSignal.timeout(WORKER_REQUEST_TIMEOUT_MS),
+    });
+
+    if (!response.ok) {
+        throw new Error(`Worker rejected account permission sync with HTTP ${response.status}.`);
+    }
+
+    return accountPermissionSyncResponseSchema.parse(await response.json());
+};


### PR DESCRIPTION
<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a></sub>

Fixes SOU-1560
Fixes SOU-1177

<img width="1627" height="73" alt="image" src="https://github.com/user-attachments/assets/0aa88154-576f-4235-b0f3-a4b8e40e95b8" />
<img width="800" height="241" alt="image" src="https://github.com/user-attachments/assets/73282634-9a75-4821-826b-6bc407735f04" />
<img width="748" height="187" alt="image" src="https://github.com/user-attachments/assets/6efa0521-b7d3-43b1-a206-06df4514dcea" />


## Summary
- persist a structured account issue when permission sync fails closed
- clear the issue only after permissions sync successfully
- show a persistent action-required banner and unhealthy linked-account state
- schedule permission recovery immediately after OAuth reauthentication
- stop treating transient token refresh errors as reconnect-required UX

## Testing
- `yarn workspace @sourcebot/backend test --run` (201 tests)
- `yarn workspace @sourcebot/web test --run` (1,095 tests)
- backend and database package builds
- Prisma schema validation
- ESLint on touched web files

Part of stack #1483. Depends on #1482.


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how repository access is represented and communicated after permanent sync failures (security-sensitive), plus a DB migration and auth-time sync scheduling, but behavior is scoped to classified fail-closed cases with tests.
> 
> **Overview**
> When permission sync **fails closed** and clears cached repo access, the backend now persists a structured **`permissionSyncIssue`** on the account (`REAUTHENTICATION_REQUIRED` or `INSUFFICIENT_SCOPE`) in the same transaction as the permission wipe, and clears it only after a **successful** sync completes.
> 
> The web app surfaces this through a **non-dismissible permission-sync banner** (action required vs. still syncing), enriches **`getPermissionSyncStatus`** with per-account issues, and updates **linked accounts** to show “needs attention” with reconnect/reauthorize instead of “refresh permissions.” **OAuth reauthentication** schedules an automatic permission-sync retry via a shared worker client; manual refresh polling now keys off full job **status** (including failed toasts).
> 
> Linked-account UX no longer drives recovery from **`tokenRefreshErrorMessage`**; transient refresh failures stay out of the reconnect flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a962821e4f66741396ebff9cf89f1159d0cace51. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clear warnings when permission synchronization requires reauthentication or additional access.
  * Added guided recovery through linked-account settings, including reconnect and permission-review actions.
  * Permission sync status now updates automatically and clears after successful recovery.
  * Successful reauthentication can automatically retry permission synchronization.

* **Bug Fixes**
  * Improved handling of permanent versus temporary synchronization failures.
  * Prevented stale repository access from remaining available after permanent permission failures.

* **Documentation**
  * Updated the unreleased changelog with the new warnings and recovery guidance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->