### PR TITLE
chore: bump vendor/zoekt to upgrade gRPC-Go to v1.82.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `shell-quote` to `^1.10.0`. [#1469](https://github.com/sourcebot-dev/sourcebot/pull/1469)
 - Upgraded `js-yaml` to `^4.3.0`. [#1470](https://github.com/sourcebot-dev/sourcebot/pull/1470)
 - Fixed multiple CVEs in JavaScript dependencies by upgrading `next-auth`, `@auth/core`, `next`, `postcss`, `sharp`, `linkify-it`, `fast-uri`, `protobufjs`, `body-parser`, `hono`, `@hono/node-server`, and `dompurify` to patched versions, resolving all Yarn audit findings. [#1502](https://github.com/sourcebot-dev/sourcebot/pull/1502)
+- Upgraded the bundled Zoekt gRPC-Go dependency to `v1.82.1`. [#1503](https://github.com/sourcebot-dev/sourcebot/pull/1503)
 
 ### Changed
 - Reduced Sentry span sampling to 10% outside development. [#1475](https://github.com/sourcebot-dev/sourcebot/pull/1475)


### PR DESCRIPTION
Fixes SOU-1567

## Summary

Advances vendor/zoekt from 58f59f1 to 0e0e62b, the merge commit from sourcebot-dev/zoekt#17. This upgrades google.golang.org/grpc from vulnerable v1.80.0 to patched v1.82.1 for GHSA-hrxh-6v49-42gf.

The Sourcebot change is pointer-only; the Zoekt dependency change is limited to go.mod and go.sum.

## Verification

- Zoekt: go test ./...
- Zoekt: go build ./...
- Sourcebot: make zoekt
- Built zoekt-webserver module metadata reports google.golang.org/grpc v1.82.1

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Pointer-only submodule bump with a targeted Go dependency upgrade in Zoekt; no application logic changes in the visible diff.
> 
> **Overview**
> Bumps the **`vendor/zoekt`** submodule so the bundled Zoekt stack picks up **`google.golang.org/grpc` v1.82.1** (from v1.80.0), addressing **GHSA-hrxh-6v49-42gf**. The Sourcebot-side change is a **submodule pointer update**; the dependency bump lives in the forked Zoekt **`go.mod` / `go.sum`**.
> 
> Documents the fix under **`[Unreleased]` → Fixed** in **`CHANGELOG.md`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d12a51129795512654eb854e7f9a4c0b2b677178. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the bundled Zoekt gRPC-Go component to version 1.82.1.
  * Includes upstream fixes and improvements from the updated Zoekt revision.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->