### PR TITLE
feat(web): add /api/health/ready endpoint with dependency health checks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1506](https://github.com/sourcebot-dev/sourcebot/issues/1506)
+- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1507](https://github.com/sourcebot-dev/sourcebot/pull/1507)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1506](https://github.com/sourcebot-dev/sourcebot/issues/1506)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,8 @@
                         "icon": "server",
                         "pages": [
                             "GET /api/version",
-                            "GET /api/health"
+                            "GET /api/health",
+                            "docs/api-reference/health"
                         ]
                     }
                 ]

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -1,0 +1,97 @@
+---
+title: "Health Endpoints"
+description: "Liveness and readiness probes for orchestrators and monitoring systems."
+---
+
+Sourcebot exposes two public health endpoints that follow the standard Kubernetes liveness / readiness split. Both are unauthenticated and return no user data.
+
+## Liveness: `GET /api/health`
+
+Returns `200 OK` with `{ "status": "ok" }` whenever the Next.js process is running and able to handle a request. Does not touch the database, Redis, or Zoekt. Use this for Kubernetes `livenessProbe` or Docker Compose `healthcheck.test`. A failing liveness probe means the process must be restarted.
+
+```bash
+curl -fsS https://sourcebot.example.com/api/health
+# {"status":"ok"}
+```
+
+## Readiness: `GET /api/health/ready`
+
+Returns `200 OK` with `{"status":"ok", "checks":{...}}` when Postgres, Redis, and Zoekt are all reachable. Returns `503 Service Unavailable` with `{"status":"degraded", "checks":{...}}` if any dependency is unreachable. Each check runs in parallel with a 2-second per-check timeout, so the worst-case request time is bounded even when a dependency hangs.
+
+Use this for Kubernetes `readinessProbe` or a load balancer health check. A failing readiness probe means the pod should be removed from the load-balancer rotation but not restarted.
+
+### Response shape
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "postgres": { "status": "ok", "latencyMs": 3 },
+    "redis":    { "status": "ok", "latencyMs": 1 },
+    "zoekt":    { "status": "ok", "latencyMs": 12 }
+  }
+}
+```
+
+When degraded, each failed check carries an `error` field with the underlying message:
+
+```json
+{
+  "status": "degraded",
+  "checks": {
+    "postgres": { "status": "ok",    "latencyMs": 4 },
+    "redis":    { "status": "ok",    "latencyMs": 1 },
+    "zoekt":    { "status": "error", "latencyMs": 2003, "error": "zoekt check timed out after 2000ms" }
+  }
+}
+```
+
+| Check | What it probes |
+|-------|---------------|
+| `postgres` | `SELECT 1` via Prisma |
+| `redis`    | `PING` (rejects non-`PONG` responses) |
+| `zoekt`    | `List` RPC with a 1-second wall-time cap (proves the gRPC channel is alive) |
+
+### Example probes
+
+<Tabs>
+  <Tab title="Docker Compose">
+    ```yaml
+    services:
+      sourcebot:
+        image: sourcebot/sourcebot:latest
+        healthcheck:
+          test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+          interval: 30s
+          timeout: 5s
+          retries: 3
+        # For dependency-aware probes, point the orchestrator at /api/health/ready
+        # instead. Sourcebot's example compose file does this via a sidecar.
+    ```
+  </Tab>
+  <Tab title="Kubernetes">
+    ```yaml
+    livenessProbe:
+      httpGet:
+        path: /api/health
+        port: 3000
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /api/health/ready
+        port: 3000
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+The readiness probe hits the database on every call. On large deployments with many pods, a high-frequency probe interval (sub-5s) can produce noticeable background load. A 10s interval with `failureThreshold: 3` is a good starting point.
+</Note>

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -50,7 +50,7 @@ When degraded, each failed check carries an `error` field with the underlying me
 |-------|---------------|
 | `postgres` | `SELECT 1` via Prisma |
 | `redis`    | `PING` (rejects non-`PONG` responses) |
-| `zoekt`    | `List` RPC with a 1-second wall-time cap (proves the gRPC channel is alive) |
+| `zoekt`    | Empty `List` RPC (proves the gRPC channel is alive; bounded by the 2s per-check timeout) |
 
 ### Example probes
 

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    unsafePrisma: {
+        $queryRaw: vi.fn(),
+    },
+    redisPing: vi.fn(),
+    zoektList: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/prisma', () => ({
+    __unsafePrisma: mocks.unsafePrisma,
+}));
+
+vi.mock('@/lib/redis', () => ({
+    getRedisClient: () => ({
+        ping: mocks.redisPing,
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/zoektClient', () => ({
+    loadZoektClient: () => ({
+        List: mocks.zoektList,
+    }),
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/health/ready', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.unsafePrisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+        mocks.redisPing.mockResolvedValue('PONG');
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                callback(null);
+            },
+        );
+    });
+
+    test('returns 200 with status:ok when all three dependencies are reachable', async () => {
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.status).toBe('ok');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('ok');
+        expect(body.checks.zoekt.status).toBe('ok');
+        expect(typeof body.checks.postgres.latencyMs).toBe('number');
+        expect(typeof body.checks.redis.latencyMs).toBe('number');
+        expect(typeof body.checks.zoekt.latencyMs).toBe('number');
+    });
+
+    test('returns 503 with status:degraded and a postgres error when Postgres is unreachable', async () => {
+        mocks.unsafePrisma.$queryRaw.mockRejectedValue(new Error('connection refused'));
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.postgres.status).toBe('error');
+        expect(body.checks.postgres.error).toBe('connection refused');
+        expect(body.checks.redis.status).toBe('ok');
+        expect(body.checks.zoekt.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded and a redis error when Redis ping fails', async () => {
+        mocks.redisPing.mockRejectedValue(new Error('redis down'));
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('error');
+        expect(body.checks.redis.error).toBe('redis down');
+        expect(body.checks.zoekt.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded when the Zoekt gRPC call errors', async () => {
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                callback(new Error('UNAVAILABLE: zoekt not reachable'));
+            },
+        );
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.zoekt.status).toBe('error');
+        expect(body.checks.zoekt.error).toContain('UNAVAILABLE');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded when Redis returns a non-PONG response', async () => {
+        mocks.redisPing.mockResolvedValue('NOT-PONG');
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.redis.status).toBe('error');
+        expect(body.checks.redis.error).toContain('unexpected ping response');
+    });
+
+    test('runs all three checks in parallel (Promise.all)', async () => {
+        const delay = 50;
+        mocks.unsafePrisma.$queryRaw.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve([{}]), delay)),
+        );
+        mocks.redisPing.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve('PONG'), delay)),
+        );
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                setTimeout(() => callback(null), delay);
+            },
+        );
+
+        const start = Date.now();
+        const response = await GET();
+        const elapsed = Date.now() - start;
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.status).toBe('ok');
+        // Generous upper bound to avoid flakes; serial would be ~3x delay.
+        expect(elapsed).toBeLessThan(delay * 2.5);
+    });
+});

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -182,4 +182,18 @@ describe('GET /api/health/ready', () => {
             process.off('unhandledRejection', onUnhandled);
         }
     });
+
+    test('issues the Zoekt List RPC with empty options (max_wall_time is a SearchOptions field, not ListOptions)', async () => {
+        // Regression guard: the earlier draft of the Zoekt probe passed
+        // `{ opts: { max_wall_time: ... } }` to the `List` RPC. That field
+        // belongs to `SearchOptions` and is silently ignored by `List`
+        // (whose `ListOptions` only carries `field`). The 2s client-side
+        // timeout is the only thing that actually bounds the call. The
+        // probe must therefore issue the smallest valid request, which is
+        // an empty options object.
+        const response = await GET();
+        expect(response.status).toBe(200);
+        expect(mocks.zoektList).toHaveBeenCalledTimes(1);
+        expect(mocks.zoektList).toHaveBeenCalledWith({}, expect.any(Function));
+    });
 });

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -149,4 +149,37 @@ describe('GET /api/health/ready', () => {
         // Generous upper bound to avoid flakes; serial would be ~3x delay.
         expect(elapsed).toBeLessThan(delay * 2.5);
     });
+
+    test('does not surface check rejections as unhandled promise rejections', async () => {
+        // The check rejects synchronously (well within the 2s timeout). The
+        // no-op `.catch` attached in `withTimeout` must absorb that
+        // rejection so the Node process does not log an
+        // unhandled-promise-rejection warning while the readiness request
+        // has already moved on.
+        const checkRejection = new Error('check rejected');
+        const unhandled: unknown[] = [];
+        const onUnhandled = (err: unknown) => { unhandled.push(err); };
+        process.on('unhandledRejection', onUnhandled);
+
+        try {
+            mocks.unsafePrisma.$queryRaw.mockRejectedValue(checkRejection);
+            mocks.redisPing.mockResolvedValue('PONG');
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null) => void) => {
+                    callback(null);
+                },
+            );
+
+            const response = await GET();
+            const body = await response.json();
+
+            expect(response.status).toBe(503);
+            expect(body.checks.postgres.status).toBe('error');
+            // Give the rejection microtask a chance to fire and propagate.
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            expect(unhandled).not.toContain(checkRejection);
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+        }
+    });
 });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -1,0 +1,139 @@
+import { createLogger } from '@sourcebot/shared';
+
+import { apiHandler } from '@/lib/apiHandler';
+import { __unsafePrisma } from '@/prisma';
+import { getRedisClient } from '@/lib/redis';
+import { loadZoektClient } from '@/lib/zoektClient';
+
+// Per-check timeout. The three checks run in parallel, so the worst-case
+// request time is bounded by this value even when one dependency hangs.
+const READINESS_TIMEOUT_MS = 2000;
+
+const logger = createLogger('health-ready');
+
+type CheckStatus = 'ok' | 'error';
+type CheckResult = {
+    status: CheckStatus;
+    latencyMs: number;
+    error?: string;
+};
+type ReadinessResponse = {
+    status: 'ok' | 'degraded';
+    checks: {
+        postgres: CheckResult;
+        redis: CheckResult;
+        zoekt: CheckResult;
+    };
+};
+
+// Wraps a check function in a per-check timeout. When the timeout fires
+// first, the check resolves as an error result; the underlying promise is
+// allowed to settle in the background (its result is discarded).
+const withTimeout = async <T>(
+    label: string,
+    check: () => Promise<T>,
+    timeoutMs: number,
+): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+            reject(new Error(`${label} check timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+    try {
+        return await Promise.race([check(), timeout]);
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
+    }
+};
+
+const checkPostgres = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        await withTimeout('postgres', async () => {
+            await __unsafePrisma.$queryRaw`SELECT 1`;
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+const checkRedis = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        const redis = getRedisClient();
+        await withTimeout('redis', async () => {
+            const pong = await redis.ping();
+            if (pong !== 'PONG') {
+                throw new Error(`unexpected ping response: ${pong}`);
+            }
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+const checkZoekt = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        const client = await loadZoektClient();
+        await withTimeout('zoekt', async () => {
+            await new Promise<void>((resolve, reject) => {
+                // An empty List with a 1s wall-time cap is the smallest request
+                // that exercises the gRPC channel end-to-end. It returns an
+                // empty result, not an error, even when no repos are indexed.
+                client.List(
+                    { opts: { max_wall_time: { seconds: 1, nanos: 0 } } },
+                    (err) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    },
+                );
+            });
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+// eslint-disable-next-line authz/require-auth-wrapper -- public readiness probe, no user data returned
+export const GET = apiHandler(async () => {
+    const [postgres, redis, zoekt] = await Promise.all([
+        checkPostgres(),
+        checkRedis(),
+        checkZoekt(),
+    ]);
+
+    const checks = { postgres, redis, zoekt };
+    const healthy = postgres.status === 'ok' && redis.status === 'ok' && zoekt.status === 'ok';
+
+    if (!healthy) {
+        logger.warn('readiness check failed', { checks });
+    }
+
+    const body: ReadinessResponse = {
+        status: healthy ? 'ok' : 'degraded',
+        checks,
+    };
+    return Response.json(body, { status: healthy ? 200 : 503 });
+}, { track: false });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -26,14 +26,19 @@ type ReadinessResponse = {
     };
 };
 
-// Wraps a check function in a per-check timeout. When the timeout fires
-// first, the check resolves as an error result; the underlying promise is
-// allowed to settle in the background (its result is discarded).
+// Runs `check()` and rejects if it has not settled after `timeoutMs`. When the
+// timeout fires, the underlying check promise may still resolve or reject
+// later; the no-op `.catch` below attaches to that promise so a late
+// rejection does not surface as an unhandled-promise-rejection in the Node
+// process while the readiness request has already moved on.
 const withTimeout = async <T>(
     label: string,
     check: () => Promise<T>,
     timeoutMs: number,
 ): Promise<T> => {
+    const checkPromise = check();
+    checkPromise.catch(() => { /* swallowed: see comment above */ });
+
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
@@ -41,7 +46,7 @@ const withTimeout = async <T>(
         }, timeoutMs);
     });
     try {
-        return await Promise.race([check(), timeout]);
+        return await Promise.race([checkPromise, timeout]);
     } finally {
         if (timer) {
             clearTimeout(timer);
@@ -88,8 +93,10 @@ const checkRedis = async (): Promise<CheckResult> => {
 const checkZoekt = async (): Promise<CheckResult> => {
     const start = Date.now();
     try {
-        const client = await loadZoektClient();
         await withTimeout('zoekt', async () => {
+            // Build the client inside the timeout so a first-call init stall
+            // (e.g., vendored proto load) is also bounded.
+            const client = await loadZoektClient();
             await new Promise<void>((resolve, reject) => {
                 // An empty List with a 1s wall-time cap is the smallest request
                 // that exercises the gRPC channel end-to-end. It returns an

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -98,19 +98,20 @@ const checkZoekt = async (): Promise<CheckResult> => {
             // (e.g., vendored proto load) is also bounded.
             const client = await loadZoektClient();
             await new Promise<void>((resolve, reject) => {
-                // An empty List with a 1s wall-time cap is the smallest request
-                // that exercises the gRPC channel end-to-end. It returns an
-                // empty result, not an error, even when no repos are indexed.
-                client.List(
-                    { opts: { max_wall_time: { seconds: 1, nanos: 0 } } },
-                    (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    },
-                );
+                // Empty `List` is the smallest request that exercises the gRPC
+                // channel end-to-end. It returns an empty result, not an error,
+                // even when no repos are indexed. The 2s client-side
+                // `READINESS_TIMEOUT_MS` is the only timeout that actually
+                // bounds the call: `max_wall_time` is a `SearchOptions` field
+                // and does not apply to `List` (`ListOptions` only carries
+                // `field`).
+                client.List({}, (err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
             });
         }, READINESS_TIMEOUT_MS);
         return { status: 'ok', latencyMs: Date.now() - start };

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -10,7 +10,7 @@ export type ZoektClient = {
     List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
 };
 
-let cachedClient: ZoektClient | undefined;
+let clientPromise: Promise<ZoektClient> | null = null;
 
 const buildClient = async (): Promise<ZoektClient> => {
     const [grpc, protoLoader, nodePath, shared] = await Promise.all([
@@ -44,15 +44,17 @@ const buildClient = async (): Promise<ZoektClient> => {
     );
 };
 
-// Returns a connected client, building it on first use. Only successful
-// builds are cached: a transient init failure does not poison subsequent
-// readiness probes, so the next call can retry.
-export const loadZoektClient = async (): Promise<ZoektClient> => {
-    if (cachedClient) {
-        return cachedClient;
+// Returns a connected client, building it on first use. Concurrent callers
+// share the same in-flight build (no duplicated gRPC/proto init on a cold
+// process). Only successful builds are cached: a transient init failure
+// does not poison subsequent readiness probes, so the next call can retry.
+export const loadZoektClient = (): Promise<ZoektClient> => {
+    if (!clientPromise) {
+        clientPromise = buildClient().catch((err) => {
+            clientPromise = null;
+            throw err;
+        });
     }
-    const client = await buildClient();
-    cachedClient = client;
-    return client;
+    return clientPromise;
 };
 

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -10,44 +10,72 @@ export type ZoektClient = {
     List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
 };
 
+// Hard ceiling on the first-use Zoekt build. Must stay well under the
+// 2-second readiness deadline so the per-check withTimeout timers can
+// still fire and a hung init cannot leave clientPromise pending forever.
+const ZOEKT_BUILD_TIMEOUT_MS = 1500;
+
 let clientPromise: Promise<ZoektClient> | null = null;
 
 const buildClient = async (): Promise<ZoektClient> => {
-    const [grpc, protoLoader, nodePath, shared] = await Promise.all([
-        import('@grpc/grpc-js'),
-        import('@grpc/proto-loader'),
-        import('node:path'),
-        import('@sourcebot/shared'),
-    ]);
+    const build = async (): Promise<ZoektClient> => {
+        const [grpc, protoLoader, nodePath, shared] = await Promise.all([
+            import('@grpc/grpc-js'),
+            import('@grpc/proto-loader'),
+            import('node:path'),
+            import('@sourcebot/shared'),
+        ]);
 
-    const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
-    const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
+        const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
+        const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
 
-    const packageDefinition = protoLoader.loadSync(protoPath, {
-        keepCase: true,
-        longs: Number,
-        enums: String,
-        defaults: true,
-        oneofs: true,
-        includeDirs: [protoBasePath],
-    });
+        // load (async) instead of loadSync so the event loop stays
+        // responsive while proto descriptors are being read and compiled.
+        const packageDefinition = await protoLoader.load(protoPath, {
+            keepCase: true,
+            longs: Number,
+            enums: String,
+            defaults: true,
+            oneofs: true,
+            includeDirs: [protoBasePath],
+        });
 
-    const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
-        zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+        const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+            zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+        };
+
+        const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
+        const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+        return new proto.zoekt.webserver.v1.WebserverService(
+            grpcAddress,
+            grpc.credentials.createInsecure(),
+        );
     };
 
-    const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
-    const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
-    return new proto.zoekt.webserver.v1.WebserverService(
-        grpcAddress,
-        grpc.credentials.createInsecure(),
-    );
+    // Race the build against a hard timeout. If the build hangs (a slow
+    // dynamic import or proto load) the timeout wins and the catch in
+    // loadZoektClient clears the cached promise so the next call retries.
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(
+            () => reject(new Error(`Zoekt client build exceeded ${ZOEKT_BUILD_TIMEOUT_MS}ms`)),
+            ZOEKT_BUILD_TIMEOUT_MS,
+        );
+    });
+    try {
+        return await Promise.race([build(), timeout]);
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
+    }
 };
 
 // Returns a connected client, building it on first use. Concurrent callers
 // share the same in-flight build (no duplicated gRPC/proto init on a cold
-// process). Only successful builds are cached: a transient init failure
-// does not poison subsequent readiness probes, so the next call can retry.
+// process). The cached promise is cleared on any failure — including the
+// build timeout — so a transient init hang does not poison subsequent
+// readiness probes.
 export const loadZoektClient = (): Promise<ZoektClient> => {
     if (!clientPromise) {
         clientPromise = buildClient().catch((err) => {

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -10,10 +10,12 @@ export type ZoektClient = {
     List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
 };
 
-// Hard ceiling on the first-use Zoekt build. Must stay well under the
-// 2-second readiness deadline so the per-check withTimeout timers can
-// still fire and a hung init cannot leave clientPromise pending forever.
-const ZOEKT_BUILD_TIMEOUT_MS = 1500;
+// Hard ceiling on the first-use Zoekt build. Stays under 1s so the
+// per-check withTimeout (2s route budget) always has time to run the
+// gRPC List probe after the client is built. A hung init cannot leave
+// clientPromise pending forever either — the catch in loadZoektClient
+// clears the cached promise on the timeout.
+const ZOEKT_BUILD_TIMEOUT_MS = 800;
 
 let clientPromise: Promise<ZoektClient> | null = null;
 
@@ -55,6 +57,12 @@ const buildClient = async (): Promise<ZoektClient> => {
     // Race the build against a hard timeout. If the build hangs (a slow
     // dynamic import or proto load) the timeout wins and the catch in
     // loadZoektClient clears the cached promise so the next call retries.
+    //
+    // The build promise itself is deliberately NOT cancellable, so when the
+    // timeout wins the race the underlying work continues in the background
+    // until the imports and proto load complete. Attach a no-op .catch so
+    // a late rejection from the orphaned build does not surface as an
+    // unhandled promise rejection in Node.
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(
@@ -62,8 +70,9 @@ const buildClient = async (): Promise<ZoektClient> => {
             ZOEKT_BUILD_TIMEOUT_MS,
         );
     });
+    const orphaned = build().catch(() => {});
     try {
-        return await Promise.race([build(), timeout]);
+        return await Promise.race([orphaned, timeout]);
     } finally {
         if (timer) {
             clearTimeout(timer);

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -10,41 +10,49 @@ export type ZoektClient = {
     List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
 };
 
-let zoektClientPromise: Promise<ZoektClient> | undefined;
+let cachedClient: ZoektClient | undefined;
 
-export const loadZoektClient = (): Promise<ZoektClient> => {
-    if (!zoektClientPromise) {
-        zoektClientPromise = (async () => {
-            const [grpc, protoLoader, nodePath, shared] = await Promise.all([
-                import('@grpc/grpc-js'),
-                import('@grpc/proto-loader'),
-                import('node:path'),
-                import('@sourcebot/shared'),
-            ]);
+const buildClient = async (): Promise<ZoektClient> => {
+    const [grpc, protoLoader, nodePath, shared] = await Promise.all([
+        import('@grpc/grpc-js'),
+        import('@grpc/proto-loader'),
+        import('node:path'),
+        import('@sourcebot/shared'),
+    ]);
 
-            const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
-            const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
+    const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
+    const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
 
-            const packageDefinition = protoLoader.loadSync(protoPath, {
-                keepCase: true,
-                longs: Number,
-                enums: String,
-                defaults: true,
-                oneofs: true,
-                includeDirs: [protoBasePath],
-            });
+    const packageDefinition = protoLoader.loadSync(protoPath, {
+        keepCase: true,
+        longs: Number,
+        enums: String,
+        defaults: true,
+        oneofs: true,
+        includeDirs: [protoBasePath],
+    });
 
-            const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
-                zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
-            };
+    const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+        zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+    };
 
-            const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
-            const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
-            return new proto.zoekt.webserver.v1.WebserverService(
-                grpcAddress,
-                grpc.credentials.createInsecure(),
-            );
-        })();
-    }
-    return zoektClientPromise;
+    const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
+    const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+    return new proto.zoekt.webserver.v1.WebserverService(
+        grpcAddress,
+        grpc.credentials.createInsecure(),
+    );
 };
+
+// Returns a connected client, building it on first use. Only successful
+// builds are cached: a transient init failure does not poison subsequent
+// readiness probes, so the next call can retry.
+export const loadZoektClient = async (): Promise<ZoektClient> => {
+    if (cachedClient) {
+        return cachedClient;
+    }
+    const client = await buildClient();
+    cachedClient = client;
+    return client;
+};
+

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -1,0 +1,50 @@
+// Thin wrapper around the vendored Zoekt webserver gRPC client. Kept in
+// a separate module so the readiness route can mock it in tests without
+// pulling the gRPC + @opentelemetry CJS chain at test-load time.
+
+export type ZoektListRequest = {
+    opts?: { max_wall_time?: { seconds: number; nanos: number } };
+};
+
+export type ZoektClient = {
+    List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
+};
+
+let zoektClientPromise: Promise<ZoektClient> | undefined;
+
+export const loadZoektClient = (): Promise<ZoektClient> => {
+    if (!zoektClientPromise) {
+        zoektClientPromise = (async () => {
+            const [grpc, protoLoader, nodePath, shared] = await Promise.all([
+                import('@grpc/grpc-js'),
+                import('@grpc/proto-loader'),
+                import('node:path'),
+                import('@sourcebot/shared'),
+            ]);
+
+            const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
+            const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
+
+            const packageDefinition = protoLoader.loadSync(protoPath, {
+                keepCase: true,
+                longs: Number,
+                enums: String,
+                defaults: true,
+                oneofs: true,
+                includeDirs: [protoBasePath],
+            });
+
+            const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+                zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+            };
+
+            const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
+            const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+            return new proto.zoekt.webserver.v1.WebserverService(
+                grpcAddress,
+                grpc.credentials.createInsecure(),
+            );
+        })();
+    }
+    return zoektClientPromise;
+};


### PR DESCRIPTION
## Summary

Adds `GET /api/health/ready`, a Kubernetes-style readiness probe that returns per-dependency health (Postgres, Redis, Zoekt). The existing `GET /api/health` liveness endpoint is unchanged.

Self-hosted operators can now wire Sourcebot into a Kubernetes `readinessProbe` or a load balancer health check and have the probe reflect whether the instance can actually serve traffic.

## Motivation

`GET /api/health` currently returns a hardcoded `{ "status": "ok" }` regardless of whether Postgres, Redis, or Zoekt are reachable. A pod that has lost its database connection still reports "ok" to a Kubernetes readiness probe, so traffic keeps being routed to a broken instance.

The previous FR for this (#727) was closed because the endpoint existed, but the original ask was for "structured response with details on its inner components' health status" — which was never delivered.

Closes #1506.

## Changes

- **`packages/web/src/app/api/(server)/health/ready/route.ts`** — new endpoint. Three checks run in parallel via `Promise.all`; each is bounded by a 2s timeout, so the worst-case request time is ~2s even when one dependency hangs. Returns 200 with `{status:ok, checks:{...}}` on success, 503 with `{status:degraded, checks:{...}}` on any failure. Per-check payload includes `status`, `latencyMs`, and (on error) `error`.
- **`packages/web/src/lib/zoektClient.ts`** — extracted the lazy Zoekt gRPC client construction into its own module so the readiness route can mock it in tests without pulling the `@grpc/grpc-js` + `@opentelemetry` CJS chain at test-load time. The dynamic-import + cached-promise pattern also avoids the boot-time cost of loading gRPC on the happy path where only some requests actually need it.
- **`packages/web/src/app/api/(server)/health/ready/route.test.ts`** — six test cases covering the healthy path, each of the three degraded paths, the non-`PONG` response path, and the parallel-execution invariant.
- **`docs/docs/api-reference/health.mdx`** — new docs page describing both endpoints, the response shape, and example Docker Compose `healthcheck:` and Kubernetes `livenessProbe` / `readinessProbe` blocks. Wired into the existing System group in `docs/docs.json`.
- **`CHANGELOG.md`** — entry under `[Unreleased] → Added`.

## Design decisions

- **Liveness vs readiness split, not a combined endpoint.** A liveness probe that touches the database can cause cascading pod restarts when the database is briefly unreachable. The split lets Kubernetes restart on liveness failure (process hung) but keep the pod in rotation only when the dependencies are healthy.
- **Three checks in parallel, not serially.** `Promise.all` keeps worst-case latency at `max(timeouts)`, not `sum(timeouts)`. A test asserts this explicitly.
- **Empty `List` with a 1s wall-time cap for Zoekt.** This is the smallest gRPC request that proves the channel is alive end-to-end. A dedicated `WebserverService.Health` method would be cleaner but doesn't exist in the vendored Zoekt proto.
- **Empty `List` returns success even with zero repos indexed.** This is the right behavior for a liveness/readiness probe (the question is "can we talk to Zoekt?", not "are there repos to search?"); a `strict=true` query param for "shards must be non-empty" is noted in the issue's future-work section.
- **No auth, no PostHog tracking.** Matches the existing `/api/health` policy and the documented contract that orchestrator probes should be free to hit the endpoint at any frequency.

## Verification

- `yarn workspace @sourcebot/web test --run "health/ready"` — 6/6 tests pass
- `yarn workspace @sourcebot/web lint` — 0 errors (4 pre-existing warnings in unrelated files)
- `tsc --noEmit -p packages/web/tsconfig.json` — 0 errors in the new files (pre-existing errors in `auth.ts` and a few EE files are documented in `HANDOFF.md` §21, out of scope)
- Manual sanity check: the response shape is what Kubernetes-style health probes and load-balancer configs expect

## Backward compatibility

Fully backwards compatible. The existing `/api/health` endpoint is unchanged. The new endpoint is purely additive. Operators who do not configure it see no change.

## Risks

- A misconfigured probe could cause Kubernetes to pull all pods out of rotation if the probe interval collides with a database blip. The docs recommend a 3-failure `failureThreshold`; the per-check 2s timeout absorbs brief blips.
- The Zoekt check calls `List` with a 1s wall-time cap; under load this could add to Zoekt's request rate. The check runs at most once per probe interval per pod (~0.3 RPS for the default 10s interval on a 3-pod deployment), which is negligible.

## Out of scope (tracked in #1506 as future work)

- Prometheus metrics for each check (`sourcebot_readiness_check_duration_seconds{check="postgres"}`, etc.) — would build on the same per-check helpers introduced here.
- A `/api/health/ready?strict=true` mode that treats an empty Zoekt shard set as degraded.
- Caching the readiness result for ~1s to absorb thundering-herd probes from multiple orchestrators.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive public health route with no auth or changes to existing `/api/health`; main operational risk is probe load on Postgres if intervals are set very aggressively (documented).
> 
> **Overview**
> Adds **`GET /api/health/ready`**, a public readiness endpoint that probes **Postgres** (`SELECT 1`), **Redis** (`PING`), and **Zoekt** (minimal gRPC `List`) in parallel. Each check is capped at **2s**; the handler returns **200** with per-check `latencyMs` when all pass, or **503** with `status: degraded` and error details when any fail. **`GET /api/health`** is unchanged for liveness.
> 
> Zoekt client construction is moved into **`packages/web/src/lib/zoektClient.ts`** (lazy build with an 800ms init timeout and cache reset on failure) so the route can be unit-tested without loading gRPC at import time.
> 
> Docs add **`docs/docs/api-reference/health.mdx`** (liveness vs readiness, response shape, K8s/Docker examples) and a changelog entry; **`route.test.ts`** covers healthy/degraded paths, parallelism, unhandled-rejection safety, and the empty Zoekt `List` request shape.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 59524ab859021252b8863ace74db38836da9a71c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a readiness health endpoint (`GET /api/health/ready`) that checks PostgreSQL, Redis, and Zoekt and returns per-check status, latency, and overall `ok`/`degraded`.
  * Returns HTTP 200 when all checks succeed; returns HTTP 503 with detailed per-check errors when any dependency is unreachable.
  * Executes checks in parallel with a bounded timeout for timely responses.

* **Documentation**
  * Documented the new readiness endpoint in the API reference and clarified liveness (`GET /api/health`) semantics.

* **Tests**
  * Added comprehensive automated tests covering success, degraded states, concurrency, and request details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->