### PR TITLE
chore: upgrade seroval to ^1.5.6 to address CVE-2026-59940

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Upgraded `seroval` to `^1.5.6`. [#1508](https://github.com/sourcebot-dev/sourcebot/pull/1508)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -21441,9 +21441,9 @@ __metadata:
   linkType: hard
 
 "seroval@npm:~1.5.0":
-  version: 1.5.0
-  resolution: "seroval@npm:1.5.0"
-  checksum: 10c0/aff16b14a7145388555cefd4ebd41759024ee1c2c064080fd8d4fabea4b7c89d103155cd98f5109523b8878e577da73cc6cd8abf98965f2d1f0ba19dc38317ab
+  version: 1.5.6
+  resolution: "seroval@npm:1.5.6"
+  checksum: 10c0/47e4fb25305bf05fdf300cac6b0d4aaaaf1e12f15c819195afcdf512d88901a3f1f7754ac5a2de740cc0bb04e912c653fbf0129fb3e4c81ce12809e6aa5815e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes SOU-1628

## Summary

- Refresh the existing `seroval@~1.5.0` lockfile resolution from `1.5.0` to `1.5.6`.
- Address CVE-2026-59940, which affects `seroval` through `1.5.2` and is first patched in `1.5.3`.
- Keep the supported transitive dependency range unchanged, with no forced resolution override.

## Verification

- `yarn why seroval --recursive`
- `yarn workspace @sourcebot/web test --run` (97 files, 1,145 tests)
- `yarn workspace @sourcebot/web lint` (0 errors; 4 pre-existing warnings)
- `yarn build:deps`
- `yarn test`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the changelog to record an upgrade of `seroval` to version 1.5.6.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Patch-level transitive dependency refresh with no app logic changes; typical low-risk security maintenance.
> 
> **Overview**
> Bumps the locked **transitive** `seroval` dependency from **1.5.0** to **1.5.6** in `yarn.lock` (still under the existing `~1.5.0` range pulled in via `solid-js`). No direct `package.json` or application code changes.
> 
> Documents the upgrade under **[Unreleased] → Fixed** in `CHANGELOG.md`, addressing **CVE-2026-59940** (vulnerable through 1.5.2; patched from 1.5.3 onward).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d5971446634c96efda722d86504c0e0ed3c96412. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->