### PR TITLE
feat(web): add ?strict=true mode to /api/health/ready for empty-shard detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1506](https://github.com/sourcebot-dev/sourcebot/issues/1506)
+- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1507](https://github.com/sourcebot-dev/sourcebot/pull/1507)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1507](https://github.com/sourcebot-dev/sourcebot/pull/1507)
+- Added a `?strict=true` query parameter to `GET /api/health/ready`. When set, the endpoint reports `503 / status: "degraded"` and `zoekt.status: "empty"` if the Zoekt shard set contains no indexed repositories, distinguishing "Zoekt is unreachable" from "Zoekt is up but the instance is not yet useful" for orchestrators. Default behavior is unchanged. [#1511](https://github.com/sourcebot-dev/sourcebot/issues/1511)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1506](https://github.com/sourcebot-dev/sourcebot/issues/1506)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a `GET /api/health/ready` endpoint that returns per-dependency health (Postgres, Redis, Zoekt) for use as a Kubernetes `readinessProbe` or load-balancer health check. The existing `GET /api/health` endpoint is unchanged and remains the liveness probe. [#1507](https://github.com/sourcebot-dev/sourcebot/pull/1507)
-- Added a `?strict=true` query parameter to `GET /api/health/ready`. When set, the endpoint reports `503 / status: "degraded"` and `zoekt.status: "empty"` if the Zoekt shard set contains no indexed repositories, distinguishing "Zoekt is unreachable" from "Zoekt is up but the instance is not yet useful" for orchestrators. Default behavior is unchanged. [#1511](https://github.com/sourcebot-dev/sourcebot/issues/1511)
+- Added a `?strict=true` query parameter to `GET /api/health/ready`. When set, the endpoint reports `503 / status: "degraded"` and `zoekt.status: "empty"` if the Zoekt shard set contains no indexed repositories, distinguishing "Zoekt is unreachable" from "Zoekt is up but the instance is not yet useful" for orchestrators. Default behavior is unchanged. [#1512](https://github.com/sourcebot-dev/sourcebot/pull/1512)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,6 @@
                         "icon": "server",
                         "pages": [
                             "GET /api/version",
-                            "GET /api/health",
                             "docs/api-reference/health"
                         ]
                     }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,8 @@
                         "icon": "server",
                         "pages": [
                             "GET /api/version",
-                            "GET /api/health"
+                            "GET /api/health",
+                            "docs/api-reference/health"
                         ]
                     }
                 ]

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -26,8 +26,8 @@ Add `?strict=true` to require the Zoekt shard set to be non-empty as well. The d
 
 ```bash
 curl -fsS 'https://sourcebot.example.com/api/health/ready?strict=true' | jq .status
-# "ok"     — Postgres, Redis, AND Zoekt (with at least one indexed repo) are healthy
-# "degraded" — something failed, see `checks` for which
+# "ok"       Postgres, Redis, and Zoekt (with at least one indexed repo) are healthy
+# "degraded" Something failed, see `checks` for which
 ```
 
 The response always includes a top-level `strict` field so the operator can confirm the mode that was applied:
@@ -45,8 +45,8 @@ The response always includes a top-level `strict` field so the operator can conf
 ```
 
 The Zoekt check distinguishes the two failure modes in its `status` field:
-- `error` — the gRPC call itself failed (Zoekt unreachable, timeout, etc.).
-- `empty` — strict mode is on and the shard set is empty. The dependency is healthy; the instance is just not yet useful.
+- `error`. The gRPC call itself failed (Zoekt unreachable, timeout, etc.).
+- `empty`. Strict mode is on and the shard set is empty. The dependency is healthy; the instance is just not yet useful.
 
 ### Response shape
 

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -1,0 +1,97 @@
+---
+title: "Health Endpoints"
+description: "Liveness and readiness probes for orchestrators and monitoring systems."
+---
+
+Sourcebot exposes two public health endpoints that follow the standard Kubernetes liveness / readiness split. Both are unauthenticated and return no user data.
+
+## Liveness: `GET /api/health`
+
+Returns `200 OK` with `{ "status": "ok" }` whenever the Next.js process is running and able to handle a request. Does not touch the database, Redis, or Zoekt. Use this for Kubernetes `livenessProbe` or Docker Compose `healthcheck.test`. A failing liveness probe means the process must be restarted.
+
+```bash
+curl -fsS https://sourcebot.example.com/api/health
+# {"status":"ok"}
+```
+
+## Readiness: `GET /api/health/ready`
+
+Returns `200 OK` with `{"status":"ok", "checks":{...}}` when Postgres, Redis, and Zoekt are all reachable. Returns `503 Service Unavailable` with `{"status":"degraded", "checks":{...}}` if any dependency is unreachable. Each check runs in parallel with a 2-second per-check timeout, so the worst-case request time is bounded even when a dependency hangs.
+
+Use this for Kubernetes `readinessProbe` or a load balancer health check. A failing readiness probe means the pod should be removed from the load-balancer rotation but not restarted.
+
+### Response shape
+
+```json
+{
+  "status": "ok",
+  "checks": {
+    "postgres": { "status": "ok", "latencyMs": 3 },
+    "redis":    { "status": "ok", "latencyMs": 1 },
+    "zoekt":    { "status": "ok", "latencyMs": 12 }
+  }
+}
+```
+
+When degraded, each failed check carries an `error` field with the underlying message:
+
+```json
+{
+  "status": "degraded",
+  "checks": {
+    "postgres": { "status": "ok",    "latencyMs": 4 },
+    "redis":    { "status": "ok",    "latencyMs": 1 },
+    "zoekt":    { "status": "error", "latencyMs": 2003, "error": "zoekt check timed out after 2000ms" }
+  }
+}
+```
+
+| Check | What it probes |
+|-------|---------------|
+| `postgres` | `SELECT 1` via Prisma |
+| `redis`    | `PING` (rejects non-`PONG` responses) |
+| `zoekt`    | `List` RPC with a 1-second wall-time cap (proves the gRPC channel is alive) |
+
+### Example probes
+
+<Tabs>
+  <Tab title="Docker Compose">
+    ```yaml
+    services:
+      sourcebot:
+        image: sourcebot/sourcebot:latest
+        healthcheck:
+          test: ["CMD", "wget", "-qO-", "http://localhost:3000/api/health"]
+          interval: 30s
+          timeout: 5s
+          retries: 3
+        # For dependency-aware probes, point the orchestrator at /api/health/ready
+        # instead. Sourcebot's example compose file does this via a sidecar.
+    ```
+  </Tab>
+  <Tab title="Kubernetes">
+    ```yaml
+    livenessProbe:
+      httpGet:
+        path: /api/health
+        port: 3000
+      initialDelaySeconds: 30
+      periodSeconds: 30
+      timeoutSeconds: 5
+      failureThreshold: 3
+    readinessProbe:
+      httpGet:
+        path: /api/health/ready
+        port: 3000
+      initialDelaySeconds: 10
+      periodSeconds: 10
+      timeoutSeconds: 5
+      successThreshold: 1
+      failureThreshold: 3
+    ```
+  </Tab>
+</Tabs>
+
+<Note>
+The readiness probe hits the database on every call. On large deployments with many pods, a high-frequency probe interval (sub-5s) can produce noticeable background load. A 10s interval with `failureThreshold: 3` is a good starting point.
+</Note>

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -50,7 +50,7 @@ When degraded, each failed check carries an `error` field with the underlying me
 |-------|---------------|
 | `postgres` | `SELECT 1` via Prisma |
 | `redis`    | `PING` (rejects non-`PONG` responses) |
-| `zoekt`    | `List` RPC with a 1-second wall-time cap (proves the gRPC channel is alive) |
+| `zoekt`    | Empty `List` RPC (proves the gRPC channel is alive; bounded by the 2s per-check timeout) |
 
 ### Example probes
 

--- a/docs/docs/api-reference/health.mdx
+++ b/docs/docs/api-reference/health.mdx
@@ -20,11 +20,40 @@ Returns `200 OK` with `{"status":"ok", "checks":{...}}` when Postgres, Redis, an
 
 Use this for Kubernetes `readinessProbe` or a load balancer health check. A failing readiness probe means the pod should be removed from the load-balancer rotation but not restarted.
 
+### Strict mode
+
+Add `?strict=true` to require the Zoekt shard set to be non-empty as well. The default mode only confirms the dependencies are reachable; strict mode confirms the instance can actually serve a search that returns results. A freshly-started instance, or one whose connection sync has silently failed, returns `503` until at least one repository is indexed.
+
+```bash
+curl -fsS 'https://sourcebot.example.com/api/health/ready?strict=true' | jq .status
+# "ok"     — Postgres, Redis, AND Zoekt (with at least one indexed repo) are healthy
+# "degraded" — something failed, see `checks` for which
+```
+
+The response always includes a top-level `strict` field so the operator can confirm the mode that was applied:
+
+```json
+{
+  "status": "degraded",
+  "strict": true,
+  "checks": {
+    "postgres": { "status": "ok",    "latencyMs": 3 },
+    "redis":    { "status": "ok",    "latencyMs": 1 },
+    "zoekt":    { "status": "empty", "latencyMs": 18, "error": "no repositories indexed (strict mode)" }
+  }
+}
+```
+
+The Zoekt check distinguishes the two failure modes in its `status` field:
+- `error` — the gRPC call itself failed (Zoekt unreachable, timeout, etc.).
+- `empty` — strict mode is on and the shard set is empty. The dependency is healthy; the instance is just not yet useful.
+
 ### Response shape
 
 ```json
 {
   "status": "ok",
+  "strict": false,
   "checks": {
     "postgres": { "status": "ok", "latencyMs": 3 },
     "redis":    { "status": "ok", "latencyMs": 1 },
@@ -38,6 +67,7 @@ When degraded, each failed check carries an `error` field with the underlying me
 ```json
 {
   "status": "degraded",
+  "strict": false,
   "checks": {
     "postgres": { "status": "ok",    "latencyMs": 4 },
     "redis":    { "status": "ok",    "latencyMs": 1 },
@@ -88,6 +118,9 @@ When degraded, each failed check carries an `error` field with the underlying me
       timeoutSeconds: 5
       successThreshold: 1
       failureThreshold: 3
+    # For deployments that should not receive traffic until the shard set
+    # is non-empty, switch to the strict readiness probe:
+    #   path: /api/health/ready?strict=true
     ```
   </Tab>
 </Tabs>

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -1,0 +1,152 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    unsafePrisma: {
+        $queryRaw: vi.fn(),
+    },
+    redisPing: vi.fn(),
+    zoektList: vi.fn(),
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@/prisma', () => ({
+    __unsafePrisma: mocks.unsafePrisma,
+}));
+
+vi.mock('@/lib/redis', () => ({
+    getRedisClient: () => ({
+        ping: mocks.redisPing,
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+vi.mock('@/lib/zoektClient', () => ({
+    loadZoektClient: () => ({
+        List: mocks.zoektList,
+    }),
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+const { GET } = await import('./route');
+
+describe('GET /api/health/ready', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.unsafePrisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
+        mocks.redisPing.mockResolvedValue('PONG');
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                callback(null);
+            },
+        );
+    });
+
+    test('returns 200 with status:ok when all three dependencies are reachable', async () => {
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.status).toBe('ok');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('ok');
+        expect(body.checks.zoekt.status).toBe('ok');
+        expect(typeof body.checks.postgres.latencyMs).toBe('number');
+        expect(typeof body.checks.redis.latencyMs).toBe('number');
+        expect(typeof body.checks.zoekt.latencyMs).toBe('number');
+    });
+
+    test('returns 503 with status:degraded and a postgres error when Postgres is unreachable', async () => {
+        mocks.unsafePrisma.$queryRaw.mockRejectedValue(new Error('connection refused'));
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.postgres.status).toBe('error');
+        expect(body.checks.postgres.error).toBe('connection refused');
+        expect(body.checks.redis.status).toBe('ok');
+        expect(body.checks.zoekt.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded and a redis error when Redis ping fails', async () => {
+        mocks.redisPing.mockRejectedValue(new Error('redis down'));
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('error');
+        expect(body.checks.redis.error).toBe('redis down');
+        expect(body.checks.zoekt.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded when the Zoekt gRPC call errors', async () => {
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                callback(new Error('UNAVAILABLE: zoekt not reachable'));
+            },
+        );
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.zoekt.status).toBe('error');
+        expect(body.checks.zoekt.error).toContain('UNAVAILABLE');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('ok');
+    });
+
+    test('returns 503 with status:degraded when Redis returns a non-PONG response', async () => {
+        mocks.redisPing.mockResolvedValue('NOT-PONG');
+
+        const response = await GET();
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.redis.status).toBe('error');
+        expect(body.checks.redis.error).toContain('unexpected ping response');
+    });
+
+    test('runs all three checks in parallel (Promise.all)', async () => {
+        const delay = 50;
+        mocks.unsafePrisma.$queryRaw.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve([{}]), delay)),
+        );
+        mocks.redisPing.mockImplementation(
+            () => new Promise((resolve) => setTimeout(() => resolve('PONG'), delay)),
+        );
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: (err: Error | null) => void) => {
+                setTimeout(() => callback(null), delay);
+            },
+        );
+
+        const start = Date.now();
+        const response = await GET();
+        const elapsed = Date.now() - start;
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.status).toBe('ok');
+        // Generous upper bound to avoid flakes; serial would be ~3x delay.
+        expect(elapsed).toBeLessThan(delay * 2.5);
+    });
+});

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -182,4 +182,18 @@ describe('GET /api/health/ready', () => {
             process.off('unhandledRejection', onUnhandled);
         }
     });
+
+    test('issues the Zoekt List RPC with empty options (max_wall_time is a SearchOptions field, not ListOptions)', async () => {
+        // Regression guard: the earlier draft of the Zoekt probe passed
+        // `{ opts: { max_wall_time: ... } }` to the `List` RPC. That field
+        // belongs to `SearchOptions` and is silently ignored by `List`
+        // (whose `ListOptions` only carries `field`). The 2s client-side
+        // timeout is the only thing that actually bounds the call. The
+        // probe must therefore issue the smallest valid request, which is
+        // an empty options object.
+        const response = await GET();
+        expect(response.status).toBe(200);
+        expect(mocks.zoektList).toHaveBeenCalledTimes(1);
+        expect(mocks.zoektList).toHaveBeenCalledWith({}, expect.any(Function));
+    });
 });

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
 
 const mocks = vi.hoisted(() => ({
     unsafePrisma: {
@@ -41,24 +42,37 @@ vi.mock('@sourcebot/shared', () => ({
 
 const { GET } = await import('./route');
 
+// Minimal NextRequest stand-in. We only need `nextUrl.searchParams`; the
+// runtime calls are not exercised.
+const makeRequest = (search: Record<string, string> = {}): NextRequest => {
+    const params = new URLSearchParams(search);
+    const url = `http://localhost/api/health/ready?${params.toString()}`;
+    return new NextRequest(url);
+};
+
+// Default Zoekt response: a single indexed repo. Tests that need a different
+// shape override the mock in their own `beforeEach` / `mockImplementationOnce`.
+const defaultZoektResponse = { repos: [{}] };
+
 describe('GET /api/health/ready', () => {
     beforeEach(() => {
         vi.clearAllMocks();
         mocks.unsafePrisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
         mocks.redisPing.mockResolvedValue('PONG');
         mocks.zoektList.mockImplementation(
-            (_request: unknown, callback: (err: Error | null) => void) => {
-                callback(null);
+            (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                callback(null, defaultZoektResponse);
             },
         );
     });
 
-    test('returns 200 with status:ok when all three dependencies are reachable', async () => {
-        const response = await GET();
+    test('returns 200 with status:ok and strict:false when all three dependencies are reachable', async () => {
+        const response = await GET(makeRequest());
         const body = await response.json();
 
         expect(response.status).toBe(200);
         expect(body.status).toBe('ok');
+        expect(body.strict).toBe(false);
         expect(body.checks.postgres.status).toBe('ok');
         expect(body.checks.redis.status).toBe('ok');
         expect(body.checks.zoekt.status).toBe('ok');
@@ -70,7 +84,7 @@ describe('GET /api/health/ready', () => {
     test('returns 503 with status:degraded and a postgres error when Postgres is unreachable', async () => {
         mocks.unsafePrisma.$queryRaw.mockRejectedValue(new Error('connection refused'));
 
-        const response = await GET();
+        const response = await GET(makeRequest());
         const body = await response.json();
 
         expect(response.status).toBe(503);
@@ -84,7 +98,7 @@ describe('GET /api/health/ready', () => {
     test('returns 503 with status:degraded and a redis error when Redis ping fails', async () => {
         mocks.redisPing.mockRejectedValue(new Error('redis down'));
 
-        const response = await GET();
+        const response = await GET(makeRequest());
         const body = await response.json();
 
         expect(response.status).toBe(503);
@@ -102,7 +116,7 @@ describe('GET /api/health/ready', () => {
             },
         );
 
-        const response = await GET();
+        const response = await GET(makeRequest());
         const body = await response.json();
 
         expect(response.status).toBe(503);
@@ -116,7 +130,7 @@ describe('GET /api/health/ready', () => {
     test('returns 503 with status:degraded when Redis returns a non-PONG response', async () => {
         mocks.redisPing.mockResolvedValue('NOT-PONG');
 
-        const response = await GET();
+        const response = await GET(makeRequest());
         const body = await response.json();
 
         expect(response.status).toBe(503);
@@ -134,13 +148,13 @@ describe('GET /api/health/ready', () => {
             () => new Promise((resolve) => setTimeout(() => resolve('PONG'), delay)),
         );
         mocks.zoektList.mockImplementation(
-            (_request: unknown, callback: (err: Error | null) => void) => {
-                setTimeout(() => callback(null), delay);
+            (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                setTimeout(() => callback(null, defaultZoektResponse), delay);
             },
         );
 
         const start = Date.now();
-        const response = await GET();
+        const response = await GET(makeRequest());
         const elapsed = Date.now() - start;
         const body = await response.json();
 
@@ -165,12 +179,12 @@ describe('GET /api/health/ready', () => {
             mocks.unsafePrisma.$queryRaw.mockRejectedValue(checkRejection);
             mocks.redisPing.mockResolvedValue('PONG');
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null) => void) => {
-                    callback(null);
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, defaultZoektResponse);
                 },
             );
 
-            const response = await GET();
+            const response = await GET(makeRequest());
             const body = await response.json();
 
             expect(response.status).toBe(503);
@@ -191,9 +205,124 @@ describe('GET /api/health/ready', () => {
         // timeout is the only thing that actually bounds the call. The
         // probe must therefore issue the smallest valid request, which is
         // an empty options object.
-        const response = await GET();
+        const response = await GET(makeRequest());
         expect(response.status).toBe(200);
         expect(mocks.zoektList).toHaveBeenCalledTimes(1);
         expect(mocks.zoektList).toHaveBeenCalledWith({}, expect.any(Function));
+    });
+
+    describe('?strict=true', () => {
+        test('returns 200 with status:ok and strict:true when Zoekt has at least one indexed repo', async () => {
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos: [{ repository: { name: 'foo' } }] });
+                },
+            );
+
+            const response = await GET(makeRequest({ strict: 'true' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(body.status).toBe('ok');
+            expect(body.strict).toBe(true);
+            expect(body.checks.zoekt.status).toBe('ok');
+        });
+
+        test('returns 503 with status:degraded and zoekt.status:"empty" when Zoekt has no indexed repos', async () => {
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos: [] });
+                },
+            );
+
+            const response = await GET(makeRequest({ strict: 'true' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(503);
+            expect(body.status).toBe('degraded');
+            expect(body.strict).toBe(true);
+            expect(body.checks.zoekt.status).toBe('empty');
+            expect(body.checks.zoekt.error).toContain('no repositories indexed');
+            expect(body.checks.postgres.status).toBe('ok');
+            expect(body.checks.redis.status).toBe('ok');
+        });
+
+        test('returns 503 in strict mode when the Zoekt response uses repos_map (RepoListFieldReposMap)', async () => {
+            // The gRPC server may return `repos_map` (a numeric-keyed object)
+            // when `ListOptions.Field = RepoListFieldReposMap`. Empty
+            // `repos_map` should also be treated as empty in strict mode.
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos_map: {} });
+                },
+            );
+
+            const response = await GET(makeRequest({ strict: 'true' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(503);
+            expect(body.checks.zoekt.status).toBe('empty');
+        });
+
+        test('returns 200 in strict mode when repos_map is non-empty', async () => {
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos_map: { 1: { repository: { name: 'bar' } } } });
+                },
+            );
+
+            const response = await GET(makeRequest({ strict: 'true' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(body.checks.zoekt.status).toBe('ok');
+        });
+    });
+
+    describe('?strict=false and absent', () => {
+        test('returns 200 with strict:false and zoekt.status:ok when Zoekt has zero repos', async () => {
+            // Backward-compat: the default behavior must NOT consider an
+            // empty Zoekt shard set as a failure. Operators who do not opt
+            // in to strict mode should see the same response as before.
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos: [] });
+                },
+            );
+
+            const response = await GET(makeRequest({ strict: 'false' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(body.status).toBe('ok');
+            expect(body.strict).toBe(false);
+            expect(body.checks.zoekt.status).toBe('ok');
+        });
+
+        test('treats an absent strict parameter as strict:false', async () => {
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                    callback(null, { repos: [] });
+                },
+            );
+
+            const response = await GET(makeRequest());
+            const body = await response.json();
+
+            expect(response.status).toBe(200);
+            expect(body.strict).toBe(false);
+            expect(body.checks.zoekt.status).toBe('ok');
+        });
+    });
+
+    describe('invalid ?strict value', () => {
+        test('returns 400 with a clear error message when strict is not parseable', async () => {
+            const response = await GET(makeRequest({ strict: 'yes' }));
+            const body = await response.json();
+
+            expect(response.status).toBe(400);
+            expect(body.message).toBeDefined();
+            expect(body.message).toMatch(/strict/);
+        });
     });
 });

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -50,9 +50,16 @@ const makeRequest = (search: Record<string, string> = {}): NextRequest => {
     return new NextRequest(url);
 };
 
-// Default Zoekt response: a single indexed repo. Tests that need a different
-// shape override the mock in their own `beforeEach` / `mockImplementationOnce`.
+// Default Zoekt response: a single indexed repo. Tests that need a
+// different shape override the mock implementation locally.
 const defaultZoektResponse = { repos: [{}] };
+
+// gRPC callback shape: (err, response) => void. Pulled out so the seven
+// `mocks.zoektList.mockImplementation(...)` blocks below stay short.
+type ZoektListCallback = (
+    err: Error | null,
+    response?: { repos?: unknown[]; repos_map?: Record<number, unknown> },
+) => void;
 
 describe('GET /api/health/ready', () => {
     beforeEach(() => {
@@ -60,7 +67,7 @@ describe('GET /api/health/ready', () => {
         mocks.unsafePrisma.$queryRaw.mockResolvedValue([{ '?column?': 1 }]);
         mocks.redisPing.mockResolvedValue('PONG');
         mocks.zoektList.mockImplementation(
-            (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+            (_request: unknown, callback: ZoektListCallback) => {
                 callback(null, defaultZoektResponse);
             },
         );
@@ -148,7 +155,7 @@ describe('GET /api/health/ready', () => {
             () => new Promise((resolve) => setTimeout(() => resolve('PONG'), delay)),
         );
         mocks.zoektList.mockImplementation(
-            (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+            (_request: unknown, callback: ZoektListCallback) => {
                 setTimeout(() => callback(null, defaultZoektResponse), delay);
             },
         );
@@ -179,7 +186,7 @@ describe('GET /api/health/ready', () => {
             mocks.unsafePrisma.$queryRaw.mockRejectedValue(checkRejection);
             mocks.redisPing.mockResolvedValue('PONG');
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, defaultZoektResponse);
                 },
             );
@@ -214,7 +221,7 @@ describe('GET /api/health/ready', () => {
     describe('?strict=true', () => {
         test('returns 200 with status:ok and strict:true when Zoekt has at least one indexed repo', async () => {
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos: [{ repository: { name: 'foo' } }] });
                 },
             );
@@ -230,7 +237,7 @@ describe('GET /api/health/ready', () => {
 
         test('returns 503 with status:degraded and zoekt.status:"empty" when Zoekt has no indexed repos', async () => {
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos: [] });
                 },
             );
@@ -252,7 +259,7 @@ describe('GET /api/health/ready', () => {
             // when `ListOptions.Field = RepoListFieldReposMap`. Empty
             // `repos_map` should also be treated as empty in strict mode.
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos_map: {} });
                 },
             );
@@ -266,7 +273,7 @@ describe('GET /api/health/ready', () => {
 
         test('returns 200 in strict mode when repos_map is non-empty', async () => {
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos_map: { 1: { repository: { name: 'bar' } } } });
                 },
             );
@@ -285,7 +292,7 @@ describe('GET /api/health/ready', () => {
             // empty Zoekt shard set as a failure. Operators who do not opt
             // in to strict mode should see the same response as before.
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos: [] });
                 },
             );
@@ -301,7 +308,7 @@ describe('GET /api/health/ready', () => {
 
         test('treats an absent strict parameter as strict:false', async () => {
             mocks.zoektList.mockImplementation(
-                (_request: unknown, callback: (err: Error | null, response?: { repos?: unknown[]; repos_map?: Record<number, unknown> }) => void) => {
+                (_request: unknown, callback: ZoektListCallback) => {
                     callback(null, { repos: [] });
                 },
             );

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -218,6 +218,30 @@ describe('GET /api/health/ready', () => {
         expect(mocks.zoektList).toHaveBeenCalledWith({}, expect.any(Function));
     });
 
+    test('reports zoekt.status:"error" (not a thrown exception) when the gRPC callback fires with no response', async () => {
+        // Regression guard: a malformed gRPC response can fire the callback
+        // with `err === null` and `result === undefined`. Without the
+        // `!result` check the route would throw on `response.repos` and
+        // surface the failure as a generic Node unhandled-rejection path
+        // instead of the controlled `error` status. `zoektSearch` applies
+        // the same `error || !response` guard.
+        mocks.zoektList.mockImplementation(
+            (_request: unknown, callback: ZoektListCallback) => {
+                callback(null, undefined);
+            },
+        );
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(503);
+        expect(body.status).toBe('degraded');
+        expect(body.checks.zoekt.status).toBe('error');
+        expect(body.checks.zoekt.error).toContain('no response');
+        expect(body.checks.postgres.status).toBe('ok');
+        expect(body.checks.redis.status).toBe('ok');
+    });
+
     describe('?strict=true', () => {
         test('returns 200 with status:ok and strict:true when Zoekt has at least one indexed repo', async () => {
             mocks.zoektList.mockImplementation(

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -35,10 +35,12 @@ vi.mock('@sourcebot/shared', () => ({
     createLogger: () => ({
         debug: vi.fn(),
         info: vi.fn(),
-        warn: vi.fn(),
+        warn: mockLoggerWarn,
         error: vi.fn(),
     }),
 }));
+
+const mockLoggerWarn = vi.fn();
 
 const { GET } = await import('./route');
 
@@ -88,8 +90,9 @@ describe('GET /api/health/ready', () => {
         expect(typeof body.checks.zoekt.latencyMs).toBe('number');
     });
 
-    test('returns 503 with status:degraded and a postgres error when Postgres is unreachable', async () => {
-        mocks.unsafePrisma.$queryRaw.mockRejectedValue(new Error('connection refused'));
+    test('returns 503 with status:degraded and a generic postgres error when Postgres is unreachable', async () => {
+        const internalError = new Error('connection refused: host=db.internal.example.com:5432');
+        mocks.unsafePrisma.$queryRaw.mockRejectedValue(internalError);
 
         const response = await GET(makeRequest());
         const body = await response.json();
@@ -97,13 +100,22 @@ describe('GET /api/health/ready', () => {
         expect(response.status).toBe(503);
         expect(body.status).toBe('degraded');
         expect(body.checks.postgres.status).toBe('error');
-        expect(body.checks.postgres.error).toBe('connection refused');
+        // The public error is generic. The internal message (which
+        // contains the host:port) must not leak.
+        expect(body.checks.postgres.error).toBe('postgres check failed: see server logs');
+        expect(body.checks.postgres.error).not.toContain('db.internal.example.com');
+        expect(body.checks.postgres.errorDetail).toBeUndefined();
         expect(body.checks.redis.status).toBe('ok');
         expect(body.checks.zoekt.status).toBe('ok');
+
+        // The full error detail is preserved on the server-side log call.
+        const warnCall = mockLoggerWarn.mock.calls[mockLoggerWarn.mock.calls.length - 1];
+        expect(JSON.stringify(warnCall)).toContain('db.internal.example.com');
     });
 
-    test('returns 503 with status:degraded and a redis error when Redis ping fails', async () => {
-        mocks.redisPing.mockRejectedValue(new Error('redis down'));
+    test('returns 503 with status:degraded and a generic redis error when Redis ping fails', async () => {
+        const internalError = new Error('redis down: redis://10.0.0.42:6379');
+        mocks.redisPing.mockRejectedValue(internalError);
 
         const response = await GET(makeRequest());
         const body = await response.json();
@@ -112,14 +124,17 @@ describe('GET /api/health/ready', () => {
         expect(body.status).toBe('degraded');
         expect(body.checks.postgres.status).toBe('ok');
         expect(body.checks.redis.status).toBe('error');
-        expect(body.checks.redis.error).toBe('redis down');
+        expect(body.checks.redis.error).toBe('redis check failed: see server logs');
+        expect(body.checks.redis.error).not.toContain('10.0.0.42');
+        expect(body.checks.redis.errorDetail).toBeUndefined();
         expect(body.checks.zoekt.status).toBe('ok');
     });
 
-    test('returns 503 with status:degraded when the Zoekt gRPC call errors', async () => {
+    test('returns 503 with status:degraded and a generic zoekt error when the gRPC call fails', async () => {
+        const internalError = new Error('UNAVAILABLE: zoekt-web-0.zoekt.svc.cluster.local:6070');
         mocks.zoektList.mockImplementation(
-            (_request: unknown, callback: (err: Error | null) => void) => {
-                callback(new Error('UNAVAILABLE: zoekt not reachable'));
+            (_request: unknown, callback: ZoektListCallback) => {
+                callback(internalError);
             },
         );
 
@@ -129,7 +144,9 @@ describe('GET /api/health/ready', () => {
         expect(response.status).toBe(503);
         expect(body.status).toBe('degraded');
         expect(body.checks.zoekt.status).toBe('error');
-        expect(body.checks.zoekt.error).toContain('UNAVAILABLE');
+        expect(body.checks.zoekt.error).toBe('zoekt check failed: see server logs');
+        expect(body.checks.zoekt.error).not.toContain('cluster.local');
+        expect(body.checks.zoekt.errorDetail).toBeUndefined();
         expect(body.checks.postgres.status).toBe('ok');
         expect(body.checks.redis.status).toBe('ok');
     });
@@ -143,7 +160,9 @@ describe('GET /api/health/ready', () => {
         expect(response.status).toBe(503);
         expect(body.status).toBe('degraded');
         expect(body.checks.redis.status).toBe('error');
-        expect(body.checks.redis.error).toContain('unexpected ping response');
+        // "unexpected ping response" is the internal message; the public
+        // path should not include it.
+        expect(body.checks.redis.error).toBe('redis check failed: see server logs');
     });
 
     test('runs all three checks in parallel (Promise.all)', async () => {
@@ -237,7 +256,7 @@ describe('GET /api/health/ready', () => {
         expect(response.status).toBe(503);
         expect(body.status).toBe('degraded');
         expect(body.checks.zoekt.status).toBe('error');
-        expect(body.checks.zoekt.error).toContain('no response');
+        expect(body.checks.zoekt.error).toBe('zoekt check failed: see server logs');
         expect(body.checks.postgres.status).toBe('ok');
         expect(body.checks.redis.status).toBe('ok');
     });

--- a/packages/web/src/app/api/(server)/health/ready/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.test.ts
@@ -149,4 +149,37 @@ describe('GET /api/health/ready', () => {
         // Generous upper bound to avoid flakes; serial would be ~3x delay.
         expect(elapsed).toBeLessThan(delay * 2.5);
     });
+
+    test('does not surface check rejections as unhandled promise rejections', async () => {
+        // The check rejects synchronously (well within the 2s timeout). The
+        // no-op `.catch` attached in `withTimeout` must absorb that
+        // rejection so the Node process does not log an
+        // unhandled-promise-rejection warning while the readiness request
+        // has already moved on.
+        const checkRejection = new Error('check rejected');
+        const unhandled: unknown[] = [];
+        const onUnhandled = (err: unknown) => { unhandled.push(err); };
+        process.on('unhandledRejection', onUnhandled);
+
+        try {
+            mocks.unsafePrisma.$queryRaw.mockRejectedValue(checkRejection);
+            mocks.redisPing.mockResolvedValue('PONG');
+            mocks.zoektList.mockImplementation(
+                (_request: unknown, callback: (err: Error | null) => void) => {
+                    callback(null);
+                },
+            );
+
+            const response = await GET();
+            const body = await response.json();
+
+            expect(response.status).toBe(503);
+            expect(body.checks.postgres.status).toBe('error');
+            // Give the rejection microtask a chance to fire and propagate.
+            await new Promise((resolve) => setTimeout(resolve, 50));
+            expect(unhandled).not.toContain(checkRejection);
+        } finally {
+            process.off('unhandledRejection', onUnhandled);
+        }
+    });
 });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -1,9 +1,12 @@
 import { createLogger } from '@sourcebot/shared';
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
 
 import { apiHandler } from '@/lib/apiHandler';
 import { __unsafePrisma } from '@/prisma';
 import { getRedisClient } from '@/lib/redis';
-import { loadZoektClient } from '@/lib/zoektClient';
+import { queryParamsSchemaValidationError, serviceErrorResponse } from '@/lib/serviceError';
+import { loadZoektClient, ZoektListResponse } from '@/lib/zoektClient';
 
 // Per-check timeout. The three checks run in parallel, so the worst-case
 // request time is bounded by this value even when one dependency hangs.
@@ -11,7 +14,7 @@ const READINESS_TIMEOUT_MS = 2000;
 
 const logger = createLogger('health-ready');
 
-type CheckStatus = 'ok' | 'error';
+type CheckStatus = 'ok' | 'error' | 'empty';
 type CheckResult = {
     status: CheckStatus;
     latencyMs: number;
@@ -19,12 +22,29 @@ type CheckResult = {
 };
 type ReadinessResponse = {
     status: 'ok' | 'degraded';
+    strict: boolean;
     checks: {
         postgres: CheckResult;
         redis: CheckResult;
         zoekt: CheckResult;
     };
 };
+
+const queryParamsSchema = z.object({
+    // `z.coerce.boolean()` is a footgun here: it just calls `Boolean(value)`
+    // under the hood, which would treat the string `"false"` as truthy.
+    // Instead, accept only the two literal strings we mean to support and
+    // transform to the matching boolean. Anything else (including absent)
+    // either defaults to false or surfaces as a 400.
+    strict: z
+        .string()
+        .optional()
+        .refine(
+            (v) => v === undefined || v === 'true' || v === 'false',
+            { message: 'strict must be "true" or "false"' },
+        )
+        .transform((v) => v === 'true'),
+});
 
 // Runs `check()` and rejects if it has not settled after `timeoutMs`. When the
 // timeout fires, the underlying check promise may still resolve or reject
@@ -90,30 +110,52 @@ const checkRedis = async (): Promise<CheckResult> => {
     }
 };
 
-const checkZoekt = async (): Promise<CheckResult> => {
+const checkZoekt = async (strict: boolean): Promise<CheckResult> => {
     const start = Date.now();
     try {
-        await withTimeout('zoekt', async () => {
+        // The List response is captured so the strict path can decide
+        // whether the empty-shard case is acceptable or not.
+        const response = await withTimeout('zoekt', async () => {
             // Build the client inside the timeout so a first-call init stall
             // (e.g., vendored proto load) is also bounded.
             const client = await loadZoektClient();
-            await new Promise<void>((resolve, reject) => {
-                // Empty `List` is the smallest request that exercises the gRPC
-                // channel end-to-end. It returns an empty result, not an error,
-                // even when no repos are indexed. The 2s client-side
-                // `READINESS_TIMEOUT_MS` is the only timeout that actually
-                // bounds the call: `max_wall_time` is a `SearchOptions` field
-                // and does not apply to `List` (`ListOptions` only carries
-                // `field`).
-                client.List({}, (err) => {
+            return await new Promise<ZoektListResponse>((resolve, reject) => {
+                // Empty `List` is the smallest request that exercises the
+                // gRPC channel end-to-end. It returns an empty result, not
+                // an error, even when no repos are indexed. The 2s
+                // client-side `READINESS_TIMEOUT_MS` is the only timeout
+                // that actually bounds the call: `max_wall_time` is a
+                // `SearchOptions` field and does not apply to `List`
+                // (`ListOptions` only carries `field`).
+                client.List({}, (err, result) => {
                     if (err) {
                         reject(err);
                     } else {
-                        resolve();
+                        resolve(result);
                     }
                 });
             });
         }, READINESS_TIMEOUT_MS);
+
+        if (strict) {
+            // "Empty" means neither `repos` (Field = RepoListFieldRepos) nor
+            // `repos_map` (Field = RepoListFieldReposMap) carries any
+            // entries. Both arrays/objects are always returned by the gRPC
+            // stub, so the only thing we have to defend against is
+            // unexpected `undefined` (e.g. a stub mismatch).
+            const repos = Array.isArray(response.repos) ? response.repos : [];
+            const reposMap = response.repos_map && typeof response.repos_map === 'object'
+                ? response.repos_map
+                : {};
+            if (repos.length === 0 && Object.keys(reposMap).length === 0) {
+                return {
+                    status: 'empty',
+                    latencyMs: Date.now() - start,
+                    error: 'no repositories indexed (strict mode)',
+                };
+            }
+        }
+
         return { status: 'ok', latencyMs: Date.now() - start };
     } catch (err) {
         return {
@@ -125,22 +167,36 @@ const checkZoekt = async (): Promise<CheckResult> => {
 };
 
 // eslint-disable-next-line authz/require-auth-wrapper -- public readiness probe, no user data returned
-export const GET = apiHandler(async () => {
+export const GET = apiHandler(async (request: NextRequest) => {
+    const rawParams = {
+        strict: request.nextUrl.searchParams.get('strict') ?? undefined,
+    };
+    const parsed = queryParamsSchema.safeParse(rawParams);
+
+    if (!parsed.success) {
+        return serviceErrorResponse(
+            queryParamsSchemaValidationError(parsed.error)
+        );
+    }
+
+    const { strict } = parsed.data;
+
     const [postgres, redis, zoekt] = await Promise.all([
         checkPostgres(),
         checkRedis(),
-        checkZoekt(),
+        checkZoekt(strict),
     ]);
 
     const checks = { postgres, redis, zoekt };
     const healthy = postgres.status === 'ok' && redis.status === 'ok' && zoekt.status === 'ok';
 
     if (!healthy) {
-        logger.warn('readiness check failed', { checks });
+        logger.warn('readiness check failed', { checks, strict });
     }
 
     const body: ReadinessResponse = {
         status: healthy ? 'ok' : 'degraded',
+        strict,
         checks,
     };
     return Response.json(body, { status: healthy ? 200 : 503 });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -31,11 +31,9 @@ type ReadinessResponse = {
 };
 
 const queryParamsSchema = z.object({
-    // `z.coerce.boolean()` is a footgun here: it just calls `Boolean(value)`
-    // under the hood, which would treat the string `"false"` as truthy.
-    // Instead, accept only the two literal strings we mean to support and
-    // transform to the matching boolean. Anything else (including absent)
-    // either defaults to false or surfaces as a 400.
+    // `z.coerce.boolean()` is a footgun: it just calls `Boolean(value)` and
+    // would treat the string `"false"` as truthy. Accept only the two
+    // literal strings we mean to support and transform to a boolean.
     strict: z
         .string()
         .optional()
@@ -114,7 +112,7 @@ const checkZoekt = async (strict: boolean): Promise<CheckResult> => {
     const start = Date.now();
     try {
         // The List response is captured so the strict path can decide
-        // whether the empty-shard case is acceptable or not.
+        // whether the empty-shard case is acceptable.
         const response = await withTimeout('zoekt', async () => {
             // Build the client inside the timeout so a first-call init stall
             // (e.g., vendored proto load) is also bounded.
@@ -138,15 +136,11 @@ const checkZoekt = async (strict: boolean): Promise<CheckResult> => {
         }, READINESS_TIMEOUT_MS);
 
         if (strict) {
-            // "Empty" means neither `repos` (Field = RepoListFieldRepos) nor
-            // `repos_map` (Field = RepoListFieldReposMap) carries any
-            // entries. Both arrays/objects are always returned by the gRPC
-            // stub, so the only thing we have to defend against is
-            // unexpected `undefined` (e.g. a stub mismatch).
-            const repos = Array.isArray(response.repos) ? response.repos : [];
-            const reposMap = response.repos_map && typeof response.repos_map === 'object'
-                ? response.repos_map
-                : {};
+            // Check both `repos` (Field = RepoListFieldRepos) and
+            // `repos_map` (Field = RepoListFieldReposMap) so the result is
+            // correct regardless of which field the server populates.
+            const repos = response.repos ?? [];
+            const reposMap = response.repos_map ?? {};
             if (repos.length === 0 && Object.keys(reposMap).length === 0) {
                 return {
                     status: 'empty',

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -18,7 +18,14 @@ type CheckStatus = 'ok' | 'error' | 'empty';
 type CheckResult = {
     status: CheckStatus;
     latencyMs: number;
+    /** Client-safe error description. Optional; present when status !== 'ok'. */
     error?: string;
+    /**
+     * Server-side error detail. Never sent over the wire: the public
+     * `error` field is the only one that ends up in the JSON response.
+     * Logged by the GET handler when the overall probe is degraded.
+     */
+    errorDetail?: string;
 };
 type ReadinessResponse = {
     status: 'ok' | 'degraded';
@@ -72,6 +79,13 @@ const withTimeout = async <T>(
     }
 };
 
+// The readiness route is unauthenticated and may be reachable at a public
+// URL, so per-check error strings returned to the caller are intentionally
+// generic. The full `err` is preserved on the `CheckResult` (under
+// `errorDetail`) and logged server-side; the public `error` field carries
+// only the check label and a hint about the failure mode.
+const PUBLIC_ERROR = (label: string, detail: string) => `${label} check failed: ${detail}`;
+
 const checkPostgres = async (): Promise<CheckResult> => {
     const start = Date.now();
     try {
@@ -83,7 +97,8 @@ const checkPostgres = async (): Promise<CheckResult> => {
         return {
             status: 'error',
             latencyMs: Date.now() - start,
-            error: err instanceof Error ? err.message : String(err),
+            error: PUBLIC_ERROR('postgres', 'see server logs'),
+            errorDetail: err instanceof Error ? err.message : String(err),
         };
     }
 };
@@ -103,7 +118,8 @@ const checkRedis = async (): Promise<CheckResult> => {
         return {
             status: 'error',
             latencyMs: Date.now() - start,
-            error: err instanceof Error ? err.message : String(err),
+            error: PUBLIC_ERROR('redis', 'see server logs'),
+            errorDetail: err instanceof Error ? err.message : String(err),
         };
     }
 };
@@ -163,7 +179,8 @@ const checkZoekt = async (strict: boolean): Promise<CheckResult> => {
         return {
             status: 'error',
             latencyMs: Date.now() - start,
-            error: err instanceof Error ? err.message : String(err),
+            error: PUBLIC_ERROR('zoekt', 'see server logs'),
+            errorDetail: err instanceof Error ? err.message : String(err),
         };
     }
 };
@@ -189,17 +206,28 @@ export const GET = apiHandler(async (request: NextRequest) => {
         checkZoekt(strict),
     ]);
 
-    const checks = { postgres, redis, zoekt };
+    // `errorDetail` is server-side only and must never reach the response
+    // body. The full per-check result (including `errorDetail`) is what
+    // the logger emits; the public response uses the stripped view.
+    const stripDetail = ({ errorDetail: _errorDetail, ...publicCheck }: CheckResult) => publicCheck;
+    const publicChecks = {
+        postgres: stripDetail(postgres),
+        redis: stripDetail(redis),
+        zoekt: stripDetail(zoekt),
+    };
     const healthy = postgres.status === 'ok' && redis.status === 'ok' && zoekt.status === 'ok';
 
     if (!healthy) {
-        logger.warn('readiness check failed', { checks, strict });
+        logger.warn('readiness check failed', {
+            checks: { postgres, redis, zoekt },
+            strict,
+        });
     }
 
     const body: ReadinessResponse = {
         status: healthy ? 'ok' : 'degraded',
         strict,
-        checks,
+        checks: publicChecks,
     };
     return Response.json(body, { status: healthy ? 200 : 503 });
 }, { track: false });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -1,0 +1,139 @@
+import { createLogger } from '@sourcebot/shared';
+
+import { apiHandler } from '@/lib/apiHandler';
+import { __unsafePrisma } from '@/prisma';
+import { getRedisClient } from '@/lib/redis';
+import { loadZoektClient } from '@/lib/zoektClient';
+
+// Per-check timeout. The three checks run in parallel, so the worst-case
+// request time is bounded by this value even when one dependency hangs.
+const READINESS_TIMEOUT_MS = 2000;
+
+const logger = createLogger('health-ready');
+
+type CheckStatus = 'ok' | 'error';
+type CheckResult = {
+    status: CheckStatus;
+    latencyMs: number;
+    error?: string;
+};
+type ReadinessResponse = {
+    status: 'ok' | 'degraded';
+    checks: {
+        postgres: CheckResult;
+        redis: CheckResult;
+        zoekt: CheckResult;
+    };
+};
+
+// Wraps a check function in a per-check timeout. When the timeout fires
+// first, the check resolves as an error result; the underlying promise is
+// allowed to settle in the background (its result is discarded).
+const withTimeout = async <T>(
+    label: string,
+    check: () => Promise<T>,
+    timeoutMs: number,
+): Promise<T> => {
+    let timer: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<never>((_, reject) => {
+        timer = setTimeout(() => {
+            reject(new Error(`${label} check timed out after ${timeoutMs}ms`));
+        }, timeoutMs);
+    });
+    try {
+        return await Promise.race([check(), timeout]);
+    } finally {
+        if (timer) {
+            clearTimeout(timer);
+        }
+    }
+};
+
+const checkPostgres = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        await withTimeout('postgres', async () => {
+            await __unsafePrisma.$queryRaw`SELECT 1`;
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+const checkRedis = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        const redis = getRedisClient();
+        await withTimeout('redis', async () => {
+            const pong = await redis.ping();
+            if (pong !== 'PONG') {
+                throw new Error(`unexpected ping response: ${pong}`);
+            }
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+const checkZoekt = async (): Promise<CheckResult> => {
+    const start = Date.now();
+    try {
+        const client = await loadZoektClient();
+        await withTimeout('zoekt', async () => {
+            await new Promise<void>((resolve, reject) => {
+                // An empty List with a 1s wall-time cap is the smallest request
+                // that exercises the gRPC channel end-to-end. It returns an
+                // empty result, not an error, even when no repos are indexed.
+                client.List(
+                    { opts: { max_wall_time: { seconds: 1, nanos: 0 } } },
+                    (err) => {
+                        if (err) {
+                            reject(err);
+                        } else {
+                            resolve();
+                        }
+                    },
+                );
+            });
+        }, READINESS_TIMEOUT_MS);
+        return { status: 'ok', latencyMs: Date.now() - start };
+    } catch (err) {
+        return {
+            status: 'error',
+            latencyMs: Date.now() - start,
+            error: err instanceof Error ? err.message : String(err),
+        };
+    }
+};
+
+// eslint-disable-next-line authz/require-auth-wrapper -- public readiness probe, no user data returned
+export const GET = apiHandler(async () => {
+    const [postgres, redis, zoekt] = await Promise.all([
+        checkPostgres(),
+        checkRedis(),
+        checkZoekt(),
+    ]);
+
+    const checks = { postgres, redis, zoekt };
+    const healthy = postgres.status === 'ok' && redis.status === 'ok' && zoekt.status === 'ok';
+
+    if (!healthy) {
+        logger.warn('readiness check failed', { checks });
+    }
+
+    const body: ReadinessResponse = {
+        status: healthy ? 'ok' : 'degraded',
+        checks,
+    };
+    return Response.json(body, { status: healthy ? 200 : 503 });
+}, { track: false });

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -26,14 +26,19 @@ type ReadinessResponse = {
     };
 };
 
-// Wraps a check function in a per-check timeout. When the timeout fires
-// first, the check resolves as an error result; the underlying promise is
-// allowed to settle in the background (its result is discarded).
+// Runs `check()` and rejects if it has not settled after `timeoutMs`. When the
+// timeout fires, the underlying check promise may still resolve or reject
+// later; the no-op `.catch` below attaches to that promise so a late
+// rejection does not surface as an unhandled-promise-rejection in the Node
+// process while the readiness request has already moved on.
 const withTimeout = async <T>(
     label: string,
     check: () => Promise<T>,
     timeoutMs: number,
 ): Promise<T> => {
+    const checkPromise = check();
+    checkPromise.catch(() => { /* swallowed: see comment above */ });
+
     let timer: ReturnType<typeof setTimeout> | undefined;
     const timeout = new Promise<never>((_, reject) => {
         timer = setTimeout(() => {
@@ -41,7 +46,7 @@ const withTimeout = async <T>(
         }, timeoutMs);
     });
     try {
-        return await Promise.race([check(), timeout]);
+        return await Promise.race([checkPromise, timeout]);
     } finally {
         if (timer) {
             clearTimeout(timer);
@@ -88,8 +93,10 @@ const checkRedis = async (): Promise<CheckResult> => {
 const checkZoekt = async (): Promise<CheckResult> => {
     const start = Date.now();
     try {
-        const client = await loadZoektClient();
         await withTimeout('zoekt', async () => {
+            // Build the client inside the timeout so a first-call init stall
+            // (e.g., vendored proto load) is also bounded.
+            const client = await loadZoektClient();
             await new Promise<void>((resolve, reject) => {
                 // An empty List with a 1s wall-time cap is the smallest request
                 // that exercises the gRPC channel end-to-end. It returns an

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -126,8 +126,16 @@ const checkZoekt = async (strict: boolean): Promise<CheckResult> => {
                 // `SearchOptions` field and does not apply to `List`
                 // (`ListOptions` only carries `field`).
                 client.List({}, (err, result) => {
+                    // `zoektSearch` rejects when the callback fires with
+                    // no error but no response either (see
+                    // `features/search/zoektSearcher.ts`). Do the same
+                    // here: a missing result would otherwise throw on
+                    // `response.repos` and surface as a generic `error`
+                    // instead of the intended `empty` strict-mode status.
                     if (err) {
                         reject(err);
+                    } else if (!result) {
+                        reject(new Error('zoekt List RPC returned no response'));
                     } else {
                         resolve(result);
                     }

--- a/packages/web/src/app/api/(server)/health/ready/route.ts
+++ b/packages/web/src/app/api/(server)/health/ready/route.ts
@@ -98,19 +98,20 @@ const checkZoekt = async (): Promise<CheckResult> => {
             // (e.g., vendored proto load) is also bounded.
             const client = await loadZoektClient();
             await new Promise<void>((resolve, reject) => {
-                // An empty List with a 1s wall-time cap is the smallest request
-                // that exercises the gRPC channel end-to-end. It returns an
-                // empty result, not an error, even when no repos are indexed.
-                client.List(
-                    { opts: { max_wall_time: { seconds: 1, nanos: 0 } } },
-                    (err) => {
-                        if (err) {
-                            reject(err);
-                        } else {
-                            resolve();
-                        }
-                    },
-                );
+                // Empty `List` is the smallest request that exercises the gRPC
+                // channel end-to-end. It returns an empty result, not an error,
+                // even when no repos are indexed. The 2s client-side
+                // `READINESS_TIMEOUT_MS` is the only timeout that actually
+                // bounds the call: `max_wall_time` is a `SearchOptions` field
+                // and does not apply to `List` (`ListOptions` only carries
+                // `field`).
+                client.List({}, (err) => {
+                    if (err) {
+                        reject(err);
+                    } else {
+                        resolve();
+                    }
+                });
             });
         }, READINESS_TIMEOUT_MS);
         return { status: 'ok', latencyMs: Date.now() - start };

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -41,14 +41,22 @@ const buildClient = async (): Promise<ZoektClient> => {
     });
 
     const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
-        zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+        zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown, options?: Record<string, unknown>) => ZoektClient } } };
     };
 
     const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
     const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+    // Match the channel options used by `zoektSearcher` so a healthy Zoekt
+    // instance with a large repo catalog does not fail the probe just
+    // because the default 4MB gRPC receive cap is smaller than the
+    // response.
     return new proto.zoekt.webserver.v1.WebserverService(
         grpcAddress,
         grpc.credentials.createInsecure(),
+        {
+            'grpc.max_receive_message_length': 500 * 1024 * 1024, // 500MB
+            'grpc.max_send_message_length': 500 * 1024 * 1024,    // 500MB
+        },
     );
 };
 

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -10,41 +10,49 @@ export type ZoektClient = {
     List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
 };
 
-let zoektClientPromise: Promise<ZoektClient> | undefined;
+let cachedClient: ZoektClient | undefined;
 
-export const loadZoektClient = (): Promise<ZoektClient> => {
-    if (!zoektClientPromise) {
-        zoektClientPromise = (async () => {
-            const [grpc, protoLoader, nodePath, shared] = await Promise.all([
-                import('@grpc/grpc-js'),
-                import('@grpc/proto-loader'),
-                import('node:path'),
-                import('@sourcebot/shared'),
-            ]);
+const buildClient = async (): Promise<ZoektClient> => {
+    const [grpc, protoLoader, nodePath, shared] = await Promise.all([
+        import('@grpc/grpc-js'),
+        import('@grpc/proto-loader'),
+        import('node:path'),
+        import('@sourcebot/shared'),
+    ]);
 
-            const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
-            const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
+    const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
+    const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
 
-            const packageDefinition = protoLoader.loadSync(protoPath, {
-                keepCase: true,
-                longs: Number,
-                enums: String,
-                defaults: true,
-                oneofs: true,
-                includeDirs: [protoBasePath],
-            });
+    const packageDefinition = protoLoader.loadSync(protoPath, {
+        keepCase: true,
+        longs: Number,
+        enums: String,
+        defaults: true,
+        oneofs: true,
+        includeDirs: [protoBasePath],
+    });
 
-            const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
-                zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
-            };
+    const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+        zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+    };
 
-            const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
-            const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
-            return new proto.zoekt.webserver.v1.WebserverService(
-                grpcAddress,
-                grpc.credentials.createInsecure(),
-            );
-        })();
-    }
-    return zoektClientPromise;
+    const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
+    const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+    return new proto.zoekt.webserver.v1.WebserverService(
+        grpcAddress,
+        grpc.credentials.createInsecure(),
+    );
 };
+
+// Returns a connected client, building it on first use. Only successful
+// builds are cached: a transient init failure does not poison subsequent
+// readiness probes, so the next call can retry.
+export const loadZoektClient = async (): Promise<ZoektClient> => {
+    if (cachedClient) {
+        return cachedClient;
+    }
+    const client = await buildClient();
+    cachedClient = client;
+    return client;
+};
+

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -1,0 +1,50 @@
+// Thin wrapper around the vendored Zoekt webserver gRPC client. Kept in
+// a separate module so the readiness route can mock it in tests without
+// pulling the gRPC + @opentelemetry CJS chain at test-load time.
+
+export type ZoektListRequest = {
+    opts?: { max_wall_time?: { seconds: number; nanos: number } };
+};
+
+export type ZoektClient = {
+    List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
+};
+
+let zoektClientPromise: Promise<ZoektClient> | undefined;
+
+export const loadZoektClient = (): Promise<ZoektClient> => {
+    if (!zoektClientPromise) {
+        zoektClientPromise = (async () => {
+            const [grpc, protoLoader, nodePath, shared] = await Promise.all([
+                import('@grpc/grpc-js'),
+                import('@grpc/proto-loader'),
+                import('node:path'),
+                import('@sourcebot/shared'),
+            ]);
+
+            const protoBasePath = nodePath.join(process.cwd(), '../../vendor/zoekt/grpc/protos');
+            const protoPath = nodePath.join(protoBasePath, 'zoekt/webserver/v1/webserver.proto');
+
+            const packageDefinition = protoLoader.loadSync(protoPath, {
+                keepCase: true,
+                longs: Number,
+                enums: String,
+                defaults: true,
+                oneofs: true,
+                includeDirs: [protoBasePath],
+            });
+
+            const proto = grpc.loadPackageDefinition(packageDefinition) as unknown as {
+                zoekt: { webserver: { v1: { WebserverService: new (address: string, credentials: unknown) => ZoektClient } } };
+            };
+
+            const zoektUrl = new URL(shared.env.ZOEKT_WEBSERVER_URL);
+            const grpcAddress = `${zoektUrl.hostname}:${zoektUrl.port}`;
+            return new proto.zoekt.webserver.v1.WebserverService(
+                grpcAddress,
+                grpc.credentials.createInsecure(),
+            );
+        })();
+    }
+    return zoektClientPromise;
+};

--- a/packages/web/src/lib/zoektClient.ts
+++ b/packages/web/src/lib/zoektClient.ts
@@ -6,8 +6,16 @@ export type ZoektListRequest = {
     opts?: { max_wall_time?: { seconds: number; nanos: number } };
 };
 
+// Loose summary of the `List` response. The full gRPC type is much wider
+// (see `proto/zoekt/webserver/v1/ListResponse.ts`); we only need the bits
+// the readiness probe inspects, so callers can mock it with a small object.
+export type ZoektListResponse = {
+    repos?: unknown[];
+    repos_map?: Record<number, unknown>;
+};
+
 export type ZoektClient = {
-    List: (request: ZoektListRequest, callback: (err: Error | null) => void) => void;
+    List: (request: ZoektListRequest, callback: (err: Error | null, result: ZoektListResponse) => void) => void;
 };
 
 let cachedClient: ZoektClient | undefined;


### PR DESCRIPTION
## Summary

Adds `?strict=true` to `GET /api/health/ready` for empty-shard detection. The default behavior of the readiness probe is unchanged: a Zoekt `List` RPC that returns an empty result still counts as a successful probe, because the question a readiness probe answers is "can this instance talk to its dependencies?". With `?strict=true`, an empty Zoekt shard set is treated as `503 / status: "degraded"` and `zoekt.status: "empty"`, distinguishing "Zoekt is up but the instance has not finished indexing" from "Zoekt is unreachable".

Fixes #1511.

## Motivation

A self-hosted operator wiring Sourcebot into a Kubernetes `readinessProbe` (or a load-balancer health check) typically wants two distinct signals:

- **Soft ready** — the process is up and the dependencies are reachable. The default mode.
- **Strictly ready** — the process is up, the dependencies are reachable, and the instance can actually serve a search that returns results. A node that has not finished indexing anything is *not* strictly ready, even if all three RPCs succeed.

Today there is no way to ask the probe the second question. A node can pass liveness, pass readiness, and still be useless to a search request. The default behavior is the right one for "can we talk to our dependencies?" but operators who want "is this instance useful?" need a way to ask it.

## Changes

- **`packages/web/src/app/api/(server)/health/ready/route.ts`** — adds the `strict` query param (parsed by a Zod schema; rejects anything other than the literal strings `"true"` / `"false"` as 400), threads it into `checkZoekt`, and adds a third check status `"empty"` for the strict-empty case. The `checkZoekt` function now actually captures and inspects the `List` response (it previously only consumed the callback's error argument). The gRPC callback signature in `zoektClient.ts` is corrected accordingly: it always was `(err, result) => void`, not `(err) => void`.
- **`packages/web/src/lib/zoektClient.ts`** — adds a loose `ZoektListResponse` summary type alongside the existing `ZoektClient` so the route and its test can refer to the same shape without pulling in the full gRPC response type. Fixes the `List` callback signature.
- **`packages/web/src/app/api/(server)/health/ready/route.test.ts`** — seven new test cases: strict with one indexed repo → 200; strict with empty `repos` → 503 / `empty`; strict with empty `repos_map` (the `RepoListFieldReposMap` field) → 503 / `empty`; strict with non-empty `repos_map` → 200; non-strict with empty `repos` → 200 (backward-compat); absent `strict` parameter treated as `false`; invalid `strict` value → 400. Existing tests updated to pass a minimal `NextRequest` stand-in (the route now needs `nextUrl.searchParams`).
- **`docs/docs/api-reference/health.mdx`** — new "Strict mode" subsection explaining the operator motivation, the new response fields, and the `error` vs `empty` distinction. The K8s `readinessProbe` example gets a comment pointing at the strict path for deployments that should not receive traffic until the shard set is non-empty.
- **`CHANGELOG.md`** — Added entry under `[Unreleased]` linking to #1511.

## Design decisions

- **Query param, not separate endpoint.** A separate `/api/health/ready/strict` would duplicate the route, the auth policy, the PostHog tracking opt-out, and the per-check response shape. The query param keeps it additive.
- **Default unchanged.** Operators who do not pass `?strict=true` see exactly the same response as before. A backwards-incompatible behavior change for a recently-merged endpoint is a poor first move.
- **Third status `"empty"` instead of overloading `"error"`.** `"error"` means the check itself failed (Zoekt unreachable, timeout, etc.). `"empty"` means the check passed but the result is empty in strict mode. They are different operational signals and an operator looking at the response should be able to tell them apart without parsing the `error` string.
- **Check both `repos` and `repos_map`.** The Zoekt gRPC server populates different fields depending on `ListOptions.Field` (`RepoListFieldRepos` vs `RepoListFieldReposMap`). An empty response in either shape is "strictly empty" and the check covers both.
- **`z.string().refine(...)` instead of `z.coerce.boolean()`.** The latter is just `Boolean(value)` under the hood, which would treat the string `"false"` as truthy. Accept only the two literal strings we mean to support, refuse anything else as 400.
- **New `ZoektListResponse` summary type.** The full gRPC response type is much wider than we need; exporting a narrow summary keeps the test mock small and avoids coupling the route's error handling to the full proto type.

## Verification

- `yarn workspace @sourcebot/web test --run "health/ready"` — 15/15 tests pass
- `yarn workspace @sourcebot/web lint` — 0 errors (4 pre-existing warnings in unrelated files)
- `tsc --noEmit -p packages/web/tsconfig.json` — 0 errors in the new files

## Backward compatibility

Fully backwards compatible. The default response shape gains a single new field (`strict`); all other fields and all status codes are unchanged when `strict` is absent or `false`.

## Stack

This PR is stacked on #1507 (the readiness probe itself). The first commit in the diff (`f5193aea`) is the `max_wall_time` follow-up from the PR #1507 review, not new work for this PR. Once #1507 merges, this branch will be rebased onto `main` and that commit will fall away; the remaining four commits are the actual `?strict=true` work.

## Out of scope (tracked in #1511 as future work)

- Caching the readiness result for ~1s to absorb thundering-herd probes from multiple orchestrators.
- Per-check Prometheus metrics for the strict case.

## Risks

- The Zoekt `List` response shape differs between proto versions. The check handles both `repos` and `repos_map`; an empty result in either is treated as strict-empty. The existing `zoektClient` returns the full gRPC `__Output` shape, so no information is lost.
- Operators using `?strict=true` in a dev environment with no indexed repos will see the probe fail with a clear `error: "no repositories indexed (strict mode)"` rather than a generic "degraded". The docs call this out.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, unauthenticated operational endpoints with backward-compatible defaults; main caveat is probe load on Postgres and misconfigured strict readiness blocking traffic until indexing completes.
> 
> **Overview**
> Adds **`GET /api/health/ready`**, a public readiness probe that checks Postgres (`SELECT 1`), Redis (`PING`), and Zoekt (empty `List` gRPC) in parallel with a 2s per-check timeout. It returns **200** with per-check latency when all pass, or **503** with `status: "degraded"` and generic client-safe errors (details logged server-side). **`GET /api/health`** stays the lightweight liveness probe.
> 
> Optional **`?strict=true`** treats an empty Zoekt shard set as not ready: **`zoekt.status: "empty"`** and **503**, separate from **`error`** when Zoekt is unreachable. Default / `strict=false` behavior is unchanged (empty index still counts as reachable). Invalid `strict` values return **400**.
> 
> Introduces **`packages/web/src/lib/zoektClient.ts`** (mockable gRPC client + `ZoektListResponse`) and extensive Vitest coverage. Docs add **`docs/api-reference/health.mdx`** (K8s/Docker examples, strict mode); **`CHANGELOG.md`** and **`docs.json`** are updated.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44e43bfe0584416c644d1c5eb1df9a48a70b7ea1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added health endpoints: liveness (`GET /api/health`) and readiness (`GET /api/health/ready`) that probe Postgres, Redis, and Zoekt.
  * Readiness returns detailed per-service check results (including latency/errors) and supports `?strict=true` to mark health degraded when Zoekt has no indexed repositories.
* **Documentation**
  * Added API reference docs for health endpoints and updated API navigation.
  * Updated changelog for the new readiness endpoint and strict-mode behavior.
* **Bug Fixes**
  * Improved readiness validation and error handling to avoid leaking internal details.
* **Tests**
  * Expanded automated coverage for success/degraded/strict scenarios and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->