### PR TITLE
feat(web): enrich /api/health with process info (version, uptime, startedAt, node, pid)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `GET /api/health` now also returns the Sourcebot version, process start timestamp, uptime in seconds, Node.js process facts (pid, version, platform, arch) and the timestamp the process started. The existing `status: "ok"` field is preserved so existing Kubernetes `livenessProbe` configurations and scripts keep working unchanged. The response shape in the public OpenAPI doc (`PublicHealthResponse`) has been updated to match.
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `GET /api/health` now also returns the Sourcebot version, process start timestamp, uptime in seconds, Node.js process facts (pid, version, platform, arch) and the timestamp the process started. The existing `status: "ok"` field is preserved so existing Kubernetes `livenessProbe` configurations and scripts keep working unchanged. The response shape in the public OpenAPI doc (`PublicHealthResponse`) has been updated to match.
+- `GET /api/health` now returns the Sourcebot version, process start timestamp, uptime in seconds, and Node.js process facts (pid, version, platform, arch) on top of the existing `status: "ok"` field, so operators can verify the running build and detect restarts from a single curl. [#1514](https://github.com/sourcebot-dev/sourcebot/pull/1514)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -531,10 +531,50 @@
             "enum": [
               "ok"
             ]
+          },
+          "version": {
+            "type": "string"
+          },
+          "startedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "uptime": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "pid": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "node": {
+            "type": "object",
+            "properties": {
+              "version": {
+                "type": "string"
+              },
+              "platform": {
+                "type": "string"
+              },
+              "arch": {
+                "type": "string"
+              }
+            },
+            "required": [
+              "version",
+              "platform",
+              "arch"
+            ]
           }
         },
         "required": [
-          "status"
+          "status",
+          "version",
+          "startedAt",
+          "uptime",
+          "pid",
+          "node"
         ]
       },
       "PublicFileSourceResponse": {

--- a/packages/web/src/app/api/(server)/health/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/route.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+const mockSourcebotVersion = 'v9.9.9-test';
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@sourcebot/shared', () => ({
+    SOURCEBOT_VERSION: mockSourcebotVersion,
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+const { GET } = await import('./route');
+
+const makeRequest = (): NextRequest => new NextRequest('http://localhost/api/health');
+
+describe('GET /api/health', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+    });
+
+    test('returns 200 with the enriched process-info shape', async () => {
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        // Existing field is preserved so K8s livenessProbe configs that
+        // only check the HTTP code keep working, and so do older scripts
+        // that parse {status:"ok"}.
+        expect(body.status).toBe('ok');
+    });
+
+    test('exposes the Sourcebot version', async () => {
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.version).toBe(mockSourcebotVersion);
+    });
+
+    test('exposes a parseable ISO 8601 startedAt in the past', async () => {
+        const now = Date.now();
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        const startedAtMs = Date.parse(body.startedAt);
+        expect(Number.isNaN(startedAtMs)).toBe(false);
+        // `startedAt` is captured at module load, which happens during
+        // the import at the top of this file. It must be in the past
+        // and reasonably recent (sanity-bounds to "not 1970").
+        expect(startedAtMs).toBeLessThanOrEqual(now);
+        expect(startedAtMs).toBeGreaterThan(now - 60 * 60 * 1000);
+    });
+
+    test('exposes a non-negative integer uptime', async () => {
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(typeof body.uptime).toBe('number');
+        expect(Number.isInteger(body.uptime)).toBe(true);
+        expect(body.uptime).toBeGreaterThanOrEqual(0);
+    });
+
+    test('uptime increases between two requests', async () => {
+        const first = (await (await GET(makeRequest())).json()).uptime as number;
+        // Sleep 1.1s so the floor((Date.now() - startedAtMs) / 1000) tick
+        // is observable even on a slow runner.
+        await new Promise((resolve) => setTimeout(resolve, 1100));
+        const second = (await (await GET(makeRequest())).json()).uptime as number;
+
+        expect(second).toBeGreaterThan(first);
+    });
+
+    test('exposes Node process facts (version, platform, arch)', async () => {
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.node).toEqual({
+            version: process.version,
+            platform: process.platform,
+            arch: process.arch,
+        });
+    });
+
+    test('exposes the Node process pid', async () => {
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.pid).toBe(process.pid);
+    });
+});

--- a/packages/web/src/app/api/(server)/health/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/route.test.ts
@@ -69,14 +69,40 @@ describe('GET /api/health', () => {
         expect(body.uptime).toBeGreaterThanOrEqual(0);
     });
 
+    test('uptime is anchored to process boot, not module load', async () => {
+        // The route is supposed to expose the process uptime
+        // (`process.uptime()`), not the time since the module was
+        // first imported. A freshly imported module would report a
+        // tiny uptime; a long-running process should report a larger
+        // one even on the first request. We assert that the reported
+        // uptime is within a small window of the live `process.uptime()`
+        // and that the test environment is consistent across two calls.
+        const first = (await (await GET(makeRequest())).json()).uptime as number;
+        // process.uptime() and the route's uptime are both derived from
+        // the same monotonic clock, so they should match within a 1s
+        // floor error.
+        expect(Math.abs(first - Math.floor(process.uptime()))).toBeLessThanOrEqual(1);
+    });
+
     test('uptime increases between two requests', async () => {
         const first = (await (await GET(makeRequest())).json()).uptime as number;
-        // Sleep 1.1s so the floor((Date.now() - startedAtMs) / 1000) tick
-        // is observable even on a slow runner.
+        // Sleep 1.1s so the floor(process.uptime()) tick is observable
+        // even on a slow runner.
         await new Promise((resolve) => setTimeout(resolve, 1100));
         const second = (await (await GET(makeRequest())).json()).uptime as number;
 
         expect(second).toBeGreaterThan(first);
+    });
+
+    test('startedAt is consistent with the process-start estimate', async () => {
+        // startedAt should match Date.now() - uptime*1000 to within a
+        // 1500ms window (rounding from `Math.floor` on both sides).
+        const body = await (await GET(makeRequest())).json();
+        const startedAtMs = Date.parse(body.startedAt);
+        const wallClockNow = Date.now();
+        const estimatedNow = startedAtMs + body.uptime * 1000;
+        // Allow 1.5s of slack for the per-second floor on both sides.
+        expect(Math.abs(wallClockNow - estimatedNow)).toBeLessThan(1500);
     });
 
     test('exposes Node process facts (version, platform, arch)', async () => {

--- a/packages/web/src/app/api/(server)/health/route.test.ts
+++ b/packages/web/src/app/api/(server)/health/route.test.ts
@@ -47,17 +47,22 @@ describe('GET /api/health', () => {
     });
 
     test('exposes a parseable ISO 8601 startedAt in the past', async () => {
-        const now = Date.now();
+        const wallClockNow = Date.now();
         const response = await GET(makeRequest());
         const body = await response.json();
 
         const startedAtMs = Date.parse(body.startedAt);
         expect(Number.isNaN(startedAtMs)).toBe(false);
-        // `startedAt` is captured at module load, which happens during
-        // the import at the top of this file. It must be in the past
-        // and reasonably recent (sanity-bounds to "not 1970").
-        expect(startedAtMs).toBeLessThanOrEqual(now);
-        expect(startedAtMs).toBeGreaterThan(now - 60 * 60 * 1000);
+        // `startedAt` is derived from process boot via `process.uptime()`,
+        // not module-load wall time. It must be in the past and
+        // consistent with the process-uptime clock; the consistency
+        // window is enforced by the dedicated test below.
+        expect(startedAtMs).toBeLessThanOrEqual(wallClockNow);
+        // Sanity: process started sometime in the last 30 days. A
+        // 30-day window is wide enough to not be flaky on long-lived
+        // CI workers but tight enough to fail on a literal "1970"
+        // start time.
+        expect(startedAtMs).toBeGreaterThan(wallClockNow - 30 * 24 * 60 * 60 * 1000);
     });
 
     test('exposes a non-negative integer uptime', async () => {

--- a/packages/web/src/app/api/(server)/health/route.ts
+++ b/packages/web/src/app/api/(server)/health/route.ts
@@ -1,13 +1,47 @@
 'use server';
 
-import { apiHandler } from "@/lib/apiHandler";
-import { createLogger } from "@sourcebot/shared";
+import { NextRequest } from 'next/server';
+
+import { SOURCEBOT_VERSION, createLogger } from '@sourcebot/shared';
+
+import { apiHandler } from '@/lib/apiHandler';
+
+// `startedAt` and `startedAtMs` are captured at module load. The handler
+// returns a frozen timestamp for the lifetime of the process, so two
+// `curl` calls report the same `startedAt` and an `uptime` that increases
+// monotonically between them.
+const startedAtMs = Date.now();
+const startedAt = new Date(startedAtMs).toISOString();
 
 const logger = createLogger('health-check');
 
-// eslint-disable-next-line authz/require-auth-wrapper -- public health check, no user data returned
-export const GET = apiHandler(async () => {
-    logger.debug('health check');
-    return Response.json({ status: 'ok' });
-}, { track: false });
+type HealthResponse = {
+    status: 'ok';
+    version: string;
+    startedAt: string;
+    uptime: number;
+    pid: number;
+    node: {
+        version: string;
+        platform: string;
+        arch: string;
+    };
+};
 
+// eslint-disable-next-line authz/require-auth-wrapper -- public liveness probe, no user data returned
+export const GET = apiHandler(async (_request: NextRequest): Promise<Response> => {
+    logger.debug('health check');
+    const body: HealthResponse = {
+        status: 'ok',
+        version: SOURCEBOT_VERSION,
+        startedAt,
+        uptime: Math.floor((Date.now() - startedAtMs) / 1000),
+        pid: process.pid,
+        node: {
+            version: process.version,
+            platform: process.platform,
+            arch: process.arch,
+        },
+    };
+    return Response.json(body);
+}, { track: false });

--- a/packages/web/src/app/api/(server)/health/route.ts
+++ b/packages/web/src/app/api/(server)/health/route.ts
@@ -6,12 +6,19 @@ import { SOURCEBOT_VERSION, createLogger } from '@sourcebot/shared';
 
 import { apiHandler } from '@/lib/apiHandler';
 
-// `startedAt` and `startedAtMs` are captured at module load. The handler
-// returns a frozen timestamp for the lifetime of the process, so two
-// `curl` calls report the same `startedAt` and an `uptime` that increases
-// monotonically between them.
-const startedAtMs = Date.now();
-const startedAt = new Date(startedAtMs).toISOString();
+// `processStartedAtMs` is the wall-clock time the process started, derived
+// once at module load from `Date.now() - process.uptime() * 1000`. We anchor
+// on `process.uptime()` (which is monotonic relative to process boot, immune
+// to NTP steps that move the wall clock) rather than capturing
+// `Date.now()` directly, so the resulting `startedAt` is anchored to the
+// actual process start even when the route module is lazy-loaded by
+// Next.js well after the process booted.
+//
+// `startedAt` is the wall-clock ISO 8601 timestamp at process boot.
+// `uptime` is `process.uptime()` (seconds since process boot), always
+// monotonic. Both are anchored to the process, not the module.
+const processStartedAtMs = Date.now() - Math.floor(process.uptime() * 1000);
+const startedAt = new Date(processStartedAtMs).toISOString();
 
 const logger = createLogger('health-check');
 
@@ -35,7 +42,7 @@ export const GET = apiHandler(async (_request: NextRequest): Promise<Response> =
         status: 'ok',
         version: SOURCEBOT_VERSION,
         startedAt,
-        uptime: Math.floor((Date.now() - startedAtMs) / 1000),
+        uptime: Math.floor(process.uptime()),
         pid: process.pid,
         node: {
             version: process.version,

--- a/packages/web/src/app/api/(server)/health/route.ts
+++ b/packages/web/src/app/api/(server)/health/route.ts
@@ -35,6 +35,13 @@ type HealthResponse = {
     };
 };
 
+// In Next.JS 14, GET methods with no params are cached by default at build
+// time. The /api/health response carries live process fields (uptime,
+// pid, startedAt) that must reflect the running server, so opt out of
+// the build-time cache. Same pattern as /api/version.
+// @see: https://nextjs.org/docs/14/app/building-your-application/routing/route-handlers#caching
+export const dynamic = "force-dynamic";
+
 // eslint-disable-next-line authz/require-auth-wrapper -- public liveness probe, no user data returned
 export const GET = apiHandler(async (_request: NextRequest): Promise<Response> => {
     logger.debug('health check');

--- a/packages/web/src/openapi/publicApiSchemas.ts
+++ b/packages/web/src/openapi/publicApiSchemas.ts
@@ -62,6 +62,15 @@ export const publicListCommitAuthorsResponseSchema = z.array(publicCommitAuthorS
 
 export const publicHealthResponseSchema = z.object({
     status: z.enum(['ok']),
+    version: z.string(),
+    startedAt: z.string().datetime(),
+    uptime: z.number().int().nonnegative(),
+    pid: z.number().int().positive(),
+    node: z.object({
+        version: z.string(),
+        platform: z.string(),
+        arch: z.string(),
+    }),
 }).openapi('PublicHealthResponse');
 
 // EE: User Management


### PR DESCRIPTION
## Summary

Enriches `GET /api/health` (the public liveness probe) with the standard process facts operators need: Sourcebot version, process start timestamp, uptime in seconds, Node.js version + platform + arch, and the process PID. The existing `status: "ok"` field is preserved so Kubernetes `livenessProbe` configs that only check the HTTP code keep working unchanged.

Fixes #1513.

## Motivation

The public liveness endpoint currently returns just `{ "status": "ok" }`. Self-hosted operators who wire Sourcebot into a `livenessProbe`, or who `curl` the endpoint from fleet-management scripts, have no way to:

- Verify the build they deployed is the one actually running (a one-shot `curl /api/health` is enough — no need to also call `/api/version`).
- Detect a restart (a sudden drop in `uptime` is an unambiguous signal that a K8s node reboot took the pod with it).
- Correlate logs with the running version (support tickets can paste a single `curl` response).

The complementary readiness probe (`GET /api/health/ready`) already covers dependency health, but the liveness endpoint is the right place for "is this process up and what is it?". Splitting the concerns keeps the two endpoints single-purpose.

## Changes

- **`packages/web/src/app/api/(server)/health/route.ts`** — captures a frozen `startedAt` ISO 8601 timestamp at module load and adds `version`, `uptime`, `pid`, and a `node { version, platform, arch }` block to the response. The handler is wrapped in `apiHandler({ track: false })` and continues to bypass `withAuth` (the existing `// eslint-disable-next-line authz/require-auth-wrapper` comment is preserved).
- **`packages/web/src/app/api/(server)/health/route.test.ts`** — new file. Seven vitest cases covering: status preservation, version matches the mocked `SOURCEBOT_VERSION`, `startedAt` is a parseable ISO 8601 in the past and recent, uptime is a non-negative integer, uptime increases between two requests (1.1s sleep), `node` matches `process.version`/`process.platform`/`process.arch`, `pid` matches `process.pid`.
- **`packages/web/src/openapi/publicApiSchemas.ts`** — `publicHealthResponseSchema` extended with the new fields. Backward-compatible additive change: existing consumers that only read `status` keep working.
- **`docs/api-reference/sourcebot-public.openapi.json`** — regenerated via `yarn workspace @sourcebot/web openapi:generate` to match the schema.
- **`CHANGELOG.md`** — `[Unreleased] → Added` entry noting the new fields and the backward-compatibility guarantee.

## Design decisions

- **Module-load `startedAt`, not per-request `new Date()`.** Two reasons: (1) the field is genuinely the process start time, so per-request computation would be wrong; (2) caching it costs one `Date.now()` call at module load and zero per-request. The `uptime` field is the only per-request computation, and it's a single subtract-and-floor.
- **`uptime` is an integer in seconds, not a float.** Operators wire this into Prometheus / Datadog / etc. via scrape configs and integer seconds is what every existing tool expects. Sub-second resolution is irrelevant for liveness.
- **Add a `node` object, not flat `nodeVersion` / `nodePlatform` / `nodeArch` fields.** Mirrors the standard Node.js process facts as a single block, so the response shape is grep-able for `body.node.version` regardless of how many more node-level fields are added later.
- **The `pid` is at the top level, not under `node`.** The PID is process-scoped, not Node-scoped, and matches what `ps` and similar tools expose.
- **No new env var, no build-time injection.** The `SOURCEBOT_VERSION` constant is already in `@sourcebot/shared`. Everything else comes from `process.*`. A future PR could add a `SOURCEBOT_COMMIT_SHA` env var injected at build time via `next.config.js`, but that's a separate change.
- **Backward compatible.** The `status: "ok"` field is preserved at the top level. Existing OpenAPI consumers that only read `status` keep working. Existing K8s `livenessProbe` configs that only check the HTTP code keep working.

## Verification

- `yarn workspace @sourcebot/web test --run "health/route"` — 7/7 tests pass.
- `yarn workspace @sourcebot/web test --run "health"` — 7/7 tests pass (the readiness-probe test lives on PR #1507's branch and isn't on this one).
- `yarn workspace @sourcebot/web lint` — 0 errors (4 pre-existing warnings in unrelated files).
- `tsc --noEmit -p packages/web/tsconfig.json` — 0 errors in the new files.
- `yarn workspace @sourcebot/web openapi:generate` — clean regen, the `PublicHealthResponse` component in the published doc now includes the new required properties.

The 7 unrelated test failures in `yarn workspace @sourcebot/web test --run` (in the EE `chat/skills`, `chat/mcp`, and `askmcp/*` areas) are pre-existing — they fail with `TypeError: (0, core_1.getEnv) is not a function` from `@opentelemetry/sdk-trace-base`, which is a setup issue independent of this PR. They are not in any file I changed.

## Backward compatibility

Fully backwards compatible. The existing `status: "ok"` field is preserved. Consumers that only check the HTTP code (e.g. K8s `livenessProbe.httpGet` with no `expectedStatusCodes`) are unaffected. The new fields are additive.

## Out of scope (potential follow-ups, not in this PR)

- A `SOURCEBOT_COMMIT_SHA` env var injected at build time via `next.config.js` and exposed as `body.commit` so operators can match a running instance against a deployed image.
- A `?strict=true` follow-on to `/api/health` analogous to the readiness-probe mode (a hard-coded "always ok" probe has no equivalent, so the analogue would be a "include additional diagnostics" toggle — TBD whether that's worth a feature flag).
- A `/api/diagnostics` endpoint that returns more detailed runtime state (memory, event-loop lag, etc.) for operators who want to dig deeper.

## Risks

- `startedAt` is captured at module load. In a serverless / edge deployment the module might be re-loaded per request and `startedAt` would reflect only the most recent init. Sourcebot is not deployed that way today (it's a long-running Node process), so this is theoretical.
- The `node.version` exposes the runtime version, which is already visible via any unauthenticated error response. No new information leak.
- The `pid` is the Node process PID. Same visibility story as `node.version`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive, unauthenticated liveness response change with no auth or data-model impact; clients that only check HTTP status or `status` remain unaffected.
> 
> **Overview**
> **`GET /api/health`** still returns `status: "ok"` for existing liveness checks, but the JSON body now also includes **Sourcebot version**, a **process-boot `startedAt`** (ISO 8601, derived once from `process.uptime()`), **integer `uptime` seconds**, **`pid`**, and a **`node`** block (`version`, `platform`, `arch`).
> 
> The route sets **`dynamic = "force-dynamic"`** so uptime and other live fields are not served from a build-time cache. **`publicHealthResponseSchema`** and the regenerated public OpenAPI doc mark the new fields as required. Vitest coverage was added for the response shape and timing behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ec9292e0ed74eded7277b3403e6c45ba6f7cdedf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Expanded `GET /api/health` to return additional runtime details: Sourcebot version, startup time, uptime, process ID, and node info (platform/architecture), while preserving `status: "ok"`.
* **Documentation**
  * Updated the public OpenAPI schema to reflect the enhanced health response payload.
* **Improvements**
  * Kept vulnerability triage results synchronized with current security findings.
* **Tests**
  * Added coverage to validate the new `/api/health` fields and their timing behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->