### PR TITLE
fix vulnerability triage for reusable callers

### DIFF
--- a/.github/scripts/classify-vulnerability-issues.jq
+++ b/.github/scripts/classify-vulnerability-issues.jq
@@ -12,6 +12,8 @@ def finding_id($prefix):
     | .findingId as $findingId
     | if .findingId == "" then
         . + { action: "ignore" }
+      elif ($skipCodeql and (.findingId | startswith("codeql:"))) then
+        . + { action: "ignore" }
       elif ($currentIds | index($findingId)) != null then
         . + { action: "keep" }
       else

--- a/.github/scripts/linear-graphql-request.sh
+++ b/.github/scripts/linear-graphql-request.sh
@@ -7,9 +7,19 @@ if [[ -z "${LINEAR_API_KEY:-}" ]]; then
 fi
 
 payload=$(cat)
-attempts="${LINEAR_GRAPHQL_ATTEMPTS:-4}"
+configured_attempts="${LINEAR_GRAPHQL_ATTEMPTS:-4}"
 retry_delay="${LINEAR_GRAPHQL_RETRY_DELAY_SECONDS:-2}"
 endpoint="${LINEAR_GRAPHQL_ENDPOINT:-https://api.linear.app/graphql}"
+is_mutation=$(jq -r '(.query // "") | test("^\\s*mutation(?:\\s|\\(|\\{)")' <<<"$payload")
+
+# Retrying a mutation after an ambiguous transport failure can replay a write
+# that Linear already committed. Queries are safe to retry; mutations fail
+# visibly after one attempt and rely on the workflow's reconciliation pass.
+if [[ "$is_mutation" == "true" ]]; then
+  attempts=1
+else
+  attempts="$configured_attempts"
+fi
 
 for ((attempt = 1; attempt <= attempts; attempt++)); do
   response_file=$(mktemp)

--- a/.github/scripts/linear-graphql-request.sh
+++ b/.github/scripts/linear-graphql-request.sh
@@ -1,0 +1,60 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [[ -z "${LINEAR_API_KEY:-}" ]]; then
+  echo "LINEAR_API_KEY is required" >&2
+  exit 1
+fi
+
+payload=$(cat)
+attempts="${LINEAR_GRAPHQL_ATTEMPTS:-4}"
+retry_delay="${LINEAR_GRAPHQL_RETRY_DELAY_SECONDS:-2}"
+endpoint="${LINEAR_GRAPHQL_ENDPOINT:-https://api.linear.app/graphql}"
+
+for ((attempt = 1; attempt <= attempts; attempt++)); do
+  response_file=$(mktemp)
+  http_code=""
+
+  if http_code=$(curl \
+    --silent \
+    --show-error \
+    --output "$response_file" \
+    --write-out '%{http_code}' \
+    --connect-timeout 10 \
+    --max-time 45 \
+    -X POST "$endpoint" \
+    -H "Content-Type: application/json" \
+    -H "Authorization: $LINEAR_API_KEY" \
+    -d "$payload"); then
+    response=$(<"$response_file")
+    rm -f "$response_file"
+
+    if [[ "$http_code" =~ ^2[0-9][0-9]$ ]] && jq -e . >/dev/null 2>&1 <<<"$response"; then
+      printf '%s' "$response"
+      exit 0
+    fi
+
+    if [[ "$http_code" =~ ^(408|429|5[0-9][0-9])$ ]]; then
+      echo "Linear GraphQL returned transient HTTP $http_code (attempt $attempt/$attempts)." >&2
+    elif jq -e . >/dev/null 2>&1 <<<"$response"; then
+      # Preserve structured non-retryable errors so the workflow can report
+      # the GraphQL response rather than replacing it with a transport error.
+      printf '%s' "$response"
+      exit 0
+    else
+      echo "Linear GraphQL returned a non-JSON response (HTTP $http_code, attempt $attempt/$attempts)." >&2
+    fi
+  else
+    curl_status=$?
+    response=$(<"$response_file")
+    rm -f "$response_file"
+    echo "Linear GraphQL request failed (curl $curl_status, HTTP ${http_code:-unknown}, attempt $attempt/$attempts)." >&2
+  fi
+
+  if ((attempt < attempts)); then
+    sleep "$retry_delay"
+  fi
+done
+
+echo "Linear GraphQL did not return a valid JSON response after $attempts attempts." >&2
+exit 1

--- a/.github/scripts/test-vulnerability-triage.sh
+++ b/.github/scripts/test-vulnerability-triage.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MATCH_FILTER="$SCRIPT_DIR/match-vulnerability-issue.jq"
 CLASSIFY_FILTER="$SCRIPT_DIR/classify-vulnerability-issues.jq"
+WORKFLOW_FILE="$SCRIPT_DIR/../workflows/vulnerability-triage.yml"
 PREFIX="[sourcebot-dev/example]"
 
 assert_json() {
@@ -19,6 +20,22 @@ assert_json() {
     exit 1
   fi
 }
+
+assert_workflow_contains() {
+  local description="$1"
+  local expected="$2"
+
+  if ! grep -Fq -- "$expected" "$WORKFLOW_FILE"; then
+    echo "FAIL: $description"
+    echo "Expected workflow to contain: $expected"
+    exit 1
+  fi
+}
+
+assert_workflow_contains "checks out assets from the called workflow repository" 'repository: ${{ job.workflow_repository }}'
+assert_workflow_contains "pins assets to the called workflow revision" 'ref: ${{ job.workflow_sha }}'
+assert_workflow_contains "uses the shared match filter" '-f .vulnerability-triage-workflow/.github/scripts/match-vulnerability-issue.jq'
+assert_workflow_contains "uses the shared classification filter" '-f .vulnerability-triage-workflow/.github/scripts/classify-vulnerability-issues.jq'
 
 match() {
   local finding_id="$1"

--- a/.github/scripts/test-vulnerability-triage.sh
+++ b/.github/scripts/test-vulnerability-triage.sh
@@ -87,6 +87,21 @@ if [[ "$(<"$FAKE_CURL_COUNT")" != "3" ]]; then
   exit 1
 fi
 
+printf '0\n' > "$FAKE_CURL_COUNT"
+if PATH="$FAKE_CURL_DIR:$PATH" \
+  FAKE_CURL_COUNT="$FAKE_CURL_COUNT" \
+  LINEAR_API_KEY="test-key" \
+  LINEAR_GRAPHQL_ATTEMPTS=3 \
+  LINEAR_GRAPHQL_RETRY_DELAY_SECONDS=0 \
+  "$LINEAR_REQUEST" <<<'{"query":"mutation { issueCreate(input: {}) { success } }"}' >/dev/null 2>&1; then
+  echo "FAIL: ambiguous Linear mutations must not be retried"
+  exit 1
+fi
+if [[ "$(<"$FAKE_CURL_COUNT")" != "1" ]]; then
+  echo "FAIL: expected exactly one Linear mutation attempt"
+  exit 1
+fi
+
 match() {
   local finding_id="$1"
   jq -c --arg prefix "$PREFIX" --arg findingId "$finding_id" -f "$MATCH_FILTER"

--- a/.github/scripts/test-vulnerability-triage.sh
+++ b/.github/scripts/test-vulnerability-triage.sh
@@ -201,13 +201,17 @@ OPEN_ISSUES='[
   }
 ]'
 
-CLASSIFIED="$(jq -c --arg prefix "$PREFIX" --slurpfile findings <(printf '%s\n' "$FINDINGS") -f "$CLASSIFY_FILTER" <<<"$OPEN_ISSUES")"
+CLASSIFIED="$(jq -c --arg prefix "$PREFIX" --argjson skipCodeql false --slurpfile findings <(printf '%s\n' "$FINDINGS") -f "$CLASSIFY_FILTER" <<<"$OPEN_ISSUES")"
 assert_json "keeps every exact current finding" "$(jq -c '[.[] | select(.action == "keep") | .id]' <<<"$CLASSIFIED")" '["keep-cve","keep-codeql"]'
 assert_json "closes only resolved managed findings" "$(jq -c '[.[] | select(.action == "close") | .id]' <<<"$CLASSIFIED")" '["close-cve","close-prefix-collision"]'
 assert_json "ignores unrelated titles and repositories" "$(jq -c '[.[] | select(.action == "ignore") | .id]' <<<"$CLASSIFIED")" '["ignore-other-repo","ignore-unmanaged"]'
 
 EMPTY_FINDINGS='{"cves":[]}'
-CLASSIFIED_EMPTY="$(jq -c --arg prefix "$PREFIX" --slurpfile findings <(printf '%s\n' "$EMPTY_FINDINGS") -f "$CLASSIFY_FILTER" <<<"$OPEN_ISSUES")"
+CLASSIFIED_EMPTY="$(jq -c --arg prefix "$PREFIX" --argjson skipCodeql false --slurpfile findings <(printf '%s\n' "$EMPTY_FINDINGS") -f "$CLASSIFY_FILTER" <<<"$OPEN_ISSUES")"
 assert_json "closes all managed issues when a complete scan is clean" "$(jq -c '[.[] | select(.action == "close") | .id]' <<<"$CLASSIFIED_EMPTY")" '["keep-cve","keep-codeql","close-cve","close-prefix-collision"]'
+
+CLASSIFIED_WITH_CODEQL_SKIPPED="$(jq -c --arg prefix "$PREFIX" --argjson skipCodeql true --slurpfile findings <(printf '%s\n' "$EMPTY_FINDINGS") -f "$CLASSIFY_FILTER" <<<"$OPEN_ISSUES")"
+assert_json "preserves CodeQL issues when CodeQL is unavailable" "$(jq -c '[.[] | select(.action == "ignore") | .id]' <<<"$CLASSIFIED_WITH_CODEQL_SKIPPED")" '["keep-codeql","ignore-other-repo","ignore-unmanaged"]'
+assert_json "still closes resolved non-CodeQL issues when CodeQL is unavailable" "$(jq -c '[.[] | select(.action == "close") | .id]' <<<"$CLASSIFIED_WITH_CODEQL_SKIPPED")" '["keep-cve","close-cve","close-prefix-collision"]'
 
 echo "All vulnerability triage reconciliation tests passed."

--- a/.github/scripts/test-vulnerability-triage.sh
+++ b/.github/scripts/test-vulnerability-triage.sh
@@ -5,6 +5,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 MATCH_FILTER="$SCRIPT_DIR/match-vulnerability-issue.jq"
 CLASSIFY_FILTER="$SCRIPT_DIR/classify-vulnerability-issues.jq"
+LINEAR_REQUEST="$SCRIPT_DIR/linear-graphql-request.sh"
 WORKFLOW_FILE="$SCRIPT_DIR/../workflows/vulnerability-triage.yml"
 PREFIX="[sourcebot-dev/example]"
 
@@ -36,6 +37,55 @@ assert_workflow_contains "checks out assets from the called workflow repository"
 assert_workflow_contains "pins assets to the called workflow revision" 'ref: ${{ job.workflow_sha }}'
 assert_workflow_contains "uses the shared match filter" '-f .vulnerability-triage-workflow/.github/scripts/match-vulnerability-issue.jq'
 assert_workflow_contains "uses the shared classification filter" '-f .vulnerability-triage-workflow/.github/scripts/classify-vulnerability-issues.jq'
+assert_workflow_contains "uses the retrying Linear GraphQL client" '.vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh'
+
+FAKE_CURL_DIR=$(mktemp -d)
+FAKE_CURL_COUNT=$(mktemp)
+trap 'rm -rf "$FAKE_CURL_DIR"; rm -f "$FAKE_CURL_COUNT"' EXIT
+printf '0\n' > "$FAKE_CURL_COUNT"
+
+cat > "$FAKE_CURL_DIR/curl" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+
+output_file=""
+while (($# > 0)); do
+  case "$1" in
+    --output)
+      output_file="$2"
+      shift 2
+      ;;
+    *)
+      shift
+      ;;
+  esac
+done
+
+count=$(( $(<"$FAKE_CURL_COUNT") + 1 ))
+printf '%s\n' "$count" > "$FAKE_CURL_COUNT"
+if ((count < 3)); then
+  printf 'Bad Gateway' > "$output_file"
+  printf '502'
+else
+  printf '{"data":{"ok":true}}' > "$output_file"
+  printf '200'
+fi
+EOF
+chmod +x "$FAKE_CURL_DIR/curl"
+
+LINEAR_RESPONSE=$(
+  PATH="$FAKE_CURL_DIR:$PATH" \
+    FAKE_CURL_COUNT="$FAKE_CURL_COUNT" \
+    LINEAR_API_KEY="test-key" \
+    LINEAR_GRAPHQL_ATTEMPTS=3 \
+    LINEAR_GRAPHQL_RETRY_DELAY_SECONDS=0 \
+    "$LINEAR_REQUEST" <<<'{"query":"query { viewer { id } }"}'
+)
+assert_json "retries non-JSON Linear responses" "$LINEAR_RESPONSE" '{"data":{"ok":true}}'
+if [[ "$(<"$FAKE_CURL_COUNT")" != "3" ]]; then
+  echo "FAIL: expected Linear request helper to retry twice"
+  exit 1
+fi
 
 match() {
   local finding_id="$1"

--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -937,6 +937,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TEAM_UUID: ${{ steps.match.outputs.team_uuid }}
           DONE_STATE_ID: ${{ steps.match.outputs.done_state_id }}
+          SKIP_CODEQL: ${{ inputs.skip_codeql }}
         run: |
           set -euo pipefail
           # The job only reaches this step after every configured scanner
@@ -985,6 +986,7 @@ jobs:
 
           jq \
             --arg prefix "$PREFIX" \
+            --argjson skipCodeql "$SKIP_CODEQL" \
             --slurpfile findings findings.json \
             -f .vulnerability-triage-workflow/.github/scripts/classify-vulnerability-issues.jq \
             /tmp/open-issues.json > /tmp/classified-issues.json

--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -618,10 +618,8 @@ jobs:
             --arg teamId "$LINEAR_TEAM_ID" \
             --arg stateName "$LINEAR_STATE_NAME" \
             '{query: $query, variables: {teamId: $teamId, stateName: $stateName}}')
-          METADATA_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            -d "$METADATA_PAYLOAD")
+          METADATA_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+            .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$METADATA_PAYLOAD")
 
           if [ "$(echo "$METADATA_RESPONSE" | jq 'has("errors") or (.data.team == null)')" = "true" ]; then
             echo "::error::Could not load Linear team metadata: $(echo "$METADATA_RESPONSE" | jq -c '.errors // .')"
@@ -645,10 +643,8 @@ jobs:
           REPO_LABEL_QUERY='query($teamId: String!, $name: String!) { team(id: $teamId) { labels(filter: { name: { eq: $name } }) { nodes { id } } } }'
           REPO_LABEL_PAYLOAD=$(jq -n --arg query "$REPO_LABEL_QUERY" --arg teamId "$TEAM_UUID" --arg name "$REPOSITORY" \
             '{query: $query, variables: {teamId: $teamId, name: $name}}')
-          REPO_LABEL_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-            -H "Content-Type: application/json" \
-            -H "Authorization: $LINEAR_API_KEY" \
-            -d "$REPO_LABEL_PAYLOAD")
+          REPO_LABEL_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+            .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$REPO_LABEL_PAYLOAD")
           REPO_LABEL_ID=$(echo "$REPO_LABEL_RESPONSE" | jq -r '.data.team.labels.nodes[0].id // empty')
 
           if [ -z "$REPO_LABEL_ID" ]; then
@@ -656,10 +652,8 @@ jobs:
             CREATE_LABEL_MUTATION='mutation($teamId: String!, $name: String!) { issueLabelCreate(input: { teamId: $teamId, name: $name }) { success issueLabel { id } } }'
             CREATE_LABEL_PAYLOAD=$(jq -n --arg query "$CREATE_LABEL_MUTATION" --arg teamId "$TEAM_UUID" --arg name "$REPOSITORY" \
               '{query: $query, variables: {teamId: $teamId, name: $name}}')
-            CREATE_LABEL_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$CREATE_LABEL_PAYLOAD")
+            CREATE_LABEL_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CREATE_LABEL_PAYLOAD")
             REPO_LABEL_ID=$(echo "$CREATE_LABEL_RESPONSE" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
             if [ -z "$REPO_LABEL_ID" ]; then
               echo "::warning::Could not create '$REPOSITORY' label: $(echo "$CREATE_LABEL_RESPONSE" | jq -c '.errors // .')"
@@ -693,10 +687,8 @@ jobs:
               --arg teamId "$TEAM_UUID" \
               '{titlePrefix: $titlePrefix, teamId: $teamId}')
             PAYLOAD=$(jq -n --arg query "$SEARCH_QUERY" --argjson vars "$VARS" '{query: $query, variables: $vars}')
-            RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$PAYLOAD")
+            RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$PAYLOAD")
 
             # A failed search is not "no match": treating it as one could create
             # a duplicate issue, so stop before any Linear mutations.
@@ -854,10 +846,13 @@ jobs:
               fi
               REOPEN_PAYLOAD=$(jq -n --arg query "$REOPEN_MUTATION" --argjson vars "$REOPEN_VARIABLES" '{query: $query, variables: $vars}')
 
-              REOPEN_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-                -H "Content-Type: application/json" \
-                -H "Authorization: $LINEAR_API_KEY" \
-                -d "$REOPEN_PAYLOAD")
+              if ! REOPEN_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+                .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$REOPEN_PAYLOAD"); then
+                echo "::error::Linear request failed while reopening $LINEAR_IDENTIFIER for $CVE_ID"
+                echo "- **FAILED** to reopen [$LINEAR_IDENTIFIER]($LINEAR_URL) for **$CVE_ID**" >> "$GITHUB_STEP_SUMMARY"
+                FAILED_COUNT=$((FAILED_COUNT + 1))
+                continue
+              fi
 
               REOPEN_URL=$(echo "$REOPEN_RESPONSE" | jq -r '.data.issueUpdate.issue.url // empty')
               REOPEN_IDENTIFIER=$(echo "$REOPEN_RESPONSE" | jq -r '.data.issueUpdate.issue.identifier // empty')
@@ -905,10 +900,13 @@ jobs:
 
             PAYLOAD=$(jq -n --arg query "$MUTATION" --argjson vars "$VARIABLES" '{query: $query, variables: $vars}')
 
-            RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$PAYLOAD")
+            if ! RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$PAYLOAD"); then
+              echo "::error::Linear request failed while creating an issue for $CVE_ID"
+              echo "- **FAILED** to create issue for **$CVE_ID** — $TITLE" >> "$GITHUB_STEP_SUMMARY"
+              FAILED_COUNT=$((FAILED_COUNT + 1))
+              continue
+            fi
 
             ISSUE_URL=$(echo "$RESPONSE" | jq -r '.data.issueCreate.issue.url // empty')
             ISSUE_IDENTIFIER=$(echo "$RESPONSE" | jq -r '.data.issueCreate.issue.identifier // empty')
@@ -966,10 +964,8 @@ jobs:
                 '{prefix: $prefix, teamId: $teamId, after: $after}')
             fi
             PAYLOAD=$(jq -n --arg query "$SEARCH_QUERY" --argjson vars "$VARS" '{query: $query, variables: $vars}')
-            RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$PAYLOAD")
+            RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$PAYLOAD")
 
             if [ "$(echo "$RESPONSE" | jq 'has("errors") or (.data.issues == null)')" = "true" ]; then
               echo "::error::Failed to fetch open Linear issues: $(echo "$RESPONSE" | jq -c '.errors // .')"
@@ -1014,10 +1010,8 @@ jobs:
 
             CLOSE_VARS=$(jq -n --arg issueId "$ISSUE_ID" --arg stateId "$DONE_STATE_ID" '{issueId: $issueId, stateId: $stateId}')
             CLOSE_PAYLOAD=$(jq -n --arg query "$CLOSE_MUTATION" --argjson vars "$CLOSE_VARS" '{query: $query, variables: $vars}')
-            CLOSE_RESPONSE=$(curl -s -X POST https://api.linear.app/graphql \
-              -H "Content-Type: application/json" \
-              -H "Authorization: $LINEAR_API_KEY" \
-              -d "$CLOSE_PAYLOAD")
+            CLOSE_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CLOSE_PAYLOAD")
 
             if [ "$(echo "$CLOSE_RESPONSE" | jq -r '.data.issueUpdate.success // false')" = "true" ]; then
               echo "Closed $ISSUE_IDENTIFIER — $FINDING_ID is no longer reported"

--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -940,7 +940,7 @@ jobs:
           REPOSITORY: ${{ github.repository }}
           TEAM_UUID: ${{ steps.match.outputs.team_uuid }}
           DONE_STATE_ID: ${{ steps.match.outputs.done_state_id }}
-          SKIP_CODEQL: ${{ inputs.skip_codeql }}
+          SKIP_CODEQL: ${{ inputs.skip_codeql || false }}
         run: |
           set -euo pipefail
           # The job only reaches this step after every configured scanner

--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -43,6 +43,11 @@ on:
         required: false
         type: boolean
         default: false
+      skip_codeql:
+        description: 'Skip CodeQL only when code scanning is unavailable for the caller repository.'
+        required: false
+        type: boolean
+        default: false
       linear_assignee_id:
         description: 'Linear user UUID to assign. Leave empty to use assign_to_api_key_owner behavior.'
         required: false
@@ -160,6 +165,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPENDABOT_PAT: ${{ secrets.DEPENDABOT_PAT || secrets.GITHUB_TOKEN }}
+          SKIP_CODEQL: ${{ inputs.skip_codeql || false }}
         run: |
           set -euo pipefail
           HAS_ALERTS=false
@@ -188,25 +194,33 @@ jobs:
             exit 1
           fi
 
-          # Check CodeQL alerts (uses GITHUB_TOKEN with security-events: read)
-          CODEQL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=1")
-          if [ "$CODEQL_STATUS" = "200" ]; then
-            CODEQL_COUNT=$(curl -s \
+          # Check CodeQL alerts (uses GITHUB_TOKEN with security-events: read).
+          # Private repositories without GitHub Code Security return HTTP 403,
+          # which is indistinguishable from a real authorization failure. Those
+          # callers must opt out explicitly rather than weakening fail-closed
+          # handling for every 403 response.
+          if [ "$SKIP_CODEQL" = "true" ]; then
+            echo "CodeQL is unavailable for this repository by caller configuration. Skipping."
+          else
+            CODEQL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GH_TOKEN" \
-              "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=1" | jq 'length')
-            if [ "$CODEQL_COUNT" -gt 0 ]; then
-              echo "Found open CodeQL alerts"
-              HAS_ALERTS=true
+              "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=1")
+            if [ "$CODEQL_STATUS" = "200" ]; then
+              CODEQL_COUNT=$(curl -s \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=1" | jq 'length')
+              if [ "$CODEQL_COUNT" -gt 0 ]; then
+                echo "Found open CodeQL alerts"
+                HAS_ALERTS=true
+              fi
+            elif [ "$CODEQL_STATUS" = "404" ]; then
+              echo "CodeQL is not enabled for this repository. Skipping."
+            else
+              echo "::error::Could not fetch CodeQL alerts (HTTP $CODEQL_STATUS). Reconciliation requires a complete alert snapshot."
+              exit 1
             fi
-          elif [ "$CODEQL_STATUS" = "404" ]; then
-            echo "CodeQL is not enabled for this repository. Skipping."
-          else
-            echo "::error::Could not fetch CodeQL alerts (HTTP $CODEQL_STATUS). Reconciliation requires a complete alert snapshot."
-            exit 1
           fi
 
           echo "has_alerts=$HAS_ALERTS" >> "$GITHUB_OUTPUT"
@@ -215,6 +229,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           DEPENDABOT_PAT: ${{ secrets.DEPENDABOT_PAT || secrets.GITHUB_TOKEN }}
+          SKIP_CODEQL: ${{ inputs.skip_codeql || false }}
         run: |
           echo "## Dependabot & CodeQL Alert Check" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -241,29 +256,34 @@ jobs:
           echo "" >> "$GITHUB_STEP_SUMMARY"
 
           # CodeQL status
-          CODEQL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
-            -H "Accept: application/vnd.github+json" \
-            -H "Authorization: Bearer $GH_TOKEN" \
-            "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100")
-          if [ "$CODEQL_STATUS" = "404" ]; then
+          if [ "$SKIP_CODEQL" = "true" ]; then
             echo "### CodeQL" >> "$GITHUB_STEP_SUMMARY"
-            echo "Not enabled for this repository." >> "$GITHUB_STEP_SUMMARY"
-          elif [ "$CODEQL_STATUS" = "200" ]; then
-            CODEQL_RESPONSE=$(curl -s \
+            echo "Unavailable (explicit caller configuration)." >> "$GITHUB_STEP_SUMMARY"
+          else
+            CODEQL_STATUS=$(curl -s -o /dev/null -w "%{http_code}" \
               -H "Accept: application/vnd.github+json" \
               -H "Authorization: Bearer $GH_TOKEN" \
               "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100")
-            CODEQL_COUNT=$(echo "$CODEQL_RESPONSE" | jq 'length')
-            echo "### CodeQL — $CODEQL_COUNT open alert(s)" >> "$GITHUB_STEP_SUMMARY"
-            if [ "$CODEQL_COUNT" -gt 0 ]; then
-              echo "" >> "$GITHUB_STEP_SUMMARY"
-              echo "| Rule ID | Severity | Tool | File | Lines | Link |" >> "$GITHUB_STEP_SUMMARY"
-              echo "|---------|----------|------|------|-------|------|" >> "$GITHUB_STEP_SUMMARY"
-              echo "$CODEQL_RESPONSE" | jq -r '.[] | "| \(.rule.id // "—") | \(.rule.security_severity_level // "—") | \(.tool.name // "—") | \(.most_recent_instance.location.path // "—") | \(.most_recent_instance.location.start_line // "—")-\(.most_recent_instance.location.end_line // "—") | [View](\(.html_url)) |"' >> "$GITHUB_STEP_SUMMARY"
+            if [ "$CODEQL_STATUS" = "404" ]; then
+              echo "### CodeQL" >> "$GITHUB_STEP_SUMMARY"
+              echo "Not enabled for this repository." >> "$GITHUB_STEP_SUMMARY"
+            elif [ "$CODEQL_STATUS" = "200" ]; then
+              CODEQL_RESPONSE=$(curl -s \
+                -H "Accept: application/vnd.github+json" \
+                -H "Authorization: Bearer $GH_TOKEN" \
+                "https://api.github.com/repos/${{ github.repository }}/code-scanning/alerts?state=open&per_page=100")
+              CODEQL_COUNT=$(echo "$CODEQL_RESPONSE" | jq 'length')
+              echo "### CodeQL — $CODEQL_COUNT open alert(s)" >> "$GITHUB_STEP_SUMMARY"
+              if [ "$CODEQL_COUNT" -gt 0 ]; then
+                echo "" >> "$GITHUB_STEP_SUMMARY"
+                echo "| Rule ID | Severity | Tool | File | Lines | Link |" >> "$GITHUB_STEP_SUMMARY"
+                echo "|---------|----------|------|------|-------|------|" >> "$GITHUB_STEP_SUMMARY"
+                echo "$CODEQL_RESPONSE" | jq -r '.[] | "| \(.rule.id // "—") | \(.rule.security_severity_level // "—") | \(.tool.name // "—") | \(.most_recent_instance.location.path // "—") | \(.most_recent_instance.location.start_line // "—")-\(.most_recent_instance.location.end_line // "—") | [View](\(.html_url)) |"' >> "$GITHUB_STEP_SUMMARY"
+              fi
+            else
+              echo "### CodeQL" >> "$GITHUB_STEP_SUMMARY"
+              echo "Failed to check (HTTP $CODEQL_STATUS)" >> "$GITHUB_STEP_SUMMARY"
             fi
-          else
-            echo "### CodeQL" >> "$GITHUB_STEP_SUMMARY"
-            echo "Failed to check (HTTP $CODEQL_STATUS)" >> "$GITHUB_STEP_SUMMARY"
           fi
 
           echo "" >> "$GITHUB_STEP_SUMMARY"
@@ -284,6 +304,15 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+
+      - name: Checkout reusable workflow assets
+        uses: actions/checkout@v4
+        with:
+          repository: ${{ job.workflow_repository }}
+          ref: ${{ job.workflow_sha }}
+          sparse-checkout: .github/scripts
+          path: .vulnerability-triage-workflow
+          persist-credentials: false
 
       - name: Download scan results
         if: needs.scan.outputs.has_vulnerabilities == 'true'
@@ -388,8 +417,15 @@ jobs:
       - name: Fetch CodeQL alerts
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SKIP_CODEQL: ${{ inputs.skip_codeql || false }}
         run: |
           set -euo pipefail
+          if [ "$SKIP_CODEQL" = "true" ]; then
+            echo "CodeQL is unavailable for this repository by caller configuration. Writing empty results."
+            echo "[]" > codeql-alerts.json
+            exit 0
+          fi
+
           ALL_ALERTS="[]"
           PAGE=1
 
@@ -672,7 +708,7 @@ jobs:
             SELECTED=$(echo "$RESPONSE" | jq \
               --arg prefix "[$REPOSITORY]" \
               --arg findingId "$CVE_ID" \
-              -f .github/scripts/match-vulnerability-issue.jq)
+              -f .vulnerability-triage-workflow/.github/scripts/match-vulnerability-issue.jq)
 
             MERGED=$(echo "$finding" "$SELECTED" | jq -s '.[0] + .[1]')
             jq --argjson item "$MERGED" '. + [$item]' /tmp/matched.json > /tmp/matched.tmp && mv /tmp/matched.tmp /tmp/matched.json
@@ -954,7 +990,7 @@ jobs:
           jq \
             --arg prefix "$PREFIX" \
             --slurpfile findings findings.json \
-            -f .github/scripts/classify-vulnerability-issues.jq \
+            -f .vulnerability-triage-workflow/.github/scripts/classify-vulnerability-issues.jq \
             /tmp/open-issues.json > /tmp/classified-issues.json
 
           CURRENT_COUNT=$(jq '.cves | length' findings.json)

--- a/.github/workflows/vulnerability-triage.yml
+++ b/.github/workflows/vulnerability-triage.yml
@@ -652,11 +652,14 @@ jobs:
             CREATE_LABEL_MUTATION='mutation($teamId: String!, $name: String!) { issueLabelCreate(input: { teamId: $teamId, name: $name }) { success issueLabel { id } } }'
             CREATE_LABEL_PAYLOAD=$(jq -n --arg query "$CREATE_LABEL_MUTATION" --arg teamId "$TEAM_UUID" --arg name "$REPOSITORY" \
               '{query: $query, variables: {teamId: $teamId, name: $name}}')
-            CREATE_LABEL_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
-              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CREATE_LABEL_PAYLOAD")
-            REPO_LABEL_ID=$(echo "$CREATE_LABEL_RESPONSE" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
-            if [ -z "$REPO_LABEL_ID" ]; then
-              echo "::warning::Could not create '$REPOSITORY' label: $(echo "$CREATE_LABEL_RESPONSE" | jq -c '.errors // .')"
+            if ! CREATE_LABEL_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CREATE_LABEL_PAYLOAD"); then
+              echo "::warning::Linear request failed while creating '$REPOSITORY' label. Continuing without it; the next run will query for an ambiguously committed label."
+            else
+              REPO_LABEL_ID=$(echo "$CREATE_LABEL_RESPONSE" | jq -r '.data.issueLabelCreate.issueLabel.id // empty')
+              if [ -z "$REPO_LABEL_ID" ]; then
+                echo "::warning::Could not create '$REPOSITORY' label: $(echo "$CREATE_LABEL_RESPONSE" | jq -c '.errors // .')"
+              fi
             fi
           fi
 
@@ -1012,8 +1015,13 @@ jobs:
 
             CLOSE_VARS=$(jq -n --arg issueId "$ISSUE_ID" --arg stateId "$DONE_STATE_ID" '{issueId: $issueId, stateId: $stateId}')
             CLOSE_PAYLOAD=$(jq -n --arg query "$CLOSE_MUTATION" --argjson vars "$CLOSE_VARS" '{query: $query, variables: $vars}')
-            CLOSE_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
-              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CLOSE_PAYLOAD")
+            if ! CLOSE_RESPONSE=$(LINEAR_API_KEY="$LINEAR_API_KEY" \
+              .vulnerability-triage-workflow/.github/scripts/linear-graphql-request.sh <<<"$CLOSE_PAYLOAD"); then
+              echo "::error::Linear request failed while closing $ISSUE_IDENTIFIER"
+              echo "- **FAILED** to close [$ISSUE_IDENTIFIER]($ISSUE_URL)" >> "$GITHUB_STEP_SUMMARY"
+              FAILED_COUNT=$((FAILED_COUNT + 1))
+              continue
+            fi
 
             if [ "$(echo "$CLOSE_RESPONSE" | jq -r '.data.issueUpdate.success // false')" = "true" ]; then
               echo "Closed $ISSUE_IDENTIFIER — $FINDING_ID is no longer reported"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
+
+### Fixed
 - Fixed vulnerability triage for reusable-workflow callers and repositories without CodeQL. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
 
 ## [5.1.4] - 2026-07-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 
 ### Fixed
-- Fixed vulnerability triage for reusable-workflow callers, repositories without CodeQL, and transient non-JSON Linear API responses. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
+- Fixed vulnerability triage for reusable-workflow callers, repositories without CodeQL, and transient non-JSON Linear query responses. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
 
 ## [5.1.4] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
+- Fixed vulnerability triage for reusable-workflow callers and repositories without CodeQL. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
 
 ## [5.1.4] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 
 ### Fixed
-- Fixed vulnerability triage for reusable-workflow callers and repositories without CodeQL. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
+- Fixed vulnerability triage for reusable-workflow callers, repositories without CodeQL, and transient non-JSON Linear API responses. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
 
 ## [5.1.4] - 2026-07-24
 


### PR DESCRIPTION
## Summary

- check out reusable-workflow jq helpers from the exact called-workflow commit
- add an explicit `skip_codeql` contract for private callers where GitHub Code Security is unavailable
- keep unexpected scanner authorization/API failures fail-closed
- extend reconciliation tests to cover the reusable-workflow asset contract

## Root cause

Reusable workflow jobs check out the caller repository, so the reconciliation filters added in #1505 were absent in `zoekt` and `sourcebot-helm-chart`. Private repositories without GitHub Code Security return HTTP 403 for CodeQL alert lookup, which the fail-closed check correctly rejected but could not distinguish from an authorization error.

## Validation

- `.github/scripts/test-vulnerability-triage.sh`
- `git diff --check`
- Ruby YAML parsing
- actionlint run; only expected schema-lag diagnostics for GitHub's current `vulnerability-alerts` permission and `job.workflow_*` contexts

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect automated Linear issue create/close/reconcile behavior and CI security triage; mistakes could leave stale issues open or close the wrong ones, though mutations are not retried and tests cover the new paths.
> 
> **Overview**
> Fixes vulnerability triage when the workflow runs as a **reusable** job: the triage job now checks out `.github/scripts` from the **called workflow** repo at `job.workflow_sha`, so jq helpers and the Linear client match the workflow revision instead of missing on caller repos like `zoekt`.
> 
> Adds a **`skip_codeql`** `workflow_call` input for repos where code scanning is unavailable (e.g. private repos without GitHub Code Security). When set, CodeQL alert checks and fetches are skipped, empty CodeQL findings are written, and reconciliation **ignores** existing `codeql:` Linear issues instead of auto-closing them; other findings still reconcile. Non-404/200 CodeQL API failures remain **fail-closed** when CodeQL is not skipped.
> 
> Introduces **`linear-graphql-request.sh`** for all Linear GraphQL calls: queries retry on transient HTTP/non-JSON responses; **mutations run once** to avoid duplicate writes. Create/reopen/close steps handle transport failures without treating them as success.
> 
> **`test-vulnerability-triage.sh`** now asserts workflow wiring, Linear retry behavior, and CodeQL-skipped classification.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 10176592ee0253ba66ad77c53b48824f544efef3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a `skip_codeql` option to explicitly bypass CodeQL-dependent alert checks when unavailable.
* **Bug Fixes**
  * Improved vulnerability triage for reusable-workflow callers and CodeQL-unavailable repositories by avoiding CodeQL probing/reconciliation failures.
  * Hardened Linear GraphQL handling for transient non-JSON responses, with retries for queries and no retries for mutations.
  * Updated classification to ignore CodeQL findings when CodeQL is skipped.
* **Tests**
  * Added validation for workflow wiring, Linear retry/non-retry behavior, and the CodeQL-unavailable classification path.
* **Documentation**
  * Updated the changelog to reflect the triage improvements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->