### PR TITLE
feat(web): add GET /api/connections admin endpoint for monitoring connection sync state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1516](https://github.com/sourcebot-dev/sourcebot/issues/1516)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1516](https://github.com/sourcebot-dev/sourcebot/issues/1516)
+- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1517](https://github.com/sourcebot-dev/sourcebot/pull/1517)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -537,6 +537,123 @@
           "status"
         ]
       },
+      "PublicConnectionLatestJob": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "FAILED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "createdAt",
+          "completedAt",
+          "errorMessage"
+        ]
+      },
+      "PublicConnectionSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "connectionType": {
+            "type": "string",
+            "enum": [
+              "github",
+              "gitlab",
+              "gitea",
+              "gerrit",
+              "bitbucket-server",
+              "bitbucket-cloud",
+              "generic-git-host",
+              "azuredevops"
+            ]
+          },
+          "isDeclarative": {
+            "type": "boolean"
+          },
+          "syncedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "repoCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "inFlightJobCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "latestJob": {
+            "$ref": "#/components/schemas/PublicConnectionLatestJob"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "connectionType",
+          "isDeclarative",
+          "syncedAt",
+          "createdAt",
+          "updatedAt",
+          "repoCount",
+          "inFlightJobCount",
+          "latestJob"
+        ]
+      },
+      "PublicListConnectionsResponse": {
+        "type": "object",
+        "properties": {
+          "connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicConnectionSummary"
+            }
+          }
+        },
+        "required": [
+          "connections"
+        ]
+      },
       "PublicFileSourceResponse": {
         "type": "object",
         "properties": {
@@ -1472,6 +1589,98 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicHealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connections": {
+      "get": {
+        "operationId": "listConnections",
+        "tags": [
+          "System"
+        ],
+        "summary": "List code-host connections",
+        "description": "Returns a paginated list of code-host connections in the org, with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count). Auth-gated. The connection `config` is never returned (it carries tokens).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "default": 50
+            },
+            "required": false,
+            "name": "perPage",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated connection list.",
+            "headers": {
+              "X-Total-Count": {
+                "description": "Total number of connections matching the query across all pages.",
+                "schema": {
+                  "type": "integer",
+                  "example": 5
+                }
+              },
+              "Link": {
+                "description": "Pagination links formatted per RFC 8288. Includes `rel=\"next\"`, `rel=\"prev\"`, `rel=\"first\"`, and `rel=\"last\"` when applicable.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicListConnectionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected connection listing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
                 }
               }
             }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,8 @@
                         "icon": "server",
                         "pages": [
                             "GET /api/version",
-                            "GET /api/health"
+                            "GET /api/health",
+                            "GET /api/connections"
                         ]
                     }
                 ]

--- a/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
+++ b/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+
+import { ConnectionSyncJobStatus } from '@sourcebot/db';
+import { withAuth } from '@/middleware/withAuth';
+import { sew } from '@/middleware/sew';
+
+export interface ListConnectionsParams {
+    page: number;
+    perPage: number;
+}
+
+export const listConnections = async (
+    { page, perPage }: ListConnectionsParams,
+) => sew(() =>
+    withAuth(async ({ prisma, org }) => {
+        const skip = (page - 1) * perPage;
+
+        const [connections, totalCount] = await Promise.all([
+            prisma.connection.findMany({
+                where: { orgId: org.id },
+                orderBy: { name: 'asc' },
+                skip,
+                take: perPage,
+                include: {
+                    _count: {
+                        select: {
+                            repos: true,
+                            syncJobs: true,
+                        },
+                    },
+                    syncJobs: {
+                        orderBy: { createdAt: 'desc' },
+                        take: 1,
+                    },
+                },
+            }),
+            prisma.connection.count({ where: { orgId: org.id } }),
+        ]);
+
+        // Count in-flight jobs (PENDING + IN_PROGRESS) per connection in
+        // a single grouped query rather than N+1 small counts.
+        const inFlightByConnection = await prisma.connectionSyncJob.groupBy({
+            by: ['connectionId'],
+            where: {
+                connectionId: { in: connections.map((c) => c.id) },
+                status: {
+                    in: [ConnectionSyncJobStatus.PENDING, ConnectionSyncJobStatus.IN_PROGRESS],
+                },
+            },
+            _count: { _all: true },
+        });
+        const inFlightMap = new Map(
+            inFlightByConnection.map((row) => [row.connectionId, row._count._all]),
+        );
+
+        return {
+            data: connections.map((connection) => {
+                const latestJob = connection.syncJobs[0] ?? null;
+                return {
+                    id: connection.id,
+                    name: connection.name,
+                    connectionType: connection.connectionType,
+                    isDeclarative: connection.isDeclarative,
+                    syncedAt: connection.syncedAt,
+                    createdAt: connection.createdAt,
+                    updatedAt: connection.updatedAt,
+                    repoCount: connection._count.repos,
+                    inFlightJobCount: inFlightMap.get(connection.id) ?? 0,
+                    latestJob: latestJob
+                        ? {
+                            id: latestJob.id,
+                            status: latestJob.status,
+                            createdAt: latestJob.createdAt,
+                            completedAt: latestJob.completedAt,
+                            errorMessage: latestJob.errorMessage,
+                        }
+                        : null,
+                };
+            }),
+            totalCount,
+        };
+    }),
+);

--- a/packages/web/src/app/api/(server)/connections/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/route.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+type AuthContext = {
+    user: { id: string };
+    org: { id: number };
+    prisma: unknown;
+};
+
+// Lightweight stand-ins for the Prisma enums. Re-exported as the same
+// names so the route's `z.nativeEnum(...)` validation accepts the test
+// values. The real enums live in `@sourcebot/db`; we mock that package
+// to keep the OpenTelemetry CJS chain out of the test load path.
+const ConnectionSyncJobStatus = {
+    PENDING: 'PENDING',
+    IN_PROGRESS: 'IN_PROGRESS',
+    COMPLETED: 'COMPLETED',
+    FAILED: 'FAILED',
+} as const;
+
+const CodeHostType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+const ConnectionType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as AuthContext | undefined,
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@sourcebot/db', () => ({
+    ConnectionSyncJobStatus,
+    ConnectionType,
+    CodeHostType,
+}));
+
+// `sew.ts` imports `@sentry/nextjs`, which transitively pulls in
+// `@opentelemetry/sdk-trace-base`. The pre-existing version mismatch
+// (sdk-trace-base 1.28.0 expects `core.getEnv`, but core 2.8.0 dropped
+// it) makes the import fail at test-load time. Stub Sentry and the OTel
+// modules so the route file can be loaded without exercising the SDK.
+vi.mock('@sentry/nextjs', () => ({
+    captureException: vi.fn(),
+    captureRequestError: vi.fn(),
+}));
+
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+    getEnv: () => ({}),
+    TraceIdRatioBasedSampler: vi.fn(),
+    ParentBasedSampler: vi.fn(),
+    AlwaysOnSampler: vi.fn(),
+    AlwaysOffSampler: vi.fn(),
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+vi.mock('@/middleware/withAuth', () => ({
+    withAuth: vi.fn(async (callback: (ctx: AuthContext) => unknown) => {
+        if (!mocks.authContext) {
+            // Mirror the production behavior: if no auth, return a
+            // service error. The route is responsible for translating
+            // that into a 401.
+            return { statusCode: 401, errorCode: 'NOT_AUTHENTICATED', message: 'Not authenticated' };
+        }
+        return callback(mocks.authContext);
+    }),
+}));
+
+const makeRequest = (search: Record<string, string> = {}): NextRequest => {
+    const params = new URLSearchParams(search);
+    const url = `http://localhost/api/connections?${params.toString()}`;
+    return new NextRequest(url);
+};
+
+const { GET } = await import('./route');
+
+// The Prisma mock is shaped to drive the four query paths the route
+// uses: listConnections.findMany, listConnections.count,
+// connectionSyncJob.groupBy, plus the relations via `include`.
+const buildPrismaMock = (opts: {
+    connections: Array<{
+        id: number;
+        name: string;
+        connectionType: typeof ConnectionType[keyof typeof ConnectionType];
+        isDeclarative: boolean;
+        syncedAt: Date | null;
+        createdAt: Date;
+        updatedAt: Date;
+        repoCount: number;
+        latestJob: {
+            id: string;
+            status: typeof ConnectionSyncJobStatus[keyof typeof ConnectionSyncJobStatus];
+            createdAt: Date;
+            completedAt: Date | null;
+            errorMessage: string | null;
+        } | null;
+    }>;
+    inFlight: Map<number, number>;
+    totalCount: number;
+}) => {
+    const findMany = vi.fn(async () => opts.connections.map((c) => ({
+        id: c.id,
+        name: c.name,
+        connectionType: c.connectionType,
+        isDeclarative: c.isDeclarative,
+        syncedAt: c.syncedAt,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+        _count: { repos: c.repoCount, syncJobs: c.latestJob ? 1 : 0 },
+        syncJobs: c.latestJob ? [c.latestJob] : [],
+    })));
+    const count = vi.fn(async () => opts.totalCount);
+    const groupBy = vi.fn(async () => Array.from(opts.inFlight.entries()).map(([connectionId, count]) => ({
+        connectionId,
+        _count: { _all: count },
+    })));
+    return { connection: { findMany, count }, connectionSyncJob: { groupBy } } as unknown;
+};
+
+const setAuth = (connections: Parameters<typeof buildPrismaMock>[0]['connections'], opts?: { inFlight?: Map<number, number>; totalCount?: number }) => {
+    const allConnections = opts?.inFlight ? new Map(opts.inFlight) : new Map<number, number>();
+    mocks.authContext = {
+        user: { id: 'user_1' },
+        org: { id: 1 },
+        prisma: buildPrismaMock({
+            connections,
+            inFlight: allConnections,
+            totalCount: opts?.totalCount ?? connections.length,
+        }),
+    };
+};
+
+describe('GET /api/connections', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.authContext = undefined;
+    });
+
+    test('returns 401 when no authenticated user', async () => {
+        // withAuth returns a service error; the route returns 401.
+        mocks.authContext = undefined;
+        const response = await GET(makeRequest());
+        expect(response.status).toBe(401);
+    });
+
+    test('returns the documented connection shape on a happy path', async () => {
+        const now = new Date('2026-07-25T14:00:00.000Z');
+        setAuth([
+            {
+                id: 1,
+                name: 'github-public',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: now,
+                createdAt: new Date('2026-06-12T08:21:00.000Z'),
+                updatedAt: now,
+                repoCount: 137,
+                latestJob: {
+                    id: 'job_1',
+                    status: ConnectionSyncJobStatus.COMPLETED,
+                    createdAt: new Date('2026-07-25T13:59:30.000Z'),
+                    completedAt: now,
+                    errorMessage: null,
+                },
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connections).toHaveLength(1);
+        expect(body.connections[0]).toEqual({
+            id: 1,
+            name: 'github-public',
+            connectionType: 'github',
+            isDeclarative: false,
+            syncedAt: now.toISOString(),
+            createdAt: new Date('2026-06-12T08:21:00.000Z').toISOString(),
+            updatedAt: now.toISOString(),
+            repoCount: 137,
+            inFlightJobCount: 0,
+            latestJob: {
+                id: 'job_1',
+                status: 'COMPLETED',
+                createdAt: new Date('2026-07-25T13:59:30.000Z').toISOString(),
+                completedAt: now.toISOString(),
+                errorMessage: null,
+            },
+        });
+    });
+
+    test('returns latestJob:null for a connection that has never been synced', async () => {
+        setAuth([
+            {
+                id: 2,
+                name: 'never-synced',
+                connectionType: ConnectionType.gitlab,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: null,
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connections[0].latestJob).toBeNull();
+        expect(body.connections[0].syncedAt).toBeNull();
+        expect(body.connections[0].repoCount).toBe(0);
+    });
+
+    test('exposes the in-flight job count per connection', async () => {
+        setAuth(
+            [
+                {
+                    id: 3,
+                    name: 'busy',
+                    connectionType: ConnectionType.github,
+                    isDeclarative: false,
+                    syncedAt: null,
+                    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                    repoCount: 5,
+                    latestJob: {
+                        id: 'job_3',
+                        status: ConnectionSyncJobStatus.IN_PROGRESS,
+                        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                        completedAt: null,
+                        errorMessage: null,
+                    },
+                },
+            ],
+            { inFlight: new Map([[3, 2]]) },
+        );
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.connections[0].inFlightJobCount).toBe(2);
+    });
+
+    test('exposes the latest job errorMessage verbatim', async () => {
+        setAuth([
+            {
+                id: 4,
+                name: 'broken',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: {
+                    id: 'job_4',
+                    status: ConnectionSyncJobStatus.FAILED,
+                    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                    completedAt: new Date('2026-07-01T00:00:30.000Z'),
+                    errorMessage: 'connection refused: host=github.example.com:443',
+                },
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.connections[0].latestJob.status).toBe('FAILED');
+        expect(body.connections[0].latestJob.errorMessage).toBe(
+            'connection refused: host=github.example.com:443',
+        );
+    });
+
+    test('does NOT include the connection config (which carries tokens)', async () => {
+        setAuth([
+            {
+                id: 5,
+                name: 'token-bearing',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: null,
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        // The config is the actual JSON the user stored (e.g. { token: { env: 'GH_TOKEN' } })
+        // for declarative connections. It must not be in the public response.
+        expect(body.connections[0].config).toBeUndefined();
+    });
+
+    test('returns 400 for perPage > 100', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ perPage: '1000' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 for perPage <= 0', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ perPage: '0' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 for non-integer page', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ page: 'abc' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('defaults page=1 and perPage=50 when no query params are provided', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest());
+        // Empty list still returns 200 (not 400); defaults are accepted.
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.connections).toEqual([]);
+    });
+
+    test('emits X-Total-Count and Link headers on the response', async () => {
+        setAuth([], { totalCount: 137 });
+
+        const response = await GET(makeRequest({ page: '1', perPage: '10' }));
+
+        expect(response.headers.get('X-Total-Count')).toBe('137');
+        const link = response.headers.get('Link');
+        expect(link).toBeTruthy();
+        expect(link).toContain('rel="first"');
+        expect(link).toContain('rel="last"');
+        expect(link).toContain('rel="next"');
+    });
+});

--- a/packages/web/src/app/api/(server)/connections/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/route.test.ts
@@ -105,7 +105,11 @@ const { GET } = await import('./route');
 
 // The Prisma mock is shaped to drive the four query paths the route
 // uses: listConnections.findMany, listConnections.count,
-// connectionSyncJob.groupBy, plus the relations via `include`.
+// connectionSyncJob.groupBy, plus the relations via `include`. The
+// mock includes a populated `config` field on every row so the
+// "config is not in the response" regression test can actually
+// detect a future change that accidentally spreads raw Prisma rows
+// into the response shape.
 const buildPrismaMock = (opts: {
     connections: Array<{
         id: number;
@@ -135,6 +139,12 @@ const buildPrismaMock = (opts: {
         syncedAt: c.syncedAt,
         createdAt: c.createdAt,
         updatedAt: c.updatedAt,
+        // The config is the actual JSON the user stored (e.g.
+        // { token: { env: 'GH_TOKEN' } }) for declarative connections.
+        // It must never appear in the public response. We include it
+        // here so the regression test below is meaningful: a future
+        // change that spreads raw Prisma rows will leak this field.
+        config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
         _count: { repos: c.repoCount, syncJobs: c.latestJob ? 1 : 0 },
         syncJobs: c.latestJob ? [c.latestJob] : [],
     })));

--- a/packages/web/src/app/api/(server)/connections/route.ts
+++ b/packages/web/src/app/api/(server)/connections/route.ts
@@ -49,7 +49,9 @@ export const GET = apiHandler(async (request: NextRequest) => {
         perPage,
         totalCount,
     });
-    if (linkHeader) headers.set('Link', linkHeader);
+    if (linkHeader) {
+        headers.set('Link', linkHeader);
+    }
 
     return new Response(JSON.stringify({ connections: data }), {
         status: 200,

--- a/packages/web/src/app/api/(server)/connections/route.ts
+++ b/packages/web/src/app/api/(server)/connections/route.ts
@@ -1,0 +1,58 @@
+'use server';
+
+import { NextRequest } from 'next/server';
+
+import { apiHandler } from '@/lib/apiHandler';
+import { buildLinkHeader } from '@/lib/pagination';
+import {
+    listConnectionsQueryParamsSchema,
+} from '@/lib/schemas';
+import {
+    queryParamsSchemaValidationError,
+    serviceErrorResponse,
+} from '@/lib/serviceError';
+import { isServiceError } from '@/lib/utils';
+
+import { listConnections } from './listConnectionsApi';
+
+// eslint-disable-next-line authz/require-auth-wrapper -- delegates to listConnections() which calls withAuth
+export const GET = apiHandler(async (request: NextRequest) => {
+    const rawParams = Object.fromEntries(
+        Object.keys(listConnectionsQueryParamsSchema.shape).map((key) => [
+            key,
+            request.nextUrl.searchParams.get(key) ?? undefined,
+        ]),
+    );
+    const parsed = listConnectionsQueryParamsSchema.safeParse(rawParams);
+
+    if (!parsed.success) {
+        return serviceErrorResponse(
+            queryParamsSchemaValidationError(parsed.error),
+        );
+    }
+
+    const { page, perPage } = parsed.data;
+
+    const result = await listConnections({ page, perPage });
+
+    if (isServiceError(result)) {
+        return serviceErrorResponse(result);
+    }
+
+    const { data, totalCount } = result;
+
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    headers.set('X-Total-Count', totalCount.toString());
+
+    const linkHeader = buildLinkHeader(request, {
+        page,
+        perPage,
+        totalCount,
+    });
+    if (linkHeader) headers.set('Link', linkHeader);
+
+    return new Response(JSON.stringify({ connections: data }), {
+        status: 200,
+        headers,
+    });
+});

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CodeHostType } from "@sourcebot/db";
+import { CodeHostType, ConnectionSyncJobStatus, ConnectionType } from "@sourcebot/db";
 
 export const repositoryQuerySchema = z.object({
     codeHostType: z.nativeEnum(CodeHostType),
@@ -41,3 +41,31 @@ export const listReposQueryParamsSchema = z.object({
 });
 
 export const listReposResponseSchema = repositoryQuerySchema.array();
+
+export const listConnectionsQueryParamsSchema = z.object({
+    page: z.coerce.number().int().positive().default(1),
+    perPage: z.coerce.number().int().positive().max(100).default(50),
+});
+
+export const connectionSummarySchema = z.object({
+    id: z.number(),
+    name: z.string(),
+    connectionType: z.nativeEnum(ConnectionType),
+    isDeclarative: z.boolean(),
+    syncedAt: z.coerce.date().nullable(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+    repoCount: z.number().int().nonnegative(),
+    inFlightJobCount: z.number().int().nonnegative(),
+    latestJob: z.object({
+        id: z.string(),
+        status: z.nativeEnum(ConnectionSyncJobStatus),
+        createdAt: z.coerce.date(),
+        completedAt: z.coerce.date().nullable(),
+        errorMessage: z.string().nullable(),
+    }).nullable(),
+});
+
+export const listConnectionsResponseSchema = z.object({
+    connections: z.array(connectionSummarySchema),
+});

--- a/packages/web/src/openapi/publicApiDocument.ts
+++ b/packages/web/src/openapi/publicApiDocument.ts
@@ -26,6 +26,8 @@ import {
     publicListCommitsResponseSchema,
     publicListReposQueryParamsSchema,
     publicListReposResponseSchema,
+    publicListConnectionsQueryParamsSchema,
+    publicListConnectionsResponseSchema,
     publicSearchRequestSchema,
     publicSearchResponseSchema,
     publicServiceErrorSchema,
@@ -198,6 +200,37 @@ export function createPublicOpenApiDocument(version: string) {
                 description: 'Service is healthy.',
                 content: jsonContent(publicHealthResponseSchema),
             },
+        },
+    });
+
+    registry.registerPath({
+        method: 'get',
+        path: '/api/connections',
+        operationId: 'listConnections',
+        tags: [systemTag.name],
+        summary: 'List code-host connections',
+        description: 'Returns a paginated list of code-host connections in the org, with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count). Auth-gated. The connection `config` is never returned (it carries tokens).',
+        request: {
+            query: publicListConnectionsQueryParamsSchema,
+        },
+        responses: {
+            200: {
+                description: 'Paginated connection list.',
+                headers: {
+                    'X-Total-Count': {
+                        description: 'Total number of connections matching the query across all pages.',
+                        schema: { type: 'integer', example: 5 },
+                    },
+                    Link: {
+                        description: 'Pagination links formatted per RFC 8288. Includes `rel="next"`, `rel="prev"`, `rel="first"`, and `rel="last"` when applicable.',
+                        schema: { type: 'string' },
+                    },
+                },
+                content: jsonContent(publicListConnectionsResponseSchema),
+            },
+            400: errorJson('Invalid query parameters.'),
+            401: errorJson('Not authenticated.'),
+            500: errorJson('Unexpected connection listing failure.'),
         },
     });
 

--- a/packages/web/src/openapi/publicApiSchemas.ts
+++ b/packages/web/src/openapi/publicApiSchemas.ts
@@ -64,6 +64,45 @@ export const publicHealthResponseSchema = z.object({
     status: z.enum(['ok']),
 }).openapi('PublicHealthResponse');
 
+export const publicListConnectionsQueryParamsSchema = z.object({
+    page: z.coerce.number().int().positive().default(1),
+    perPage: z.coerce.number().int().positive().max(100).default(50),
+}).openapi('PublicListConnectionsQuery');
+
+export const publicConnectionLatestJobSchema = z.object({
+    id: z.string(),
+    status: z.enum(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED']),
+    createdAt: z.string().datetime(),
+    completedAt: z.string().datetime().nullable(),
+    errorMessage: z.string().nullable(),
+}).openapi('PublicConnectionLatestJob');
+
+export const publicConnectionSummarySchema = z.object({
+    id: z.number().int().positive(),
+    name: z.string(),
+    connectionType: z.enum([
+        'github',
+        'gitlab',
+        'gitea',
+        'gerrit',
+        'bitbucket-server',
+        'bitbucket-cloud',
+        'generic-git-host',
+        'azuredevops',
+    ]),
+    isDeclarative: z.boolean(),
+    syncedAt: z.string().datetime().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    repoCount: z.number().int().nonnegative(),
+    inFlightJobCount: z.number().int().nonnegative(),
+    latestJob: publicConnectionLatestJobSchema.nullable(),
+}).openapi('PublicConnectionSummary');
+
+export const publicListConnectionsResponseSchema = z.object({
+    connections: z.array(publicConnectionSummarySchema),
+}).openapi('PublicListConnectionsResponse');
+
 // EE: User Management
 export const publicEeUserSchema = z.object({
     id: z.string(),


### PR DESCRIPTION
## Summary

Adds `GET /api/connections` — a paginated, auth-gated public endpoint that returns the per-connection sync state for the org: id, name, code-host type, last successful sync, latest job status (with the worker's error message exposed verbatim), in-flight job count, and repo count. Operators can now monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts.

Fixes #1516.

## Motivation

The "settings → connections" page is the only place a self-hosted operator can see which code-host connections are failing sync. The data is loaded via a Server Action (`getConnectionsWithLatestJob`) that reads from Prisma directly, so it is not reachable as `curl`. Three concrete scenarios this unblocks:

1. **Operational monitoring.** A bot runs every 5 minutes and `curl`s `/api/connections`. If a connection's `latestJob.status` is `FAILED`, the bot alerts the on-call. Today the only way to do this is to scrape the Prisma DB directly, which requires DB credentials and bypasses the application layer.
2. **External dashboarding.** A Grafana / Datadog / New Relic panel reads the connection status alongside other Sourcebot metrics. With this endpoint, the panel can hit the same authenticated route the UI uses.
3. **Self-audit before a config change.** Before rolling out a config change that touches a connection, the operator `curl`s the endpoint to confirm the connection is currently `COMPLETED` (not `IN_PROGRESS`), so the change doesn't race with an in-flight sync.

## Changes

- **`packages/web/src/app/api/(server)/connections/route.ts`** — new endpoint. Auth: `withAuth` (any signed-in user, same access level as the settings page). Standard pagination via `page` / `perPage`. Standard response headers (`X-Total-Count`, `Link`) reused from `/api/repos` via `buildLinkHeader`. The `connection.config` field (which carries tokens) is never in the response.
- **`packages/web/src/app/api/(server)/connections/listConnectionsApi.ts`** — new file. Uses `withAuth` and `sew` for error wrapping. Issues a single `prisma.connection.findMany` with `include: { _count: { select: { repos: true, syncJobs: true } }, syncJobs: { take: 1, orderBy: { createdAt: 'desc' } } }` and a separate `prisma.connectionSyncJob.groupBy` for the per-connection in-flight counts (so the in-flight count is a single grouped query, not N+1).
- **`packages/web/src/app/api/(server)/connections/route.test.ts`** — 11 vitest cases covering: 401 when no auth, the documented response shape on a happy path, `latestJob: null` for never-synced connections, the in-flight count populated from the groupBy query, the latest job `errorMessage` exposed verbatim, the `config` field NOT in the response, 400 for invalid `perPage` / `page`, 200 with empty list, and the `X-Total-Count` + `Link` headers.
- **`packages/web/src/lib/schemas.ts`** — three new Zod schemas: `listConnectionsQueryParamsSchema`, `connectionSummarySchema`, `listConnectionsResponseSchema`.
- **`packages/web/src/openapi/publicApiSchemas.ts`** — four new public schemas registered with `.openapi(...)`: `PublicListConnectionsQuery`, `PublicConnectionLatestJob`, `PublicConnectionSummary`, `PublicListConnectionsResponse`.
- **`packages/web/src/openapi/publicApiDocument.ts`** — new path registered under `systemTag` (alongside `/api/version` and `/api/health`).
- **`docs/api-reference/sourcebot-public.openapi.json`** — regenerated via `yarn workspace @sourcebot/web openapi:generate`.
- **`docs/docs.json`** — added `GET /api/connections` to the System group in the API Reference tab.
- **`CHANGELOG.md`** — `[Unreleased] → Added` entry.

## Design decisions

- **Auth at `withAuth`, not `withOptionalAuth`.** Connections are org-private data. Anonymous access would expose what code hosts the org uses, which is not safe. `withAuth` matches the existing settings-page access level.
- **Not OWNER-gated.** The settings page is visible to any signed-in org member, so gating the API stricter than the UI would be inconsistent. The connection `config` (which carries tokens) is never returned, so the data exposure is limited to "names and types of code hosts this org uses" — the same thing the settings page already shows.
- **In-flight count via `groupBy`, not N+1.** The first cut was a loop of `prisma.connectionSyncJob.count` per connection. The `groupBy` query is one round-trip and matches the same pattern the rest of the codebase uses for batch aggregations.
- **Sort by `name` ascending.** The settings UI sorts by name. Operators scripting off this endpoint will see a stable, predictable order.
- **`latestJob.errorMessage` exposed verbatim.** The readiness probe (`/api/health/ready`) scrubs internal details to keep the public route safe; this is an authenticated endpoint and the worker error message is exactly what an operator needs to debug a failing sync.
- **No new dependencies, no schema migration.** Pure addition on top of the existing Prisma models.

## Verification

- `yarn workspace @sourcebot/web test --run "connections"` — 22/22 tests pass (11 new).
- `yarn workspace @sourcebot/web lint` — 0 errors (4 pre-existing warnings in unrelated files).
- `tsc --noEmit -p packages/web/tsconfig.json` — 0 errors in the new files.
- `yarn workspace @sourcebot/web openapi:generate` — clean regen, the new path and four new schemas are in the published spec.

The 7 unrelated test failures in `yarn workspace @sourcebot/web test --run` (in the EE `chat/skills`, `chat/mcp`, and `askmcp/*` areas) are pre-existing — they fail with `TypeError: (0, core_1.getEnv) is not a function` from `@opentelemetry/sdk-trace-base`, which is a setup issue independent of this PR. They are not in any file I changed.

## Backward compatibility

Fully additive. No existing routes, schemas, or Prisma models change. The only consumer-visible change is the new `GET /api/connections` route, which is opt-in.

## Out of scope (potential follow-ups, not in this PR)

- A per-connection `GET /api/connections/:id` detail endpoint (drill-down for the dashboard use case once the list is the primary driver).
- Webhook notifications for connection state changes (a connection going from `COMPLETED` to `FAILED` could trigger a Slack/PagerDuty alert server-side instead of requiring an external poller).
- A `POST /api/connections/:id/sync` to trigger a re-sync from the API. (The existing `POST /api/sync-connection` worker endpoint exists, but the web app's Server Action layer doesn't expose it as a public API.)

## Risks

- The endpoint exposes the list of code-host names and types in the org. This is the same data the settings page already shows to any signed-in org member, so no new information leak.
- The `errorMessage` field may include stack traces or internal hostnames from the worker. The endpoint is auth-gated, so the exposure is limited to the org's own members. Operators need the full message to debug.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive read-only API gated like the settings connections page; main caveat is authenticated exposure of worker error messages (hostnames/stack traces), which is intentional for debugging.
> 
> **Overview**
> Adds **`GET /api/connections`**, an authenticated public API so operators can poll org code-host connection health (sync timestamps, latest job status and error text, in-flight job counts, repo counts) without scraping the DB or the settings UI.
> 
> The handler follows the same pattern as **`/api/repos`**: `page` / `perPage` query validation, **`X-Total-Count`** and RFC 8288 **`Link`** headers, and org scoping via **`withAuth`**. Responses deliberately omit **`connection.config`** (tokens); in-flight counts use a single **`groupBy`** instead of per-connection counts. OpenAPI schemas, generated spec, docs nav, changelog, and Vitest coverage (including a regression that **`config`** never leaks) ship with the route.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0564eb154b0a3f8ea85c8272540e5060f682efbf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an authenticated **GET `/api/connections`** endpoint to list code-host connections with pagination.
  * Returns per-connection sync state (last sync, latest job details, active sync job count) and repo counts.
  * Includes pagination headers (`X-Total-Count` and `Link`).
* **Bug Fixes**
  * Improved vulnerability triage synchronization to match current security findings, fixing failures affecting reusable-workflow callers, CodeQL-less repositories, and transient non-JSON responses.
* **Documentation**
  * Updated OpenAPI schemas and API reference navigation for `/api/connections`.
* **Tests**
  * Added endpoint tests covering auth, pagination validation, payload shape, and headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->