### PR TITLE
feat(web): add GET /api/connections/{id} detail endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,14 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1517](https://github.com/sourcebot-dev/sourcebot/pull/1517)
 - `GET /api/connections/{id}` returns one connection in the org by id with its latest sync job, the count of in-flight jobs, and the most recent jobs (default 10, max 50 via `?jobLimit=`); the connection `config` is never returned. [#1518](https://github.com/sourcebot-dev/sourcebot/pull/1518)
 
-### Fixed
-- Upgraded `seroval` to `^1.5.6`. [#1508](https://github.com/sourcebot-dev/sourcebot/pull/1508)
-
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 
 ### Fixed
 - Fixed vulnerability triage for reusable-workflow callers, repositories without CodeQL, and transient non-JSON Linear query responses. [#1515](https://github.com/sourcebot-dev/sourcebot/pull/1515)
+- Upgraded `seroval` to `^1.5.6`. [#1508](https://github.com/sourcebot-dev/sourcebot/pull/1508)
 
 ## [5.1.4] - 2026-07-24
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1516](https://github.com/sourcebot-dev/sourcebot/issues/1516)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1517](https://github.com/sourcebot-dev/sourcebot/pull/1517)
+- `GET /api/connections/{id}` returns one connection in the org by id with its latest sync job, the count of in-flight jobs, and the most recent jobs (default 10, max 50 via `?jobLimit=`); the connection `config` is never returned. [#1518](https://github.com/sourcebot-dev/sourcebot/pull/1518)
 
 ### Fixed
 - Upgraded `seroval` to `^1.5.6`. [#1508](https://github.com/sourcebot-dev/sourcebot/pull/1508)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1517](https://github.com/sourcebot-dev/sourcebot/pull/1517)
 
+### Fixed
+- Upgraded `seroval` to `^1.5.6`. [#1508](https://github.com/sourcebot-dev/sourcebot/pull/1508)
+
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1516](https://github.com/sourcebot-dev/sourcebot/issues/1516)
+- `GET /api/connections` returns a paginated, auth-gated list of code-host connections in the org with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count) so operators can monitor connection health from a script and pipe into Prometheus / Datadog / Grafana / Slack alerts. [#1517](https://github.com/sourcebot-dev/sourcebot/pull/1517)
 
 ### Changed
 - Vulnerability triage now keeps Linear issues synchronized with current security findings.

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -537,6 +537,123 @@
           "status"
         ]
       },
+      "PublicConnectionLatestJob": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "FAILED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "createdAt",
+          "completedAt",
+          "errorMessage"
+        ]
+      },
+      "PublicConnectionSummary": {
+        "type": "object",
+        "properties": {
+          "id": {
+            "type": "integer",
+            "minimum": 0,
+            "exclusiveMinimum": true
+          },
+          "name": {
+            "type": "string"
+          },
+          "connectionType": {
+            "type": "string",
+            "enum": [
+              "github",
+              "gitlab",
+              "gitea",
+              "gerrit",
+              "bitbucket-server",
+              "bitbucket-cloud",
+              "generic-git-host",
+              "azuredevops"
+            ]
+          },
+          "isDeclarative": {
+            "type": "boolean"
+          },
+          "syncedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "updatedAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "repoCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "inFlightJobCount": {
+            "type": "integer",
+            "minimum": 0
+          },
+          "latestJob": {
+            "$ref": "#/components/schemas/PublicConnectionLatestJob"
+          }
+        },
+        "required": [
+          "id",
+          "name",
+          "connectionType",
+          "isDeclarative",
+          "syncedAt",
+          "createdAt",
+          "updatedAt",
+          "repoCount",
+          "inFlightJobCount",
+          "latestJob"
+        ]
+      },
+      "PublicListConnectionsResponse": {
+        "type": "object",
+        "properties": {
+          "connections": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicConnectionSummary"
+            }
+          }
+        },
+        "required": [
+          "connections"
+        ]
+      },
       "PublicFileSourceResponse": {
         "type": "object",
         "properties": {
@@ -1472,6 +1589,98 @@
               "application/json": {
                 "schema": {
                   "$ref": "#/components/schemas/PublicHealthResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connections": {
+      "get": {
+        "operationId": "listConnections",
+        "tags": [
+          "System"
+        ],
+        "summary": "List code-host connections",
+        "description": "Returns a paginated list of code-host connections in the org, with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count). Auth-gated. The connection `config` is never returned (it carries tokens).",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "default": 1
+            },
+            "required": false,
+            "name": "page",
+            "in": "query"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 100,
+              "default": 50
+            },
+            "required": false,
+            "name": "perPage",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Paginated connection list.",
+            "headers": {
+              "X-Total-Count": {
+                "description": "Total number of connections matching the query across all pages.",
+                "schema": {
+                  "type": "integer",
+                  "example": 5
+                }
+              },
+              "Link": {
+                "description": "Pagination links formatted per RFC 8288. Includes `rel=\"next\"`, `rel=\"prev\"`, `rel=\"first\"`, and `rel=\"last\"` when applicable.",
+                "schema": {
+                  "type": "string"
+                }
+              }
+            },
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicListConnectionsResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid query parameters.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected connection listing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
                 }
               }
             }

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -654,6 +654,87 @@
           "connections"
         ]
       },
+      "PublicConnectionJob": {
+        "type": "object",
+        "nullable": true,
+        "properties": {
+          "id": {
+            "type": "string"
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "PENDING",
+              "IN_PROGRESS",
+              "COMPLETED",
+              "FAILED"
+            ]
+          },
+          "createdAt": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "completedAt": {
+            "type": "string",
+            "nullable": true,
+            "format": "date-time"
+          },
+          "durationMs": {
+            "type": "integer",
+            "nullable": true,
+            "minimum": 0
+          },
+          "errorMessage": {
+            "type": "string",
+            "nullable": true
+          },
+          "warningMessages": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            }
+          }
+        },
+        "required": [
+          "id",
+          "status",
+          "createdAt",
+          "completedAt",
+          "durationMs",
+          "errorMessage",
+          "warningMessages"
+        ]
+      },
+      "PublicGetConnectionResponse": {
+        "type": "object",
+        "properties": {
+          "connection": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PublicConnectionSummary"
+              },
+              {
+                "type": "object",
+                "properties": {
+                  "latestJob": {
+                    "$ref": "#/components/schemas/PublicConnectionJob"
+                  }
+                }
+              }
+            ]
+          },
+          "recentJobs": {
+            "type": "array",
+            "items": {
+              "$ref": "#/components/schemas/PublicConnectionJob"
+            }
+          }
+        },
+        "required": [
+          "connection",
+          "recentJobs"
+        ]
+      },
       "PublicFileSourceResponse": {
         "type": "object",
         "properties": {
@@ -1677,6 +1758,92 @@
           },
           "500": {
             "description": "Unexpected connection listing failure.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/api/connections/{id}": {
+      "get": {
+        "operationId": "getConnection",
+        "tags": [
+          "System"
+        ],
+        "summary": "Get a single code-host connection",
+        "description": "Returns one connection in the org by id, plus its most recent sync jobs (default 10, max 50 via `?jobLimit=`) and the count of in-flight jobs. The connection `config` is never returned (it carries tokens). Cross-org access returns 404 (not 403) to avoid leaking the existence of connections in other orgs.",
+        "parameters": [
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true
+            },
+            "required": true,
+            "name": "id",
+            "in": "path"
+          },
+          {
+            "schema": {
+              "type": "integer",
+              "minimum": 0,
+              "exclusiveMinimum": true,
+              "maximum": 50,
+              "default": 10
+            },
+            "required": false,
+            "name": "jobLimit",
+            "in": "query"
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "The connection, its latest job, and recent sync jobs.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicGetConnectionResponse"
+                }
+              }
+            }
+          },
+          "400": {
+            "description": "Invalid `id` or `jobLimit` query parameter.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Not authenticated.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Connection not found in the org.",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PublicApiServiceError"
+                }
+              }
+            }
+          },
+          "500": {
+            "description": "Unexpected connection read failure.",
             "content": {
               "application/json": {
                 "schema": {

--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -682,7 +682,8 @@
           "durationMs": {
             "type": "integer",
             "nullable": true,
-            "minimum": 0
+            "minimum": 0,
+            "description": "Elapsed time from job enqueue to completion, in milliseconds. Includes queue wait time as well as execution time, not sync execution alone. Null while the job is still running."
           },
           "errorMessage": {
             "type": "string",
@@ -709,18 +710,68 @@
         "type": "object",
         "properties": {
           "connection": {
-            "allOf": [
-              {
-                "$ref": "#/components/schemas/PublicConnectionSummary"
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "integer",
+                "minimum": 0,
+                "exclusiveMinimum": true
               },
-              {
-                "type": "object",
-                "properties": {
-                  "latestJob": {
-                    "$ref": "#/components/schemas/PublicConnectionJob"
-                  }
-                }
+              "name": {
+                "type": "string"
+              },
+              "connectionType": {
+                "type": "string",
+                "enum": [
+                  "github",
+                  "gitlab",
+                  "gitea",
+                  "gerrit",
+                  "bitbucket-server",
+                  "bitbucket-cloud",
+                  "generic-git-host",
+                  "azuredevops"
+                ]
+              },
+              "isDeclarative": {
+                "type": "boolean"
+              },
+              "syncedAt": {
+                "type": "string",
+                "nullable": true,
+                "format": "date-time"
+              },
+              "createdAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "updatedAt": {
+                "type": "string",
+                "format": "date-time"
+              },
+              "repoCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "inFlightJobCount": {
+                "type": "integer",
+                "minimum": 0
+              },
+              "latestJob": {
+                "$ref": "#/components/schemas/PublicConnectionJob"
               }
+            },
+            "required": [
+              "id",
+              "name",
+              "connectionType",
+              "isDeclarative",
+              "syncedAt",
+              "createdAt",
+              "updatedAt",
+              "repoCount",
+              "inFlightJobCount",
+              "latestJob"
             ]
           },
           "recentJobs": {
@@ -1794,9 +1845,11 @@
               "minimum": 0,
               "exclusiveMinimum": true,
               "maximum": 50,
-              "default": 10
+              "default": 10,
+              "description": "Maximum number of recent sync jobs to return. Defaults to 10, max 50."
             },
             "required": false,
+            "description": "Maximum number of recent sync jobs to return. Defaults to 10, max 50.",
             "name": "jobLimit",
             "in": "query"
           }

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -218,7 +218,8 @@
                         "pages": [
                             "GET /api/version",
                             "GET /api/health",
-                            "GET /api/connections"
+                            "GET /api/connections",
+                            "GET /api/connections/{id}"
                         ]
                     }
                 ]

--- a/docs/docs.json
+++ b/docs/docs.json
@@ -217,7 +217,8 @@
                         "icon": "server",
                         "pages": [
                             "GET /api/version",
-                            "GET /api/health"
+                            "GET /api/health",
+                            "GET /api/connections"
                         ]
                     }
                 ]

--- a/packages/web/src/app/api/(server)/connections/[id]/getConnectionApi.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/getConnectionApi.ts
@@ -1,0 +1,91 @@
+import 'server-only';
+
+import { ConnectionSyncJobStatus } from '@sourcebot/db';
+import { withAuth } from '@/middleware/withAuth';
+import { sew } from '@/middleware/sew';
+
+export interface GetConnectionParams {
+    id: number;
+    jobLimit: number;
+}
+
+export const getConnection = async (
+    { id, jobLimit }: GetConnectionParams,
+) => sew(() =>
+    withAuth(async ({ prisma, org }) => {
+        // Scope by orgId so a request for a connection in another org
+        // returns 404 (not 403). This avoids leaking the existence of
+        // connections in other orgs.
+        const connection = await prisma.connection.findFirst({
+            where: { id, orgId: org.id },
+            include: {
+                _count: { select: { repos: true } },
+            },
+        });
+
+        if (!connection) {
+            return null;
+        }
+
+        const [recentJobs, inFlightRows] = await Promise.all([
+            prisma.connectionSyncJob.findMany({
+                where: { connectionId: id },
+                orderBy: { createdAt: 'desc' },
+                take: jobLimit,
+            }),
+            prisma.connectionSyncJob.groupBy({
+                by: ['connectionId'],
+                where: {
+                    connectionId: id,
+                    status: {
+                        in: [ConnectionSyncJobStatus.PENDING, ConnectionSyncJobStatus.IN_PROGRESS],
+                    },
+                },
+                _count: { _all: true },
+            }),
+        ]);
+
+        const inFlightJobCount = inFlightRows[0]?._count._all ?? 0;
+        const latestJob = recentJobs[0] ?? null;
+
+        return {
+            data: {
+                connection: {
+                    id: connection.id,
+                    name: connection.name,
+                    connectionType: connection.connectionType,
+                    isDeclarative: connection.isDeclarative,
+                    syncedAt: connection.syncedAt,
+                    createdAt: connection.createdAt,
+                    updatedAt: connection.updatedAt,
+                    repoCount: connection._count?.repos ?? 0,
+                    inFlightJobCount,
+                    latestJob: latestJob
+                        ? {
+                            id: latestJob.id,
+                            status: latestJob.status,
+                            createdAt: latestJob.createdAt,
+                            completedAt: latestJob.completedAt,
+                            durationMs: latestJob.completedAt
+                                ? latestJob.completedAt.getTime() - latestJob.createdAt.getTime()
+                                : null,
+                            errorMessage: latestJob.errorMessage,
+                            warningMessages: latestJob.warningMessages,
+                        }
+                        : null,
+                },
+                recentJobs: recentJobs.map((job) => ({
+                    id: job.id,
+                    status: job.status,
+                    createdAt: job.createdAt,
+                    completedAt: job.completedAt,
+                    durationMs: job.completedAt
+                        ? job.completedAt.getTime() - job.createdAt.getTime()
+                        : null,
+                    errorMessage: job.errorMessage,
+                    warningMessages: job.warningMessages,
+                })),
+            },
+        };
+    }),
+);

--- a/packages/web/src/app/api/(server)/connections/[id]/getConnectionApi.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/getConnectionApi.ts
@@ -9,6 +9,30 @@ export interface GetConnectionParams {
     jobLimit: number;
 }
 
+// Shape a single sync-job row the way the public OpenAPI exposes it:
+// an explicit `durationMs` derived from createdAt/completedAt so callers
+// don't have to compute it client-side, plus the warning list and
+// error verbatim. Used for both the embedded `latestJob` and each
+// element of `recentJobs`.
+const toConnectionJob = (job: {
+    id: string;
+    status: ConnectionSyncJobStatus;
+    createdAt: Date;
+    completedAt: Date | null;
+    errorMessage: string | null;
+    warningMessages: string[];
+}) => ({
+    id: job.id,
+    status: job.status,
+    createdAt: job.createdAt,
+    completedAt: job.completedAt,
+    durationMs: job.completedAt
+        ? job.completedAt.getTime() - job.createdAt.getTime()
+        : null,
+    errorMessage: job.errorMessage,
+    warningMessages: job.warningMessages,
+});
+
 export const getConnection = async (
     { id, jobLimit }: GetConnectionParams,
 ) => sew(() =>
@@ -45,9 +69,6 @@ export const getConnection = async (
             }),
         ]);
 
-        const inFlightJobCount = inFlightRows[0]?._count._all ?? 0;
-        const latestJob = recentJobs[0] ?? null;
-
         return {
             data: {
                 connection: {
@@ -59,32 +80,10 @@ export const getConnection = async (
                     createdAt: connection.createdAt,
                     updatedAt: connection.updatedAt,
                     repoCount: connection._count?.repos ?? 0,
-                    inFlightJobCount,
-                    latestJob: latestJob
-                        ? {
-                            id: latestJob.id,
-                            status: latestJob.status,
-                            createdAt: latestJob.createdAt,
-                            completedAt: latestJob.completedAt,
-                            durationMs: latestJob.completedAt
-                                ? latestJob.completedAt.getTime() - latestJob.createdAt.getTime()
-                                : null,
-                            errorMessage: latestJob.errorMessage,
-                            warningMessages: latestJob.warningMessages,
-                        }
-                        : null,
+                    inFlightJobCount: inFlightRows[0]?._count._all ?? 0,
+                    latestJob: recentJobs[0] ? toConnectionJob(recentJobs[0]) : null,
                 },
-                recentJobs: recentJobs.map((job) => ({
-                    id: job.id,
-                    status: job.status,
-                    createdAt: job.createdAt,
-                    completedAt: job.completedAt,
-                    durationMs: job.completedAt
-                        ? job.completedAt.getTime() - job.createdAt.getTime()
-                        : null,
-                    errorMessage: job.errorMessage,
-                    warningMessages: job.warningMessages,
-                })),
+                recentJobs: recentJobs.map(toConnectionJob),
             },
         };
     }),

--- a/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
@@ -1,0 +1,419 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+type AuthContext = {
+    user: { id: string };
+    org: { id: number };
+    prisma: unknown;
+};
+
+// Lightweight stand-ins for the Prisma enums. Re-exported as the same
+// names so the route's `z.nativeEnum(...)` validation accepts the test
+// values. The real enums live in `@sourcebot/db`; we mock that package
+// to keep the OpenTelemetry CJS chain out of the test load path.
+const ConnectionSyncJobStatus = {
+    PENDING: 'PENDING',
+    IN_PROGRESS: 'IN_PROGRESS',
+    COMPLETED: 'COMPLETED',
+    FAILED: 'FAILED',
+} as const;
+
+const CodeHostType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+// The Prisma enum is its own runtime object, not a type alias. We
+// mirror the values so `z.nativeEnum(ConnectionType)` at the route's
+// load time picks up the right keys.
+const ConnectionType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as AuthContext | undefined,
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@sourcebot/db', () => ({
+    ConnectionSyncJobStatus,
+    ConnectionType,
+    CodeHostType,
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+vi.mock('@/middleware/withAuth', () => ({
+    withAuth: vi.fn(async (callback: (ctx: AuthContext) => unknown) => {
+        if (!mocks.authContext) {
+            return { statusCode: 401, errorCode: 'NOT_AUTHENTICATED', message: 'Not authenticated' };
+        }
+        return callback(mocks.authContext);
+    }),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+    captureException: vi.fn(),
+    captureRequestError: vi.fn(),
+}));
+
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+    getEnv: () => ({}),
+    TraceIdRatioBasedSampler: vi.fn(),
+    ParentBasedSampler: vi.fn(),
+    AlwaysOnSampler: vi.fn(),
+    AlwaysOffSampler: vi.fn(),
+}));
+
+const makeRequest = (id: string, search: Record<string, string> = {}): NextRequest => {
+    const params = new URLSearchParams(search);
+    const url = `http://localhost/api/connections/${id}?${params.toString()}`;
+    return new NextRequest(url);
+};
+
+const { GET } = await import('./route');
+
+// The Prisma mock is shaped to drive the four query paths the action
+// uses: connection.findFirst (with orgId scope + _count.repos), the
+// recent-jobs findMany, and the in-flight groupBy. The connection
+// row includes a populated `config` field so the regression test
+// below is meaningful: a future change that spreads raw Prisma rows
+// will leak this field, and the test catches it.
+type JobFixture = {
+    id: string;
+    status: keyof typeof ConnectionSyncJobStatus;
+    createdAt: Date;
+    completedAt: Date | null;
+    errorMessage: string | null;
+    warningMessages: string[];
+};
+
+const buildPrismaMock = (opts: {
+    connection:
+        | (Omit<{
+            id: number;
+            name: string;
+            connectionType: keyof typeof ConnectionType;
+            isDeclarative: boolean;
+            syncedAt: Date | null;
+            createdAt: Date;
+            updatedAt: Date;
+            _count: { repos: number };
+        }, never> & { config: unknown })
+        | null;
+    recentJobs: JobFixture[];
+    inFlightCount: number;
+}) => {
+    const findFirst = vi.fn(async () => opts.connection);
+    const findMany = vi.fn(async () => opts.recentJobs);
+    const groupBy = vi.fn(async () => opts.inFlightCount > 0
+        ? [{ connectionId: opts.connection?.id ?? 0, _count: { _all: opts.inFlightCount } }]
+        : []);
+    return {
+        connection: { findFirst },
+        connectionSyncJob: { findMany, groupBy },
+    } as unknown;
+};
+
+const setAuth = (
+    connection: Parameters<typeof buildPrismaMock>[0]['connection'],
+    recentJobs: JobFixture[] = [],
+    inFlightCount = 0,
+) => {
+    mocks.authContext = {
+        user: { id: 'user_1' },
+        org: { id: 1 },
+        prisma: buildPrismaMock({ connection, recentJobs, inFlightCount }),
+    };
+};
+
+const fakeCompletedAt = (createdAt: Date) => new Date(createdAt.getTime() + 30_000);
+
+describe('GET /api/connections/:id', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.authContext = undefined;
+    });
+
+    test('returns 401 when no authenticated user', async () => {
+        mocks.authContext = undefined;
+        const response = await GET(makeRequest('1'), { params: Promise.resolve({ id: '1' }) });
+        expect(response.status).toBe(401);
+    });
+
+    test('returns 400 when id is not a positive integer', async () => {
+        setAuth(null);
+        const response = await GET(makeRequest('abc'), { params: Promise.resolve({ id: 'abc' }) });
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 when id is zero or negative', async () => {
+        setAuth(null);
+        const response = await GET(makeRequest('0'), { params: Promise.resolve({ id: '0' }) });
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 404 when the connection does not exist in the org', async () => {
+        setAuth(null);
+        const response = await GET(makeRequest('999'), { params: Promise.resolve({ id: '999' }) });
+        expect(response.status).toBe(404);
+    });
+
+    test('returns 200 with the documented shape on a happy path', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        const completedAt = fakeCompletedAt(createdAt);
+        setAuth(
+            {
+                id: 1,
+                name: 'github-public',
+                connectionType: 'github',
+                isDeclarative: false,
+                syncedAt: completedAt,
+                createdAt: new Date('2026-06-12T08:21:00.000Z'),
+                updatedAt: completedAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+            [
+                {
+                    id: 'job_1',
+                    status: 'COMPLETED',
+                    createdAt,
+                    completedAt,
+                    errorMessage: null,
+                    warningMessages: [],
+                },
+            ],
+            0,
+        );
+
+        const response = await GET(makeRequest('1'), { params: Promise.resolve({ id: '1' }) });
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connection).toEqual({
+            id: 1,
+            name: 'github-public',
+            connectionType: 'github',
+            isDeclarative: false,
+            syncedAt: completedAt.toISOString(),
+            createdAt: new Date('2026-06-12T08:21:00.000Z').toISOString(),
+            updatedAt: completedAt.toISOString(),
+            repoCount: 0, // _count.repos: 0
+            inFlightJobCount: 0,
+            latestJob: {
+                id: 'job_1',
+                status: 'COMPLETED',
+                createdAt: createdAt.toISOString(),
+                completedAt: completedAt.toISOString(),
+                durationMs: 30000,
+                errorMessage: null,
+                warningMessages: [],
+            },
+        });
+        expect(body.recentJobs).toHaveLength(1);
+    });
+
+    test('does NOT include the connection config (which carries tokens)', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        setAuth(
+            {
+                id: 5,
+                name: 'token-bearing',
+                connectionType: 'github',
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt,
+                updatedAt: createdAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+        );
+
+        const response = await GET(makeRequest('5'), { params: Promise.resolve({ id: '5' }) });
+        const body = await response.json();
+
+        expect(body.connection.config).toBeUndefined();
+    });
+
+    test('exposes the latest job errorMessage and warningMessages verbatim', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        const completedAt = fakeCompletedAt(createdAt);
+        setAuth(
+            {
+                id: 1,
+                name: 'broken',
+                connectionType: 'github',
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt,
+                updatedAt: completedAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+            [
+                {
+                    id: 'job_42',
+                    status: 'FAILED',
+                    createdAt,
+                    completedAt,
+                    errorMessage: 'connection refused: host=github.example.com:443',
+                    warningMessages: ['8 repos were skipped: 404 not found'],
+                },
+            ],
+        );
+
+        const response = await GET(makeRequest('1'), { params: Promise.resolve({ id: '1' }) });
+        const body = await response.json();
+
+        expect(body.recentJobs[0].errorMessage).toBe(
+            'connection refused: host=github.example.com:443',
+        );
+        expect(body.recentJobs[0].warningMessages).toEqual([
+            '8 repos were skipped: 404 not found',
+        ]);
+    });
+
+    test('respects the jobLimit query parameter', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        const completedAt = fakeCompletedAt(createdAt);
+        const jobs: JobFixture[] = Array.from({ length: 5 }, (_, i) => ({
+            id: `job_${i}`,
+            status: 'COMPLETED' as const,
+            createdAt: new Date(createdAt.getTime() - i * 60_000),
+            completedAt: new Date(createdAt.getTime() - i * 60_000 + 30_000),
+            errorMessage: null,
+            warningMessages: [],
+        }));
+        setAuth(
+            {
+                id: 1,
+                name: 'busy',
+                connectionType: 'github',
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt,
+                updatedAt: completedAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+            jobs,
+        );
+
+        const response = await GET(
+            makeRequest('1', { jobLimit: '2' }),
+            { params: Promise.resolve({ id: '1' }) },
+        );
+        const body = await response.json();
+
+        // The action passes the jobLimit to Prisma's `take`; the mock
+        // returns whatever we set, so we assert the request body shape
+        // (recentJobs length) matches what we provided (5). The route
+        // itself doesn't truncate.
+        expect(body.recentJobs).toHaveLength(5);
+    });
+
+    test('returns 400 for jobLimit=0', async () => {
+        setAuth(null);
+        const response = await GET(
+            makeRequest('1', { jobLimit: '0' }),
+            { params: Promise.resolve({ id: '1' }) },
+        );
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 for jobLimit > 50', async () => {
+        setAuth(null);
+        const response = await GET(
+            makeRequest('1', { jobLimit: '51' }),
+            { params: Promise.resolve({ id: '1' }) },
+        );
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 200 with empty recentJobs for a connection that has never been synced', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        setAuth(
+            {
+                id: 2,
+                name: 'never-synced',
+                connectionType: 'gitlab',
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt,
+                updatedAt: createdAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+            [],
+        );
+
+        const response = await GET(makeRequest('2'), { params: Promise.resolve({ id: '2' }) });
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connection.syncedAt).toBeNull();
+        expect(body.connection.latestJob).toBeNull();
+        expect(body.recentJobs).toEqual([]);
+    });
+
+    test('populates inFlightJobCount from the groupBy query', async () => {
+        const createdAt = new Date('2026-07-25T13:59:30.000Z');
+        setAuth(
+            {
+                id: 3,
+                name: 'busy',
+                connectionType: 'github',
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt,
+                updatedAt: createdAt,
+                _count: { repos: 0 },
+                config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
+            },
+            [],
+            2, // inFlightCount
+        );
+
+        const response = await GET(makeRequest('3'), { params: Promise.resolve({ id: '3' }) });
+        const body = await response.json();
+
+        expect(body.connection.inFlightJobCount).toBe(2);
+    });
+
+    test('cross-org access returns 404 (not 403) to avoid leaking existence', async () => {
+        // The action scopes by `where: { id, orgId: org.id }`. If the
+        // connection is in another org, findFirst returns null, and the
+        // route returns 404 — not 403. This is the security-critical
+        // assertion: a 403 here would tell an attacker that the id
+        // exists in some other org.
+        setAuth(null);
+        const response = await GET(makeRequest('42'), { params: Promise.resolve({ id: '42' }) });
+        expect(response.status).toBe(404);
+    });
+});

--- a/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
@@ -299,7 +299,7 @@ describe('GET /api/connections/:id', () => {
         ]);
     });
 
-    test('respects the jobLimit query parameter', async () => {
+    test('forwards jobLimit to Prisma as the findMany `take`', async () => {
         const createdAt = new Date('2026-07-25T13:59:30.000Z');
         const completedAt = fakeCompletedAt(createdAt);
         const jobs: JobFixture[] = Array.from({ length: 5 }, (_, i) => ({
@@ -331,10 +331,15 @@ describe('GET /api/connections/:id', () => {
         );
         const body = await response.json();
 
-        // The action passes the jobLimit to Prisma's `take`; the mock
-        // returns whatever we set, so we assert the request body shape
-        // (recentJobs length) matches what we provided (5). The route
-        // itself doesn't truncate.
+        // The mock returns whatever the test sets; the meaningful
+        // assertion is that the action passed the parsed jobLimit
+        // through to the recent-jobs findMany.
+        const prisma = mocks.authContext?.prisma as {
+            connectionSyncJob: { findMany: ReturnType<typeof vi.fn> };
+        };
+        expect(prisma.connectionSyncJob.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ take: 2, orderBy: { createdAt: 'desc' } }),
+        );
         expect(body.recentJobs).toHaveLength(5);
     });
 

--- a/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/route.test.ts
@@ -216,6 +216,18 @@ describe('GET /api/connections/:id', () => {
         const body = await response.json();
 
         expect(response.status).toBe(200);
+        // The action must pass the org id to Prisma so cross-org rows
+        // are filtered at the query level (the 404 path test above
+        // already exercises the not-found branch; this asserts the
+        // happy path also scopes the query).
+        const prisma = mocks.authContext?.prisma as {
+            connection: { findFirst: ReturnType<typeof vi.fn> };
+        };
+        expect(prisma.connection.findFirst).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: 1, orgId: 1 },
+            }),
+        );
         expect(body.connection).toEqual({
             id: 1,
             name: 'github-public',
@@ -420,5 +432,19 @@ describe('GET /api/connections/:id', () => {
         setAuth(null);
         const response = await GET(makeRequest('42'), { params: Promise.resolve({ id: '42' }) });
         expect(response.status).toBe(404);
+
+        // Beyond the response code, assert that the action actually
+        // passed the org id to Prisma. A future change that drops
+        // `orgId: org.id` from the `where` clause would still pass the
+        // 404 assertion (because the mock returns null regardless of
+        // args) but would expose cross-org data in production.
+        const prisma = mocks.authContext?.prisma as {
+            connection: { findFirst: ReturnType<typeof vi.fn> };
+        };
+        expect(prisma.connection.findFirst).toHaveBeenCalledWith(
+            expect.objectContaining({
+                where: { id: 42, orgId: 1 },
+            }),
+        );
     });
 });

--- a/packages/web/src/app/api/(server)/connections/[id]/route.ts
+++ b/packages/web/src/app/api/(server)/connections/[id]/route.ts
@@ -1,0 +1,49 @@
+'use server';
+
+import { NextRequest } from 'next/server';
+import { z } from 'zod';
+
+import { apiHandler } from '@/lib/apiHandler';
+import { getConnectionQueryParamsSchema } from '@/lib/schemas';
+import {
+    notFound,
+    queryParamsSchemaValidationError,
+    serviceErrorResponse,
+} from '@/lib/serviceError';
+import { isServiceError } from '@/lib/utils';
+
+import { getConnection } from './getConnectionApi';
+
+const connectionIdParamSchema = z.coerce.number().int().positive();
+
+// eslint-disable-next-line authz/require-auth-wrapper -- delegates to getConnection() which calls withAuth
+export const GET = apiHandler(async (
+    request: NextRequest,
+    { params }: { params: Promise<{ id: string }> },
+) => {
+    const { id: rawId } = await params;
+    const idParsed = connectionIdParamSchema.safeParse(rawId);
+    if (!idParsed.success) {
+        return serviceErrorResponse(queryParamsSchemaValidationError(idParsed.error));
+    }
+    const id = idParsed.data;
+
+    const jobLimitRaw = request.nextUrl.searchParams.get('jobLimit') ?? undefined;
+    const paramsParsed = getConnectionQueryParamsSchema.safeParse({ jobLimit: jobLimitRaw });
+    if (!paramsParsed.success) {
+        return serviceErrorResponse(queryParamsSchemaValidationError(paramsParsed.error));
+    }
+    const { jobLimit } = paramsParsed.data;
+
+    const result = await getConnection({ id, jobLimit });
+
+    if (isServiceError(result)) {
+        return serviceErrorResponse(result);
+    }
+
+    if (result === null || result === undefined) {
+        return serviceErrorResponse(notFound());
+    }
+
+    return Response.json(result.data, { status: 200 });
+});

--- a/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
+++ b/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
@@ -1,0 +1,83 @@
+import 'server-only';
+
+import { ConnectionSyncJobStatus } from '@sourcebot/db';
+import { withAuth } from '@/middleware/withAuth';
+import { sew } from '@/middleware/sew';
+
+export interface ListConnectionsParams {
+    page: number;
+    perPage: number;
+}
+
+export const listConnections = async (
+    { page, perPage }: ListConnectionsParams,
+) => sew(() =>
+    withAuth(async ({ prisma, org }) => {
+        const skip = (page - 1) * perPage;
+
+        const [connections, totalCount] = await Promise.all([
+            prisma.connection.findMany({
+                where: { orgId: org.id },
+                orderBy: { name: 'asc' },
+                skip,
+                take: perPage,
+                include: {
+                    _count: {
+                        select: {
+                            repos: true,
+                            syncJobs: true,
+                        },
+                    },
+                    syncJobs: {
+                        orderBy: { createdAt: 'desc' },
+                        take: 1,
+                    },
+                },
+            }),
+            prisma.connection.count({ where: { orgId: org.id } }),
+        ]);
+
+        // Count in-flight jobs (PENDING + IN_PROGRESS) per connection in
+        // a single grouped query rather than N+1 small counts.
+        const inFlightByConnection = await prisma.connectionSyncJob.groupBy({
+            by: ['connectionId'],
+            where: {
+                connectionId: { in: connections.map((c) => c.id) },
+                status: {
+                    in: [ConnectionSyncJobStatus.PENDING, ConnectionSyncJobStatus.IN_PROGRESS],
+                },
+            },
+            _count: { _all: true },
+        });
+        const inFlightMap = new Map(
+            inFlightByConnection.map((row) => [row.connectionId, row._count._all]),
+        );
+
+        return {
+            data: connections.map((connection) => {
+                const latestJob = connection.syncJobs[0] ?? null;
+                return {
+                    id: connection.id,
+                    name: connection.name,
+                    connectionType: connection.connectionType,
+                    isDeclarative: connection.isDeclarative,
+                    syncedAt: connection.syncedAt,
+                    createdAt: connection.createdAt,
+                    updatedAt: connection.updatedAt,
+                    repoCount: connection._count.repos,
+                    inFlightJobCount: inFlightMap.get(connection.id) ?? 0,
+                    latestJob: latestJob
+                        ? {
+                            id: latestJob.id,
+                            status: latestJob.status,
+                            createdAt: latestJob.createdAt,
+                            completedAt: latestJob.completedAt,
+                            errorMessage: latestJob.errorMessage,
+                        }
+                        : null,
+                };
+            }),
+            totalCount,
+        };
+    }),
+);

--- a/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
+++ b/packages/web/src/app/api/(server)/connections/listConnectionsApi.ts
@@ -25,7 +25,6 @@ export const listConnections = async (
                     _count: {
                         select: {
                             repos: true,
-                            syncJobs: true,
                         },
                     },
                     syncJobs: {

--- a/packages/web/src/app/api/(server)/connections/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/route.test.ts
@@ -1,0 +1,368 @@
+import { beforeEach, describe, expect, test, vi } from 'vitest';
+import { NextRequest } from 'next/server';
+
+type AuthContext = {
+    user: { id: string };
+    org: { id: number };
+    prisma: unknown;
+};
+
+// Lightweight stand-ins for the Prisma enums. Re-exported as the same
+// names so the route's `z.nativeEnum(...)` validation accepts the test
+// values. The real enums live in `@sourcebot/db`; we mock that package
+// to keep the OpenTelemetry CJS chain out of the test load path.
+const ConnectionSyncJobStatus = {
+    PENDING: 'PENDING',
+    IN_PROGRESS: 'IN_PROGRESS',
+    COMPLETED: 'COMPLETED',
+    FAILED: 'FAILED',
+} as const;
+
+const CodeHostType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+const ConnectionType = {
+    github: 'github',
+    gitlab: 'gitlab',
+    gitea: 'gitea',
+    gerrit: 'gerrit',
+    bitbucketServer: 'bitbucket-server',
+    bitbucketCloud: 'bitbucket-cloud',
+    genericGitHost: 'generic-git-host',
+    azuredevops: 'azuredevops',
+} as const;
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as AuthContext | undefined,
+}));
+
+vi.mock('server-only', () => ({}));
+
+vi.mock('@sourcebot/db', () => ({
+    ConnectionSyncJobStatus,
+    ConnectionType,
+    CodeHostType,
+}));
+
+// `sew.ts` imports `@sentry/nextjs`, which transitively pulls in
+// `@opentelemetry/sdk-trace-base`. The pre-existing version mismatch
+// (sdk-trace-base 1.28.0 expects `core.getEnv`, but core 2.8.0 dropped
+// it) makes the import fail at test-load time. Stub Sentry and the OTel
+// modules so the route file can be loaded without exercising the SDK.
+vi.mock('@sentry/nextjs', () => ({
+    captureException: vi.fn(),
+    captureRequestError: vi.fn(),
+}));
+
+vi.mock('@opentelemetry/sdk-trace-base', () => ({
+    getEnv: () => ({}),
+    TraceIdRatioBasedSampler: vi.fn(),
+    ParentBasedSampler: vi.fn(),
+    AlwaysOnSampler: vi.fn(),
+    AlwaysOffSampler: vi.fn(),
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+    }),
+}));
+
+vi.mock('@/lib/posthog', () => ({
+    captureEvent: vi.fn(),
+}));
+
+vi.mock('@/middleware/withAuth', () => ({
+    withAuth: vi.fn(async (callback: (ctx: AuthContext) => unknown) => {
+        if (!mocks.authContext) {
+            // Mirror the production behavior: if no auth, return a
+            // service error. The route is responsible for translating
+            // that into a 401.
+            return { statusCode: 401, errorCode: 'NOT_AUTHENTICATED', message: 'Not authenticated' };
+        }
+        return callback(mocks.authContext);
+    }),
+}));
+
+const makeRequest = (search: Record<string, string> = {}): NextRequest => {
+    const params = new URLSearchParams(search);
+    const url = `http://localhost/api/connections?${params.toString()}`;
+    return new NextRequest(url);
+};
+
+const { GET } = await import('./route');
+
+// The Prisma mock is shaped to drive the four query paths the route
+// uses: listConnections.findMany, listConnections.count,
+// connectionSyncJob.groupBy, plus the relations via `include`.
+const buildPrismaMock = (opts: {
+    connections: Array<{
+        id: number;
+        name: string;
+        connectionType: typeof ConnectionType[keyof typeof ConnectionType];
+        isDeclarative: boolean;
+        syncedAt: Date | null;
+        createdAt: Date;
+        updatedAt: Date;
+        repoCount: number;
+        latestJob: {
+            id: string;
+            status: typeof ConnectionSyncJobStatus[keyof typeof ConnectionSyncJobStatus];
+            createdAt: Date;
+            completedAt: Date | null;
+            errorMessage: string | null;
+        } | null;
+    }>;
+    inFlight: Map<number, number>;
+    totalCount: number;
+}) => {
+    const findMany = vi.fn(async () => opts.connections.map((c) => ({
+        id: c.id,
+        name: c.name,
+        connectionType: c.connectionType,
+        isDeclarative: c.isDeclarative,
+        syncedAt: c.syncedAt,
+        createdAt: c.createdAt,
+        updatedAt: c.updatedAt,
+        _count: { repos: c.repoCount, syncJobs: c.latestJob ? 1 : 0 },
+        syncJobs: c.latestJob ? [c.latestJob] : [],
+    })));
+    const count = vi.fn(async () => opts.totalCount);
+    const groupBy = vi.fn(async () => Array.from(opts.inFlight.entries()).map(([connectionId, count]) => ({
+        connectionId,
+        _count: { _all: count },
+    })));
+    return { connection: { findMany, count }, connectionSyncJob: { groupBy } } as unknown;
+};
+
+const setAuth = (connections: Parameters<typeof buildPrismaMock>[0]['connections'], opts?: { inFlight?: Map<number, number>; totalCount?: number }) => {
+    const allConnections = opts?.inFlight ? new Map(opts.inFlight) : new Map<number, number>();
+    mocks.authContext = {
+        user: { id: 'user_1' },
+        org: { id: 1 },
+        prisma: buildPrismaMock({
+            connections,
+            inFlight: allConnections,
+            totalCount: opts?.totalCount ?? connections.length,
+        }),
+    };
+};
+
+describe('GET /api/connections', () => {
+    beforeEach(() => {
+        vi.clearAllMocks();
+        mocks.authContext = undefined;
+    });
+
+    test('returns 401 when no authenticated user', async () => {
+        // withAuth returns a service error; the route returns 401.
+        mocks.authContext = undefined;
+        const response = await GET(makeRequest());
+        expect(response.status).toBe(401);
+    });
+
+    test('returns the documented connection shape on a happy path', async () => {
+        const now = new Date('2026-07-25T14:00:00.000Z');
+        setAuth([
+            {
+                id: 1,
+                name: 'github-public',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: now,
+                createdAt: new Date('2026-06-12T08:21:00.000Z'),
+                updatedAt: now,
+                repoCount: 137,
+                latestJob: {
+                    id: 'job_1',
+                    status: ConnectionSyncJobStatus.COMPLETED,
+                    createdAt: new Date('2026-07-25T13:59:30.000Z'),
+                    completedAt: now,
+                    errorMessage: null,
+                },
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connections).toHaveLength(1);
+        expect(body.connections[0]).toEqual({
+            id: 1,
+            name: 'github-public',
+            connectionType: 'github',
+            isDeclarative: false,
+            syncedAt: now.toISOString(),
+            createdAt: new Date('2026-06-12T08:21:00.000Z').toISOString(),
+            updatedAt: now.toISOString(),
+            repoCount: 137,
+            inFlightJobCount: 0,
+            latestJob: {
+                id: 'job_1',
+                status: 'COMPLETED',
+                createdAt: new Date('2026-07-25T13:59:30.000Z').toISOString(),
+                completedAt: now.toISOString(),
+                errorMessage: null,
+            },
+        });
+    });
+
+    test('returns latestJob:null for a connection that has never been synced', async () => {
+        setAuth([
+            {
+                id: 2,
+                name: 'never-synced',
+                connectionType: ConnectionType.gitlab,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: null,
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(response.status).toBe(200);
+        expect(body.connections[0].latestJob).toBeNull();
+        expect(body.connections[0].syncedAt).toBeNull();
+        expect(body.connections[0].repoCount).toBe(0);
+    });
+
+    test('exposes the in-flight job count per connection', async () => {
+        setAuth(
+            [
+                {
+                    id: 3,
+                    name: 'busy',
+                    connectionType: ConnectionType.github,
+                    isDeclarative: false,
+                    syncedAt: null,
+                    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                    updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                    repoCount: 5,
+                    latestJob: {
+                        id: 'job_3',
+                        status: ConnectionSyncJobStatus.IN_PROGRESS,
+                        createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                        completedAt: null,
+                        errorMessage: null,
+                    },
+                },
+            ],
+            { inFlight: new Map([[3, 2]]) },
+        );
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.connections[0].inFlightJobCount).toBe(2);
+    });
+
+    test('exposes the latest job errorMessage verbatim', async () => {
+        setAuth([
+            {
+                id: 4,
+                name: 'broken',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: {
+                    id: 'job_4',
+                    status: ConnectionSyncJobStatus.FAILED,
+                    createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                    completedAt: new Date('2026-07-01T00:00:30.000Z'),
+                    errorMessage: 'connection refused: host=github.example.com:443',
+                },
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        expect(body.connections[0].latestJob.status).toBe('FAILED');
+        expect(body.connections[0].latestJob.errorMessage).toBe(
+            'connection refused: host=github.example.com:443',
+        );
+    });
+
+    test('does NOT include the connection config (which carries tokens)', async () => {
+        setAuth([
+            {
+                id: 5,
+                name: 'token-bearing',
+                connectionType: ConnectionType.github,
+                isDeclarative: false,
+                syncedAt: null,
+                createdAt: new Date('2026-07-01T00:00:00.000Z'),
+                updatedAt: new Date('2026-07-01T00:00:00.000Z'),
+                repoCount: 0,
+                latestJob: null,
+            },
+        ]);
+
+        const response = await GET(makeRequest());
+        const body = await response.json();
+
+        // The config is the actual JSON the user stored (e.g. { token: { env: 'GH_TOKEN' } })
+        // for declarative connections. It must not be in the public response.
+        expect(body.connections[0].config).toBeUndefined();
+    });
+
+    test('returns 400 for perPage > 100', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ perPage: '1000' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 for perPage <= 0', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ perPage: '0' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('returns 400 for non-integer page', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest({ page: 'abc' }));
+        expect(response.status).toBe(400);
+    });
+
+    test('defaults page=1 and perPage=50 when no query params are provided', async () => {
+        setAuth([]);
+        const response = await GET(makeRequest());
+        // Empty list still returns 200 (not 400); defaults are accepted.
+        expect(response.status).toBe(200);
+        const body = await response.json();
+        expect(body.connections).toEqual([]);
+    });
+
+    test('emits X-Total-Count and Link headers on the response', async () => {
+        setAuth([], { totalCount: 137 });
+
+        const response = await GET(makeRequest({ page: '1', perPage: '10' }));
+
+        expect(response.headers.get('X-Total-Count')).toBe('137');
+        const link = response.headers.get('Link');
+        expect(link).toBeTruthy();
+        expect(link).toContain('rel="first"');
+        expect(link).toContain('rel="last"');
+        expect(link).toContain('rel="next"');
+    });
+});

--- a/packages/web/src/app/api/(server)/connections/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/route.test.ts
@@ -208,6 +208,20 @@ describe('GET /api/connections', () => {
         const body = await response.json();
 
         expect(response.status).toBe(200);
+        // The action must pass the org id to both Prisma queries so
+        // cross-org rows are filtered at the query level. The mock
+        // returns its fixture regardless of args, so a future change
+        // that drops `orgId: org.id` from the where clause would
+        // still pass the response-shape assertions above.
+        const prisma = mocks.authContext?.prisma as {
+            connection: { findMany: ReturnType<typeof vi.fn>; count: ReturnType<typeof vi.fn> };
+        };
+        expect(prisma.connection.findMany).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { orgId: 1 } }),
+        );
+        expect(prisma.connection.count).toHaveBeenCalledWith(
+            expect.objectContaining({ where: { orgId: 1 } }),
+        );
         expect(body.connections).toHaveLength(1);
         expect(body.connections[0]).toEqual({
             id: 1,

--- a/packages/web/src/app/api/(server)/connections/route.test.ts
+++ b/packages/web/src/app/api/(server)/connections/route.test.ts
@@ -105,7 +105,11 @@ const { GET } = await import('./route');
 
 // The Prisma mock is shaped to drive the four query paths the route
 // uses: listConnections.findMany, listConnections.count,
-// connectionSyncJob.groupBy, plus the relations via `include`.
+// connectionSyncJob.groupBy, plus the relations via `include`. The
+// mock includes a populated `config` field on every row so the
+// "config is not in the response" regression test can actually
+// detect a future change that accidentally spreads raw Prisma rows
+// into the response shape.
 const buildPrismaMock = (opts: {
     connections: Array<{
         id: number;
@@ -135,6 +139,12 @@ const buildPrismaMock = (opts: {
         syncedAt: c.syncedAt,
         createdAt: c.createdAt,
         updatedAt: c.updatedAt,
+        // The config is the actual JSON the user stored (e.g.
+        // { token: { env: 'GH_TOKEN' } }) for declarative connections.
+        // It must never appear in the public response. We include it
+        // here so the regression test below is meaningful: a future
+        // change that spreads raw Prisma rows will leak this field.
+        config: { token: { env: 'SOURCEBOT_TEST_TOKEN' } },
         _count: { repos: c.repoCount, syncJobs: c.latestJob ? 1 : 0 },
         syncJobs: c.latestJob ? [c.latestJob] : [],
     })));

--- a/packages/web/src/app/api/(server)/connections/route.ts
+++ b/packages/web/src/app/api/(server)/connections/route.ts
@@ -49,7 +49,9 @@ export const GET = apiHandler(async (request: NextRequest) => {
         perPage,
         totalCount,
     });
-    if (linkHeader) headers.set('Link', linkHeader);
+    if (linkHeader) {
+        headers.set('Link', linkHeader);
+    }
 
     return new Response(JSON.stringify({ connections: data }), {
         status: 200,

--- a/packages/web/src/app/api/(server)/connections/route.ts
+++ b/packages/web/src/app/api/(server)/connections/route.ts
@@ -1,0 +1,58 @@
+'use server';
+
+import { NextRequest } from 'next/server';
+
+import { apiHandler } from '@/lib/apiHandler';
+import { buildLinkHeader } from '@/lib/pagination';
+import {
+    listConnectionsQueryParamsSchema,
+} from '@/lib/schemas';
+import {
+    queryParamsSchemaValidationError,
+    serviceErrorResponse,
+} from '@/lib/serviceError';
+import { isServiceError } from '@/lib/utils';
+
+import { listConnections } from './listConnectionsApi';
+
+// eslint-disable-next-line authz/require-auth-wrapper -- delegates to listConnections() which calls withAuth
+export const GET = apiHandler(async (request: NextRequest) => {
+    const rawParams = Object.fromEntries(
+        Object.keys(listConnectionsQueryParamsSchema.shape).map((key) => [
+            key,
+            request.nextUrl.searchParams.get(key) ?? undefined,
+        ]),
+    );
+    const parsed = listConnectionsQueryParamsSchema.safeParse(rawParams);
+
+    if (!parsed.success) {
+        return serviceErrorResponse(
+            queryParamsSchemaValidationError(parsed.error),
+        );
+    }
+
+    const { page, perPage } = parsed.data;
+
+    const result = await listConnections({ page, perPage });
+
+    if (isServiceError(result)) {
+        return serviceErrorResponse(result);
+    }
+
+    const { data, totalCount } = result;
+
+    const headers = new Headers({ 'Content-Type': 'application/json' });
+    headers.set('X-Total-Count', totalCount.toString());
+
+    const linkHeader = buildLinkHeader(request, {
+        page,
+        perPage,
+        totalCount,
+    });
+    if (linkHeader) headers.set('Link', linkHeader);
+
+    return new Response(JSON.stringify({ connections: data }), {
+        status: 200,
+        headers,
+    });
+});

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -47,6 +47,20 @@ export const listConnectionsQueryParamsSchema = z.object({
     perPage: z.coerce.number().int().positive().max(100).default(50),
 });
 
+// The full sync-job row used by the detail endpoint. The list endpoint's
+// `connectionSummarySchema.latestJob` is a strict subset of this (no
+// `durationMs`, no `warningMessages`); it's derived via `.omit(...)` below
+// to keep the two shapes from drifting.
+export const connectionJobSchema = z.object({
+    id: z.string(),
+    status: z.nativeEnum(ConnectionSyncJobStatus),
+    createdAt: z.coerce.date(),
+    completedAt: z.coerce.date().nullable(),
+    durationMs: z.number().int().nonnegative().nullable(),
+    errorMessage: z.string().nullable(),
+    warningMessages: z.array(z.string()),
+});
+
 export const connectionSummarySchema = z.object({
     id: z.number(),
     name: z.string(),
@@ -57,12 +71,9 @@ export const connectionSummarySchema = z.object({
     updatedAt: z.coerce.date(),
     repoCount: z.number().int().nonnegative(),
     inFlightJobCount: z.number().int().nonnegative(),
-    latestJob: z.object({
-        id: z.string(),
-        status: z.nativeEnum(ConnectionSyncJobStatus),
-        createdAt: z.coerce.date(),
-        completedAt: z.coerce.date().nullable(),
-        errorMessage: z.string().nullable(),
+    latestJob: connectionJobSchema.omit({
+        durationMs: true,
+        warningMessages: true,
     }).nullable(),
 });
 
@@ -72,16 +83,6 @@ export const listConnectionsResponseSchema = z.object({
 
 export const getConnectionQueryParamsSchema = z.object({
     jobLimit: z.coerce.number().int().positive().max(50).default(10),
-});
-
-export const connectionJobSchema = z.object({
-    id: z.string(),
-    status: z.nativeEnum(ConnectionSyncJobStatus),
-    createdAt: z.coerce.date(),
-    completedAt: z.coerce.date().nullable(),
-    durationMs: z.number().int().nonnegative().nullable(),
-    errorMessage: z.string().nullable(),
-    warningMessages: z.array(z.string()),
 });
 
 export const getConnectionResponseSchema = z.object({

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -69,3 +69,26 @@ export const connectionSummarySchema = z.object({
 export const listConnectionsResponseSchema = z.object({
     connections: z.array(connectionSummarySchema),
 });
+
+export const getConnectionQueryParamsSchema = z.object({
+    jobLimit: z.coerce.number().int().positive().max(50).default(10),
+});
+
+export const connectionJobSchema = z.object({
+    id: z.string(),
+    status: z.nativeEnum(ConnectionSyncJobStatus),
+    createdAt: z.coerce.date(),
+    completedAt: z.coerce.date().nullable(),
+    durationMs: z.number().int().nonnegative().nullable(),
+    errorMessage: z.string().nullable(),
+    warningMessages: z.array(z.string()),
+});
+
+export const getConnectionResponseSchema = z.object({
+    connection: connectionSummarySchema.omit({
+        latestJob: true,
+    }).extend({
+        latestJob: connectionJobSchema.nullable(),
+    }),
+    recentJobs: z.array(connectionJobSchema),
+});

--- a/packages/web/src/lib/schemas.ts
+++ b/packages/web/src/lib/schemas.ts
@@ -1,5 +1,5 @@
 import { z } from "zod";
-import { CodeHostType } from "@sourcebot/db";
+import { CodeHostType, ConnectionSyncJobStatus, ConnectionType } from "@sourcebot/db";
 
 export const repositoryQuerySchema = z.object({
     codeHostType: z.nativeEnum(CodeHostType),
@@ -41,3 +41,31 @@ export const listReposQueryParamsSchema = z.object({
 });
 
 export const listReposResponseSchema = repositoryQuerySchema.array();
+
+export const listConnectionsQueryParamsSchema = z.object({
+    page: z.coerce.number().int().positive().default(1),
+    perPage: z.coerce.number().int().positive().max(100).default(50),
+});
+
+export const connectionSummarySchema = z.object({
+    id: z.number(),
+    name: z.string(),
+    connectionType: z.nativeEnum(ConnectionType),
+    isDeclarative: z.boolean(),
+    syncedAt: z.coerce.date().nullable(),
+    createdAt: z.coerce.date(),
+    updatedAt: z.coerce.date(),
+    repoCount: z.number().int().nonnegative(),
+    inFlightJobCount: z.number().int().nonnegative(),
+    latestJob: z.object({
+        id: z.string(),
+        status: z.nativeEnum(ConnectionSyncJobStatus),
+        createdAt: z.coerce.date(),
+        completedAt: z.coerce.date().nullable(),
+        errorMessage: z.string().nullable(),
+    }).nullable(),
+});
+
+export const listConnectionsResponseSchema = z.object({
+    connections: z.array(connectionSummarySchema),
+});

--- a/packages/web/src/openapi/publicApiDocument.ts
+++ b/packages/web/src/openapi/publicApiDocument.ts
@@ -26,6 +26,8 @@ import {
     publicListCommitsResponseSchema,
     publicListReposQueryParamsSchema,
     publicListReposResponseSchema,
+    publicListConnectionsQueryParamsSchema,
+    publicListConnectionsResponseSchema,
     publicSearchRequestSchema,
     publicSearchResponseSchema,
     publicServiceErrorSchema,
@@ -198,6 +200,37 @@ export function createPublicOpenApiDocument(version: string) {
                 description: 'Service is healthy.',
                 content: jsonContent(publicHealthResponseSchema),
             },
+        },
+    });
+
+    registry.registerPath({
+        method: 'get',
+        path: '/api/connections',
+        operationId: 'listConnections',
+        tags: [systemTag.name],
+        summary: 'List code-host connections',
+        description: 'Returns a paginated list of code-host connections in the org, with per-connection sync state (last sync timestamp, latest job status, in-flight job count, repo count). Auth-gated. The connection `config` is never returned (it carries tokens).',
+        request: {
+            query: publicListConnectionsQueryParamsSchema,
+        },
+        responses: {
+            200: {
+                description: 'Paginated connection list.',
+                headers: {
+                    'X-Total-Count': {
+                        description: 'Total number of connections matching the query across all pages.',
+                        schema: { type: 'integer', example: 5 },
+                    },
+                    Link: {
+                        description: 'Pagination links formatted per RFC 8288. Includes `rel="next"`, `rel="prev"`, `rel="first"`, and `rel="last"` when applicable.',
+                        schema: { type: 'string' },
+                    },
+                },
+                content: jsonContent(publicListConnectionsResponseSchema),
+            },
+            400: errorJson('Invalid query parameters.'),
+            401: errorJson('Not authenticated.'),
+            500: errorJson('Unexpected connection listing failure.'),
         },
     });
 

--- a/packages/web/src/openapi/publicApiDocument.ts
+++ b/packages/web/src/openapi/publicApiDocument.ts
@@ -28,6 +28,8 @@ import {
     publicListReposResponseSchema,
     publicListConnectionsQueryParamsSchema,
     publicListConnectionsResponseSchema,
+    publicGetConnectionQueryParamsSchema,
+    publicGetConnectionResponseSchema,
     publicSearchRequestSchema,
     publicSearchResponseSchema,
     publicServiceErrorSchema,
@@ -231,6 +233,31 @@ export function createPublicOpenApiDocument(version: string) {
             400: errorJson('Invalid query parameters.'),
             401: errorJson('Not authenticated.'),
             500: errorJson('Unexpected connection listing failure.'),
+        },
+    });
+
+    registry.registerPath({
+        method: 'get',
+        path: '/api/connections/{id}',
+        operationId: 'getConnection',
+        tags: [systemTag.name],
+        summary: 'Get a single code-host connection',
+        description: 'Returns one connection in the org by id, plus its most recent sync jobs (default 10, max 50 via `?jobLimit=`) and the count of in-flight jobs. The connection `config` is never returned (it carries tokens). Cross-org access returns 404 (not 403) to avoid leaking the existence of connections in other orgs.',
+        request: {
+            params: z.object({
+                id: z.coerce.number().int().positive(),
+            }),
+            query: publicGetConnectionQueryParamsSchema,
+        },
+        responses: {
+            200: {
+                description: 'The connection, its latest job, and recent sync jobs.',
+                content: jsonContent(publicGetConnectionResponseSchema),
+            },
+            400: errorJson('Invalid `id` or `jobLimit` query parameter.'),
+            401: errorJson('Not authenticated.'),
+            404: errorJson('Connection not found in the org.'),
+            500: errorJson('Unexpected connection read failure.'),
         },
     });
 

--- a/packages/web/src/openapi/publicApiSchemas.ts
+++ b/packages/web/src/openapi/publicApiSchemas.ts
@@ -64,6 +64,45 @@ export const publicHealthResponseSchema = z.object({
     status: z.enum(['ok']),
 }).openapi('PublicHealthResponse');
 
+export const publicListConnectionsQueryParamsSchema = z.object({
+    page: z.coerce.number().int().positive().default(1),
+    perPage: z.coerce.number().int().positive().max(100).default(50),
+}).openapi('PublicListConnectionsQuery');
+
+export const publicConnectionLatestJobSchema = z.object({
+    id: z.string(),
+    status: z.enum(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED']),
+    createdAt: z.string().datetime(),
+    completedAt: z.string().datetime().nullable(),
+    errorMessage: z.string().nullable(),
+}).openapi('PublicConnectionLatestJob');
+
+export const publicConnectionSummarySchema = z.object({
+    id: z.number().int().positive(),
+    name: z.string(),
+    connectionType: z.enum([
+        'github',
+        'gitlab',
+        'gitea',
+        'gerrit',
+        'bitbucket-server',
+        'bitbucket-cloud',
+        'generic-git-host',
+        'azuredevops',
+    ]),
+    isDeclarative: z.boolean(),
+    syncedAt: z.string().datetime().nullable(),
+    createdAt: z.string().datetime(),
+    updatedAt: z.string().datetime(),
+    repoCount: z.number().int().nonnegative(),
+    inFlightJobCount: z.number().int().nonnegative(),
+    latestJob: publicConnectionLatestJobSchema.nullable(),
+}).openapi('PublicConnectionSummary');
+
+export const publicListConnectionsResponseSchema = z.object({
+    connections: z.array(publicConnectionSummarySchema),
+}).openapi('PublicListConnectionsResponse');
+
 // EE: User Management
 export const publicEeUserSchema = z.object({
     id: z.string(),

--- a/packages/web/src/openapi/publicApiSchemas.ts
+++ b/packages/web/src/openapi/publicApiSchemas.ts
@@ -104,7 +104,7 @@ export const publicListConnectionsResponseSchema = z.object({
 }).openapi('PublicListConnectionsResponse');
 
 export const publicGetConnectionQueryParamsSchema = z.object({
-    jobLimit: z.coerce.number().int().positive().max(50).default(10),
+    jobLimit: z.coerce.number().int().positive().max(50).default(10).describe('Maximum number of recent sync jobs to return. Defaults to 10, max 50.'),
 }).openapi('PublicGetConnectionQuery');
 
 export const publicConnectionJobSchema = z.object({
@@ -112,13 +112,15 @@ export const publicConnectionJobSchema = z.object({
     status: z.enum(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED']),
     createdAt: z.string().datetime(),
     completedAt: z.string().datetime().nullable(),
-    durationMs: z.number().int().nonnegative().nullable(),
+    durationMs: z.number().int().nonnegative().nullable().describe('Elapsed time from job enqueue to completion, in milliseconds. Includes queue wait time as well as execution time, not sync execution alone. Null while the job is still running.'),
     errorMessage: z.string().nullable(),
     warningMessages: z.array(z.string()),
 }).openapi('PublicConnectionJob');
 
 export const publicGetConnectionResponseSchema = z.object({
-    connection: publicConnectionSummarySchema.extend({
+    connection: publicConnectionSummarySchema.omit({
+        latestJob: true,
+    }).extend({
         latestJob: publicConnectionJobSchema.nullable(),
     }),
     recentJobs: z.array(publicConnectionJobSchema),

--- a/packages/web/src/openapi/publicApiSchemas.ts
+++ b/packages/web/src/openapi/publicApiSchemas.ts
@@ -103,6 +103,27 @@ export const publicListConnectionsResponseSchema = z.object({
     connections: z.array(publicConnectionSummarySchema),
 }).openapi('PublicListConnectionsResponse');
 
+export const publicGetConnectionQueryParamsSchema = z.object({
+    jobLimit: z.coerce.number().int().positive().max(50).default(10),
+}).openapi('PublicGetConnectionQuery');
+
+export const publicConnectionJobSchema = z.object({
+    id: z.string(),
+    status: z.enum(['PENDING', 'IN_PROGRESS', 'COMPLETED', 'FAILED']),
+    createdAt: z.string().datetime(),
+    completedAt: z.string().datetime().nullable(),
+    durationMs: z.number().int().nonnegative().nullable(),
+    errorMessage: z.string().nullable(),
+    warningMessages: z.array(z.string()),
+}).openapi('PublicConnectionJob');
+
+export const publicGetConnectionResponseSchema = z.object({
+    connection: publicConnectionSummarySchema.extend({
+        latestJob: publicConnectionJobSchema.nullable(),
+    }),
+    recentJobs: z.array(publicConnectionJobSchema),
+}).openapi('PublicGetConnectionResponse');
+
 // EE: User Management
 export const publicEeUserSchema = z.object({
     id: z.string(),

--- a/yarn.lock
+++ b/yarn.lock
@@ -21441,9 +21441,9 @@ __metadata:
   linkType: hard
 
 "seroval@npm:~1.5.0":
-  version: 1.5.0
-  resolution: "seroval@npm:1.5.0"
-  checksum: 10c0/aff16b14a7145388555cefd4ebd41759024ee1c2c064080fd8d4fabea4b7c89d103155cd98f5109523b8878e577da73cc6cd8abf98965f2d1f0ba19dc38317ab
+  version: 1.5.6
+  resolution: "seroval@npm:1.5.6"
+  checksum: 10c0/47e4fb25305bf05fdf300cac6b0d4aaaaf1e12f15c819195afcdf512d88901a3f1f7754ac5a2de740cc0bb04e912c653fbf0129fb3e4c81ce12809e6aa5815e3
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

Adds a `GET /api/connections/{id}` endpoint that returns one connection in the org by id, plus its most recent sync jobs and the count of in-flight jobs. Stacks on PR #1517 (the list endpoint) and reuses its `connectionSummarySchema` to keep the row shape consistent across both endpoints.

Fixes #1518.

## What it returns

```json
{
  "connection": {
    "id": 1,
    "name": "github-public",
    "connectionType": "github",
    "isDeclarative": false,
    "syncedAt": "2026-07-25T13:59:30.000Z",
    "createdAt": "2026-06-12T08:21:00.000Z",
    "updatedAt": "2026-07-25T13:59:30.000Z",
    "repoCount": 12,
    "inFlightJobCount": 0,
    "latestJob": {
      "id": "ckxxx...",
      "status": "COMPLETED",
      "createdAt": "2026-07-25T13:59:00.000Z",
      "completedAt": "2026-07-25T13:59:30.000Z",
      "durationMs": 30000,
      "errorMessage": null,
      "warningMessages": []
    }
  },
  "recentJobs": [ /* up to ?jobLimit= (default 10, max 50) */ ]
}
```

## Design decisions

- **`?jobLimit=` defaults to 10, capped at 50.** A `take` of 50 is plenty for an operator inspecting why a connection is broken; the cap prevents an unbounded `findMany` from a misbehaving client. The recent-jobs list and the embedded `latestJob` always agree (both come from the same `findMany`).
- **In-flight job count via `connectionSyncJob.groupBy`**, not N+1 per-connection counts. Matches the list endpoint's pattern in PR #1517.
- **Cross-org access returns 404, not 403.** A 403 would tell an attacker that the id exists in some other org. Scoping by `where: { id, orgId: org.id }` collapses that case to "not found in this org" — same pattern the list endpoint uses.
- **`config` is never in the response.** It carries tokens. The regression test for this is a deliberately populated `config` in the Prisma mock so a future change that spreads raw Prisma rows fails the test.
- **Latest-job `errorMessage` and `warningMessages` are exposed verbatim.** The endpoint is auth-gated (any user in the org, not just owners), and the worker message is exactly what an operator needs to debug a failing sync. The warning list is also exposed for the "8 repos were skipped" case that comes up on GitHub Apps with limited permissions.
- **`durationMs` is computed server-side** from `completedAt - createdAt`, so clients don't have to. `null` while the job is still running.
- **Stacks on PR #1517** so the new endpoint inherits the list's `connectionSummarySchema` and the consistent `latestJob` row shape (without `durationMs` or `warningMessages`, since the list endpoint doesn't return full job rows). When #1517 merges, this PR re-resolves on `main` cleanly.

## Test coverage

13 vitest cases in `route.test.ts`:

- 401 when no auth
- 400 when `id` is not a positive integer
- 400 when `id` is zero or negative
- 404 when the connection doesn't exist in the org
- 200 happy path with full document shape
- The `config` field never leaks to the response
- The latest-job `errorMessage` and `warningMessages` are passed through verbatim
- The parsed `jobLimit` is forwarded to Prisma's `findMany` as `take`
- 400 for `jobLimit=0`
- 400 for `jobLimit > 50`
- 200 with empty `recentJobs` for an un-synced connection
- `inFlightJobCount` populated from the `groupBy` query
- Cross-org access returns 404 (not 403)

All 35 web tests pass (13 new + 22 pre-existing). No new TypeScript errors.

## OpenAPI / docs

- Registered the new path under the `systemTag` in `publicApiDocument.ts`.
- Regenerated `docs/api-reference/sourcebot-public.openapi.json` via `yarn openapi:generate`.
- Added the new page to `docs/docs.json` under the System group.
- Added a one-sentence CHANGELOG entry under `[Unreleased] → Added` linking to this PR.

## Risks

- **No new auth model.** Same `withAuth` (any user in the org) as the list endpoint. Connection names, types, and recent sync state are exposed to any user who can sign in.
- **In-flight count is per-connection, not per-org.** If an org has many connections and you need an org-wide queue depth, hit each connection's detail endpoint. The list endpoint exposes per-connection in-flight counts but not an aggregate.

## Future work

- Aggregate org-wide in-flight job count for ops dashboards that want a single number.
- Webhook for `connection_sync_job.status` changes (a polling model is fine for a few connections; not for hundreds).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New org-scoped read APIs expose connection names and sync job errors to any authenticated org member; correctness of org filtering and omitting `config` is security-sensitive, though heavily tested.
> 
> **Overview**
> Introduces **authenticated public APIs** so operators can inspect code-host connection health without using the UI.
> 
> **`GET /api/connections`** returns a paginated org-scoped list with sync metadata (`syncedAt`, `repoCount`, `inFlightJobCount`, trimmed `latestJob`), using `X-Total-Count` and RFC 8288 `Link` headers like other list routes. **`GET /api/connections/{id}`** returns one connection with a fuller `latestJob` (including server-computed `durationMs` and `warningMessages`) and `recentJobs` capped by `?jobLimit=` (default 10, max 50). Both handlers map Prisma rows explicitly so **`config` (tokens) is never serialized**; cross-org lookups use `orgId` in the query and respond with **404**.
> 
> Shared **Zod schemas** in `schemas.ts` and **OpenAPI** registration/schemas are updated, with docs navigation and changelog entries. **`seroval` is bumped to ^1.5.6** in the lockfile. Broad **route tests** cover auth, validation, pagination headers, and the security regressions above.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 603e0ac7e4b5692cbf5f3fa9e0909690c43ac609. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated endpoints to list and retrieve code-host connections, including pagination, sync health/status, repository counts, in-flight job counts, and latest/recent job details.
  * Job results now include computed duration, and sensitive connection configuration is omitted from responses.
* **Documentation**
  * Updated the public API reference, OpenAPI schemas, and changelog to document the new endpoints and response formats (including headers like total count and pagination links).
* **Bug Fixes**
  * Upgraded `seroval` to `^1.5.6`.
* **Tests**
  * Added comprehensive route/handler tests covering auth, validation, missing-connection behavior, pagination, and response shaping.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->