### PR TITLE
fix(web): hide upgrade prompts from non-owner users in the sidebar

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- The "Upgrade to Pro" button in the sidebar footer and the per-item "Upgrade" badges in the default and settings sidebars are now hidden for users who are not an OWNER in the org, since those prompts are only meaningful for the billing decision-maker. [#1524](https://github.com/sourcebot-dev/sourcebot/pull/1524)
+
 ## [5.1.5] - 2026-07-31
 
 ### Fixed

--- a/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/index.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/index.tsx
@@ -59,11 +59,13 @@ export async function DefaultSidebar() {
             collapsible="icon"
             isValidLicenseActive={licenseActive}
             isAskGhEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
+            isOwner={isOwner}
             headerContent={
                 <Nav
                     isSettingsNotificationVisible={isSettingsNotificationVisible}
                     isSignedIn={!!session}
                     homeView={homeView}
+                    isOwner={isOwner}
                 />
             }
         >

--- a/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.test.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.test.tsx
@@ -1,0 +1,98 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { ReactNode } from 'react';
+import { Entitlement } from '@sourcebot/shared';
+
+// next/link renders a plain anchor so we can assert on the rendered href
+// without a Next.js router context.
+vi.mock('next/link', async () => {
+    const { createElement } = await import('react');
+    return {
+        default: ({ href, children }: { href: string; children: ReactNode }) =>
+            createElement('a', { href }, children),
+    };
+});
+
+// `useEntitlements` is a client hook backed by an entitlements context.
+// Stub it so each test can pick the entitlement set it wants.
+const mockEntitlements = vi.hoisted(() => ({
+    current: [] as Entitlement[],
+}));
+
+vi.mock('@/features/entitlements/useEntitlements', () => ({
+    useEntitlements: () => mockEntitlements.current,
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/search',
+}));
+
+// Stub the UpgradeBadge so the test doesn't need the lucide-react tree.
+vi.mock('@/app/(app)/@sidebar/components/upgradeBadge', () => ({
+    UpgradeBadge: () => <span data-testid="upgrade-badge">Upgrade</span>,
+}));
+
+// useIsMobile reads window.matchMedia in a useEffect, which jsdom does
+// not implement. Stub it so the test environment stays stable.
+vi.mock('@/hooks/use-mobile', () => ({
+    useIsMobile: () => false,
+}));
+
+// Import after mocks so the test file's hoisted values take effect.
+const { Nav } = await import('./nav');
+
+const renderNav = (opts: { isOwner?: boolean; isSignedIn?: boolean }) => {
+    // No entitlements: every gated nav item in the default sidebar
+    // ("settings" → audit) should be missing its required entitlement
+    // and would therefore trigger the badge if the isOwner gate is not
+    // in place.
+    mockEntitlements.current = [];
+    return render(
+        // SidebarProvider is required because Nav uses SidebarMenuButton
+        // which calls useSidebar(); the provider's "defaultOpen" is
+        // arbitrary for these tests because we only assert on badge
+        // presence, not on interaction state.
+        <SidebarProvider defaultOpen={true}>
+            <TooltipProvider>
+                <Nav
+                    isSettingsNotificationVisible={false}
+                    isSignedIn={opts.isSignedIn ?? true}
+                    homeView="search"
+                    isOwner={opts.isOwner}
+                />
+            </TooltipProvider>
+        </SidebarProvider>
+    );
+};
+
+const countBadges = (container: HTMLElement) =>
+    container.querySelectorAll('[data-testid="upgrade-badge"]').length;
+
+describe('Nav upgrade badge gating (issue #1524)', () => {
+    test('renders the upgrade badge for an OWNER who is missing the required entitlement', () => {
+        // Without the fix, isOwner is ignored and the badge shows for
+        // everyone. With the fix, the badge only renders for owners —
+        // this asserts the positive case (the badge is reachable at all
+        // when the user IS an owner).
+        const { container } = renderNav({ isOwner: true });
+        expect(countBadges(container)).toBeGreaterThan(0);
+    });
+
+    test('does NOT render the upgrade badge for a non-owner (MEMBER) user', () => {
+        // The same fixture as the positive test, but with isOwner=false.
+        // The badge must disappear — the entitlement check is unchanged,
+        // so the only thing that suppresses the badge is the new isOwner
+        // gate.
+        const { container } = renderNav({ isOwner: false });
+        expect(countBadges(container)).toBe(0);
+    });
+
+    test('does NOT render the upgrade badge for an unauthenticated user', () => {
+        // Unauthenticated visitors hit the sidebar on the landing page
+        // (no auth context, so isOwner defaults to false). No badge.
+        const { container } = renderNav({ isOwner: undefined, isSignedIn: false });
+        expect(countBadges(container)).toBe(0);
+    });
+});

--- a/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.tsx
@@ -31,12 +31,19 @@ interface NavProps {
     isSettingsNotificationVisible?: boolean;
     isSignedIn?: boolean;
     homeView: HomeView;
+    /**
+     * Whether the current user is an OWNER in the org. The per-item
+     * "Upgrade" badge is only meaningful for owners — a MEMBER cannot
+     * act on the upgrade flow, so we hide the badge unless this is true.
+     */
+    isOwner?: boolean;
 }
 
 export function Nav({
     isSettingsNotificationVisible,
     isSignedIn,
-    homeView
+    homeView,
+    isOwner = false,
 }: NavProps) {
     const pathname = usePathname();
     const entitlements = useEntitlements();
@@ -121,6 +128,7 @@ export function Nav({
                     (item.key === "settings" && isSettingsNotificationVisible);
 
                 const showUpgradeBadge =
+                    isOwner &&
                     (item.requiredEntitlement && !entitlements.includes(item.requiredEntitlement));
 
                 return (

--- a/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/index.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/index.tsx
@@ -6,6 +6,8 @@ import { SidebarBase } from "../sidebarBase";
 import { Nav } from "./nav";
 import { SettingsSidebarHeader } from "./header";
 import { isValidLicenseActive } from "@/lib/entitlements";
+import { getAuthContext } from "@/middleware/withAuth";
+import { OrgRole } from "@prisma/client";
 import { env } from "@sourcebot/shared";
 
 export async function SettingsSidebar() {
@@ -18,15 +20,22 @@ export async function SettingsSidebar() {
 
     const licenseActive = await isValidLicenseActive();
 
+    // The "Upgrade" prompts in the sidebar (UpgradeButton in the footer
+    // and the per-item UpgradeBadge) are only meaningful for the org's
+    // owner — a MEMBER cannot act on the upgrade flow. See issue #1524.
+    const authContext = await getAuthContext();
+    const isOwner = !isServiceError(authContext) && authContext.role === OrgRole.OWNER;
+
     return (
         <SidebarBase
             session={session}
             collapsible="none"
             isValidLicenseActive={licenseActive}
             isAskGhEnabled={env.EXPERIMENT_ASK_GH_ENABLED === 'true'}
+            isOwner={isOwner}
             headerContent={<SettingsSidebarHeader />}
         >
-            <Nav groups={sidebarNavGroups} />
+            <Nav groups={sidebarNavGroups} isOwner={isOwner} />
         </SidebarBase>
     );
 }

--- a/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/nav.test.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/nav.test.tsx
@@ -1,0 +1,83 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { ReactNode } from 'react';
+import { Entitlement } from '@sourcebot/shared';
+
+vi.mock('next/link', async () => {
+    const { createElement } = await import('react');
+    return {
+        default: ({ href, children }: { href: string; children: ReactNode }) =>
+            createElement('a', { href }, children),
+    };
+});
+
+const mockEntitlements = vi.hoisted(() => ({
+    current: [] as Entitlement[],
+}));
+
+vi.mock('@/features/entitlements/useEntitlements', () => ({
+    useEntitlements: () => mockEntitlements.current,
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/settings/security',
+}));
+
+vi.mock('@/app/(app)/@sidebar/components/upgradeBadge', () => ({
+    UpgradeBadge: () => <span data-testid="upgrade-badge">Upgrade</span>,
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+    useIsMobile: () => false,
+}));
+
+const { Nav } = await import('./nav');
+
+// Two nav items: one gated on an entitlement the test is missing
+// ('audit'), one ungated (no `requiredEntitlement`). The settings nav
+// real entries (`Security` → `audit`, `License` → none) match this
+// shape — see packages/web/src/app/(app)/settings/layout.tsx.
+const GROUPS = [
+    {
+        label: 'Test group',
+        items: [
+            { href: '/settings/audit', title: 'Audit', icon: 'scroll-text' as const, requiredEntitlement: 'audit' as Entitlement },
+            { href: '/settings/license', title: 'License', icon: 'key-round' as const },
+        ],
+    },
+];
+
+const renderNav = (isOwner?: boolean) => {
+    mockEntitlements.current = [];
+    return render(
+        <SidebarProvider defaultOpen={true}>
+            <TooltipProvider>
+                <Nav groups={GROUPS} isOwner={isOwner} />
+            </TooltipProvider>
+        </SidebarProvider>
+    );
+};
+
+const countBadges = (container: HTMLElement) =>
+    container.querySelectorAll('[data-testid="upgrade-badge"]').length;
+
+describe('settingsSidebar Nav upgrade badge gating (issue #1524)', () => {
+    test('renders the upgrade badge for an OWNER missing the required entitlement', () => {
+        // The ungated "License" item should never show a badge; the
+        // gated "Audit" item should show exactly one when isOwner=true
+        // and the user is missing the audit entitlement.
+        const { container } = renderNav(true);
+        expect(countBadges(container)).toBe(1);
+    });
+
+    test('does NOT render the upgrade badge for a non-owner (MEMBER) user', () => {
+        // Same fixture, isOwner=false: the only entitlement-gated item
+        // is suppressed, so the total drops to 0. The "License" item
+        // was never gated and remains badge-free, so the count is a
+        // clean 0 — the regression assertion for the bug.
+        const { container } = renderNav(false);
+        expect(countBadges(container)).toBe(0);
+    });
+});

--- a/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/nav.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/settingsSidebar/nav.tsx
@@ -66,9 +66,15 @@ export type NavGroup = {
 
 interface NavProps {
     groups: NavGroup[];
+    /**
+     * Whether the current user is an OWNER in the org. The per-item
+     * "Upgrade" badge is only meaningful for owners — a MEMBER cannot
+     * act on the upgrade flow, so we hide the badge unless this is true.
+     */
+    isOwner?: boolean;
 }
 
-export function Nav({ groups }: NavProps) {
+export function Nav({ groups, isOwner = false }: NavProps) {
     const pathname = usePathname();
     const entitlements = useEntitlements();
 
@@ -85,6 +91,7 @@ export function Nav({ groups }: NavProps) {
                                     : pathname === item.href;
 
                                 const showUpgradeBadge =
+                                    isOwner &&
                                     (item.requiredEntitlement && !entitlements.includes(item.requiredEntitlement));
                                 
                                 const Icon = item.icon ? iconMap[item.icon] : undefined;

--- a/packages/web/src/app/(app)/@sidebar/components/sidebarBase.test.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/sidebarBase.test.tsx
@@ -1,0 +1,133 @@
+import { describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/react';
+import { SidebarProvider } from '@/components/ui/sidebar';
+import type { ReactNode } from 'react';
+
+// The SidebarBase component pulls in a lot of client-only dependencies
+// (theme, keymap, PostHog, signOut, lucide icons). Stub the heavy
+// imports so the test only exercises the upgrade CTA gate, which is
+// the only behaviour this PR changes.
+vi.mock('@/components/ui/dropdown-menu', () => ({
+    DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuGroup: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuItem: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuPortal: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuRadioGroup: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuRadioItem: () => null,
+    DropdownMenuSeparator: () => null,
+    DropdownMenuSub: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuSubContent: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuSubTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+    DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/app/components/sourcebotLogo', () => ({
+    SourcebotLogo: () => <span data-testid="sourcebot-logo" />,
+}));
+
+vi.mock('@/components/userAvatar', () => ({
+    UserAvatar: () => <span data-testid="user-avatar" />,
+}));
+
+vi.mock('@/hooks/use-mobile', () => ({
+    useIsMobile: () => false,
+}));
+
+vi.mock('@/hooks/useKeymapType', () => ({
+    useKeymapType: () => ['default', vi.fn()] as const,
+}));
+
+vi.mock('next-themes', () => ({
+    useTheme: () => ({ theme: 'light', setTheme: vi.fn(), resolvedTheme: 'light' }),
+}));
+
+vi.mock('posthog-js', () => ({
+    default: { capture: vi.fn() },
+}));
+
+vi.mock('next-auth/react', () => ({
+    signOut: vi.fn(),
+}));
+
+vi.mock('./whatsNewSidebarButton', () => ({
+    WhatsNewSidebarButton: () => null,
+}));
+
+vi.mock('./bookACallSidebarButton', () => ({
+    BookACallSidebarButton: () => null,
+}));
+
+// The UpgradeButton component itself makes a fetch call to offers.
+// Stub the inner button to just render a recognisable marker so the
+// test can assert on its presence vs absence.
+vi.mock('./upgradeButton', () => ({
+    UpgradeButton: () => <button data-testid="upgrade-button">Upgrade to Pro</button>,
+}));
+
+vi.mock('lucide-react', () => ({
+    ArrowLeftToLineIcon: () => null,
+    ArrowRightToLineIcon: () => null,
+    ChevronsUpDown: () => null,
+    CodeIcon: () => null,
+    Laptop: () => null,
+    LogIn: () => null,
+    LogOut: () => null,
+    Menu: () => null,
+    Moon: () => null,
+    SettingsIcon: () => null,
+    Sun: () => null,
+    UserIcon: () => null,
+}));
+
+vi.mock('@/app/components/keyboardShortcutHint', () => ({
+    KeyboardShortcutHint: () => null,
+}));
+
+const { SidebarBase } = await import('./sidebarBase');
+
+const renderSidebarBase = (opts: { isOwner: boolean; isValidLicenseActive: boolean }) => {
+    return render(
+        <SidebarProvider defaultOpen={true}>
+            <SidebarBase
+                session={null}
+                isValidLicenseActive={opts.isValidLicenseActive}
+                isAskGhEnabled={false}
+                isOwner={opts.isOwner}
+                headerContent={<div data-testid="header">header</div>}
+            >
+                <div data-testid="child">child</div>
+            </SidebarBase>
+        </SidebarProvider>
+    );
+};
+
+const hasUpgradeButton = (container: HTMLElement) =>
+    container.querySelectorAll('[data-testid="upgrade-button"]').length > 0;
+
+describe('SidebarBase UpgradeButton gating (issue #1524)', () => {
+    test('renders the UpgradeButton for an OWNER when no license is active', () => {
+        // Owner + invalid license → button shows. This is the existing
+        // happy path the bug is preserving; the assertion makes sure
+        // the gate didn't accidentally hide it for owners too.
+        const { container } = renderSidebarBase({ isOwner: true, isValidLicenseActive: false });
+        expect(hasUpgradeButton(container)).toBe(true);
+    });
+
+    test('does NOT render the UpgradeButton for a non-owner (MEMBER) even when no license is active', () => {
+        // Member + invalid license → button hidden. This is the
+        // regression test for the bug. The "no license" condition is
+        // still true, so the only thing that suppresses the button is
+        // the new isOwner gate.
+        const { container } = renderSidebarBase({ isOwner: false, isValidLicenseActive: false });
+        expect(hasUpgradeButton(container)).toBe(false);
+    });
+
+    test('does NOT render the UpgradeButton for an OWNER when a license is already active', () => {
+        // Owner + valid license → button hidden. This is the existing
+        // gate (was `!isValidLicenseActive`); adding it to the suite
+        // makes sure the isOwner refactor didn't break it.
+        const { container } = renderSidebarBase({ isOwner: true, isValidLicenseActive: true });
+        expect(hasUpgradeButton(container)).toBe(false);
+    });
+});

--- a/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
+++ b/packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx
@@ -60,9 +60,16 @@ interface SidebarBaseProps {
     children: ReactNode;
     isValidLicenseActive: boolean;
     isAskGhEnabled: boolean;
+    /**
+     * Whether the current user is an OWNER in the org. The "Upgrade" CTA
+     * in the sidebar footer is only meaningful for owners — a MEMBER
+     * (or an unauthenticated visitor) cannot act on it, so we hide it
+     * unless this is true.
+     */
+    isOwner?: boolean;
 }
 
-export function SidebarBase({ session, collapsible = "icon", headerContent, children, isValidLicenseActive, isAskGhEnabled }: SidebarBaseProps) {
+export function SidebarBase({ session, collapsible = "icon", headerContent, children, isValidLicenseActive, isAskGhEnabled, isOwner = false }: SidebarBaseProps) {
     const [isScrolled, setIsScrolled] = useState(false);
     const contentRef = useRef<HTMLDivElement>(null);
     const isMobile = useIsMobile();
@@ -114,7 +121,7 @@ export function SidebarBase({ session, collapsible = "icon", headerContent, chil
                     {children}
                 </SidebarContent>
                 <SidebarFooter className="border-t border-sidebar-border">
-                    {!isValidLicenseActive && <UpgradeButton />}
+                    {isOwner && !isValidLicenseActive && <UpgradeButton />}
                     {
                         (collapsible !== "none" && !isMobile) &&
                         <CollapseSidebarButton />


### PR DESCRIPTION
## Summary

The "Upgrade to Pro" button in the sidebar footer and the per-item "Upgrade" badges in the default and settings sidebars were rendered to any signed-in user, not just to the org's OWNER. A MEMBER (or a former owner who lost the role) would see prompts they cannot act on.

Fixes #1524.

## What changes

Thread an `isOwner` prop from the sidebar index files through the `Nav` and `SidebarBase` components. Both `UpgradeBadge` rendering in the two `Nav` components and `UpgradeButton` rendering in `SidebarBase` are now gated on `isOwner`.

`defaultSidebar/index.tsx` already computed `isOwner` for the connection-stats notification dot — that value is now also passed to `<Nav>` and `<SidebarBase>`. `settingsSidebar/index.tsx` did not compute it at all; it now does (using the same `getAuthContext` + `OrgRole.OWNER` pattern) and threads it through.

## Files

- `packages/web/src/app/(app)/@sidebar/components/sidebarBase.tsx` — added `isOwner?: boolean` to `SidebarBaseProps`, gated the `UpgradeButton` on `isOwner && !isValidLicenseActive`.
- `packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.tsx` — added `isOwner?: boolean` to `NavProps`, gated `showUpgradeBadge` on `isOwner && missingEntitlement`.
- `packages/web/src/app/(app)/@sidebar/components/defaultSidebar/index.tsx` — pass `isOwner={isOwner}` to `<Nav>` and `<SidebarBase>` (the value was already computed at line 43).
- `packages/web/src/app/(app)/@sidebar/components/settingsSidebar/nav.tsx` — same pattern as `defaultSidebar/nav.tsx`.
- `packages/web/src/app/(app)/@sidebar/components/settingsSidebar/index.tsx` — compute `isOwner` (same pattern as `defaultSidebar/index.tsx`) and pass to `<Nav>` and `<SidebarBase>`.
- `packages/web/src/app/(app)/@sidebar/components/defaultSidebar/nav.test.tsx` — 3 vitest cases covering: (1) badge renders for an OWNER missing the entitlement, (2) badge is hidden for a non-owner MEMBER, (3) badge is hidden for an unauthenticated user.
- `CHANGELOG.md` — one-sentence entry under `[Unreleased] → Fixed`.

## Why this is in scope

The settings pages already gate on OWNER via `authenticatedPage(..., { minRole: OrgRole.OWNER, ... })`, so the upsell cards inside `/settings/security` and `/settings/audit` were never affected — only the shared sidebar was missing the check. The fix lives in the sidebar, not in the entitlement-gated pages, because the sidebar is shared across all users.

## Why I didn't push the gate into `UpgradeBadge` itself

`UpgradeBadge` is a tiny presentational element. Gating belongs in the parent `Nav` so all callers (default and settings) get the same behaviour without each importing the auth context. The settings sidebar would otherwise need its own `getAuthContext` call just to render the badge.

## Test coverage

3 vitest cases in `nav.test.tsx`:

- **OWNER + missing entitlement → badge renders.** Locks in the positive case so a future change that drops the `isOwner` gate entirely is caught (the badge would still render for non-owners if the gate is removed, and the test suite would flip red).
- **MEMBER + missing entitlement → badge is hidden.** This is the regression test for the bug. The entitlement check is unchanged, so the only thing that suppresses the badge in this case is the new `isOwner` gate.
- **Unauthenticated user → badge is hidden.** The default `isOwner = false` means a missing prop is treated the same as a MEMBER, which matches the production fallback path.

The 7 pre-existing `getEnv is not a function` failures in `ee/askmcp/...`, `ee/permissionSyncStatus/...`, etc. are unchanged by this PR — they fail to *load* due to the OTel SDK version mismatch, before any of my code runs.

## Backward compatibility

Pure UI behaviour change. No API, no schema, no migration. Existing users on the OWNER role see no change. Non-owner users stop seeing prompts they couldn't act on.

## Risks

Minimal. The settings pages already gate on OWNER, so the upsell cards inside `/settings/security` and `/settings/audit` are unaffected. The only behaviour change is in the shared sidebar, which is what the issue called out.

## Future work

- A `hasEntitlement('org-management')` check on the settings pages' `UpgradeBadge` instances is a related but separate concern — those pages are already owner-only, so the badge is only seen by owners, but a future "view-only settings" feature would need to gate them. Not in scope for this PR.
- A shared `<RoleGate role="OWNER">` component would consolidate the `isOwner && ...` pattern across the sidebar and the settings pages. Punted; one-off gate is fine until we have three or more call sites.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only visibility change with no API or auth logic changes; owners keep prior behavior.
> 
> **Overview**
> Fixes [#1524](https://github.com/sourcebot-dev/sourcebot/issues/1524) by limiting sidebar upgrade CTAs to org **owners**, who are the ones who can act on billing.
> 
> An **`isOwner`** flag (from `getAuthContext()` + `OrgRole.OWNER`) is passed from the default and settings sidebar entry points into **`SidebarBase`** and both **`Nav`** implementations. The footer **Upgrade to Pro** button now requires `isOwner && !isValidLicenseActive`, and per-nav **Upgrade** badges require `isOwner` in addition to the existing missing-entitlement check. The default sidebar reuses owner detection it already had for settings notifications; the settings sidebar adds the same lookup.
> 
> Vitest coverage was added for owner vs member vs unauthenticated badge/button visibility, plus a changelog entry under **Unreleased → Fixed**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 680bfb821096533d14b1152f1ba4a5e1d1426bc3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Upgrade prompts in the sidebar are now shown only to organization owners.
  * Non-owner members and unauthenticated users no longer see the “Upgrade to Pro” button or upgrade badges.
  * Updated default and settings sidebars to apply the same role-based visibility consistently.

* **Documentation**
  * Added an Unreleased changelog entry describing the sidebar upgrade prompt changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->