### PR TITLE
fix(web): scope file-search recents to (repo, revision) in the browse dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `brace-expansion` to `^1.1.17`/`^2.1.3`/`^5.0.8`. [#1527](https://github.com/sourcebot-dev/sourcebot/pull/1527)
-- The browse file-search dialog's recently-opened files are now scoped to the `(repo, revision)` tuple, so switching branches in the same repo no longer carries over suggestions from a different revision that may not exist on the current one. [#1387](https://github.com/sourcebot-dev/sourcebot/issues/1387)
+- The browse file-search dialog's recently-opened files are now scoped to the `(repo, revision)` tuple, so switching branches in the same repo no longer carries over suggestions from a different revision that may not exist on the current one. [#1529](https://github.com/sourcebot-dev/sourcebot/pull/1529)
 
 ## [5.1.5] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `brace-expansion` to `^1.1.17`/`^2.1.3`/`^5.0.8`. [#1527](https://github.com/sourcebot-dev/sourcebot/pull/1527)
+- The browse file-search dialog's recently-opened files are now scoped to the `(repo, revision)` tuple, so switching branches in the same repo no longer carries over suggestions from a different revision that may not exist on the current one. [#1387](https://github.com/sourcebot-dev/sourcebot/issues/1387)
 
 ## [5.1.5] - 2026-07-31
 

--- a/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.test.tsx
+++ b/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.test.tsx
@@ -1,0 +1,122 @@
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { render } from '@testing-library/react';
+
+// Stub `useLocalStorage` so the test can capture the key the component
+// passes and assert on it. Without this, we'd be asserting on real
+// localStorage (which jsdom does provide, but the key changes per
+// revision and the test only wants to verify the key format).
+const capturedKeys: string[] = [];
+vi.mock('usehooks-ts', () => ({
+    useLocalStorage: <T,>(key: string, initial: T) => {
+        capturedKeys.push(key);
+        return [initial, vi.fn()] as [T, (v: T) => void];
+    },
+}));
+
+// Make the params mock swappable per-test. We use a single mutable
+// holder so each `it` can set its own (repoName, revisionName) tuple
+// before rendering.
+const mockParams: { repoName: string; revisionName: string | undefined } = {
+    repoName: 'github.com/foo/bar',
+    revisionName: 'main',
+};
+vi.mock('@/app/(app)/browse/hooks/useBrowseParams', () => ({
+    useBrowseParams: () => ({ repoName: mockParams.repoName, revisionName: mockParams.revisionName }),
+}));
+vi.mock('@/app/(app)/browse/hooks/useBrowseState', () => ({
+    useBrowseState: () => ({ state: { isFileSearchOpen: false }, updateBrowseState: vi.fn() }),
+}));
+vi.mock('@/app/(app)/browse/hooks/useBrowseNavigation', () => ({
+    useBrowseNavigation: () => ({ navigateToPath: vi.fn() }),
+}));
+
+vi.mock('next/navigation', () => ({
+    usePathname: () => '/browse/github.com/foo/bar@main/-/tree/src',
+}));
+
+vi.mock('@tanstack/react-query', () => ({
+    useQuery: () => ({ data: [], isLoading: false, isError: false }),
+}));
+
+vi.mock('@/app/api/(client)/client', () => ({
+    getFiles: vi.fn(),
+}));
+
+vi.mock('react-hotkeys-hook', () => ({
+    useHotkeys: vi.fn(),
+}));
+
+vi.mock('@/app/(app)/browse/components/fileTreeItemIcon', () => ({
+    FileTreeItemIcon: () => null,
+}));
+
+vi.mock('@/components/ui/command', () => ({
+    Command: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CommandEmpty: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CommandGroup: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CommandInput: () => null,
+    CommandItem: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    CommandList: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+vi.mock('@/components/ui/dialog', () => ({
+    Dialog: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DialogContent: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+    DialogDescription: () => null,
+    DialogTitle: () => null,
+}));
+
+const { FileSearchCommandDialog } = await import('./fileSearchCommandDialog');
+
+const renderWithParams = () => {
+    capturedKeys.length = 0;
+    render(<FileSearchCommandDialog />);
+    return capturedKeys[0];
+};
+
+describe('FileSearchCommandDialog recents key (issue #1387)', () => {
+    afterEach(() => {
+        // Reset the mock params to the default between tests so a
+        // mutation in one test doesn't leak into the next.
+        mockParams.repoName = 'github.com/foo/bar';
+        mockParams.revisionName = 'main';
+    });
+
+    test('scopes the recents localStorage key to the (repo, revision) tuple', () => {
+        // The previous key was `recentlyOpenedFiles-${repoName}` — same
+        // across revisions. After the fix, the key is scoped per
+        // revision so switching branches doesn't carry over suggestions
+        // from another revision that may not exist on the current one.
+        mockParams.repoName = 'github.com/foo/bar';
+        mockParams.revisionName = 'main';
+        const key = renderWithParams();
+        expect(key).toBe('recentlyOpenedFiles-github.com/foo/bar-main');
+    });
+
+    test('uses the HEAD fallback for the "no revision in URL" case', () => {
+        // The file-fetch on the next line uses `revisionName ?? 'HEAD'`
+        // as the default; the recents key needs to agree so the user
+        // sees a consistent recents list for the "default branch" view.
+        mockParams.repoName = 'github.com/foo/bar';
+        mockParams.revisionName = undefined;
+        const key = renderWithParams();
+        expect(key).toBe('recentlyOpenedFiles-github.com/foo/bar-HEAD');
+    });
+
+    test('produces a different key for a different revision in the same repo', () => {
+        // The bug was: switching from `main` to `feature/foo` showed
+        // recents from `main`. After the fix, the keys differ, so the
+        // recents are naturally scoped. This test asserts that the
+        // keys differ for the two revisions.
+        mockParams.repoName = 'github.com/foo/bar';
+        mockParams.revisionName = 'main';
+        const keyMain = renderWithParams();
+
+        mockParams.revisionName = 'feature/foo';
+        const keyFeature = renderWithParams();
+
+        expect(keyMain).toBe('recentlyOpenedFiles-github.com/foo/bar-main');
+        expect(keyFeature).toBe('recentlyOpenedFiles-github.com/foo/bar-feature/foo');
+        expect(keyMain).not.toBe(keyFeature);
+    });
+});

--- a/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.test.tsx
+++ b/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.test.tsx
@@ -90,7 +90,7 @@ describe('FileSearchCommandDialog recents key (issue #1387)', () => {
         mockParams.repoName = 'github.com/foo/bar';
         mockParams.revisionName = 'main';
         const key = renderWithParams();
-        expect(key).toBe('recentlyOpenedFiles-github.com/foo/bar-main');
+        expect(key).toBe('recentlyOpenedFiles::["github.com/foo/bar","main"]');
     });
 
     test('uses the HEAD fallback for the "no revision in URL" case', () => {
@@ -100,7 +100,7 @@ describe('FileSearchCommandDialog recents key (issue #1387)', () => {
         mockParams.repoName = 'github.com/foo/bar';
         mockParams.revisionName = undefined;
         const key = renderWithParams();
-        expect(key).toBe('recentlyOpenedFiles-github.com/foo/bar-HEAD');
+        expect(key).toBe('recentlyOpenedFiles::["github.com/foo/bar","HEAD"]');
     });
 
     test('produces a different key for a different revision in the same repo', () => {
@@ -115,8 +115,24 @@ describe('FileSearchCommandDialog recents key (issue #1387)', () => {
         mockParams.revisionName = 'feature/foo';
         const keyFeature = renderWithParams();
 
-        expect(keyMain).toBe('recentlyOpenedFiles-github.com/foo/bar-main');
-        expect(keyFeature).toBe('recentlyOpenedFiles-github.com/foo/bar-feature/foo');
+        expect(keyMain).toBe('recentlyOpenedFiles::["github.com/foo/bar","main"]');
+        expect(keyFeature).toBe('recentlyOpenedFiles::["github.com/foo/bar","feature/foo"]');
         expect(keyMain).not.toBe(keyFeature);
+    });
+
+    test('does not collide for tuples whose naive-dash concatenation would be ambiguous', () => {
+        // CodeRabbit finding: a naive `<repoName>-<revisionName>` format
+        // collides for tuples like (`foo-bar`, `baz`) vs (`foo`, `bar-baz`).
+        // The JSON-encoded format is collision-free by construction, so
+        // this test asserts that two such tuples produce different keys.
+        mockParams.repoName = 'foo-bar';
+        mockParams.revisionName = 'baz';
+        const keyA = renderWithParams();
+
+        mockParams.repoName = 'foo';
+        mockParams.revisionName = 'bar-baz';
+        const keyB = renderWithParams();
+
+        expect(keyA).not.toBe(keyB);
     });
 });

--- a/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
+++ b/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
@@ -35,7 +35,16 @@ export const FileSearchCommandDialog = () => {
     const [searchQuery, setSearchQuery] = useState('');
     const { navigateToPath } = useBrowseNavigation();
 
-    const [recentlyOpened, setRecentlyOpened] = useLocalStorage<FileTreeItem[]>(`recentlyOpenedFiles-${repoName}`, []);
+    // Scope the recents to the (repo, revision) tuple so a switch
+    // branches doesn't carry over suggestions from another revision
+    // that may not exist on the current one. The 'HEAD' default
+    // matches the file-fetch fallback on the next line so the
+    // recents key and the file list key agree on the "no revision
+    // in URL" case. Issue #1387.
+    const [recentlyOpened, setRecentlyOpened] = useLocalStorage<FileTreeItem[]>(
+        `recentlyOpenedFiles-${repoName}-${revisionName ?? 'HEAD'}`,
+        [],
+    );
 
     useHotkeys("mod+p", (event) => {
         event.preventDefault();

--- a/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
+++ b/packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx
@@ -40,9 +40,11 @@ export const FileSearchCommandDialog = () => {
     // that may not exist on the current one. The 'HEAD' default
     // matches the file-fetch fallback on the next line so the
     // recents key and the file list key agree on the "no revision
-    // in URL" case. Issue #1387.
+    // in URL" case. The components are JSON-encoded to avoid
+    // boundary ambiguity (e.g. `foo-bar` + `baz` vs `foo` + `bar-baz`
+    // would otherwise produce the same key). Issue #1387.
     const [recentlyOpened, setRecentlyOpened] = useLocalStorage<FileTreeItem[]>(
-        `recentlyOpenedFiles-${repoName}-${revisionName ?? 'HEAD'}`,
+        `recentlyOpenedFiles::${JSON.stringify([repoName, revisionName ?? 'HEAD'])}`,
         [],
     );
 


### PR DESCRIPTION
## Summary

The browse file-search dialog (`mod+p`) stored recently opened files in `localStorage` under a key scoped only by `repoName`. A user who opened a file on `main`, switched to `feature/foo`, and re-opened the dialog would see recents from `main` — paths that may not exist on the new revision. Selecting one navigated with the new revision and landed on a 404.

Fix: scope the `localStorage` key to the `(repoName, revisionName)` tuple, so a branch switch in the same repo yields a fresh recents list scoped to the new revision.

Fixes #1387.

## What changes

`packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx:38` — the `useLocalStorage` key changes from `` `recentlyOpenedFiles-${repoName}` `` to `` `recentlyOpenedFiles-${repoName}-${revisionName ?? 'HEAD'}` ``. The `'HEAD'` default matches the file-fetch fallback on the next line, so the recents key and the file list key agree on the "no revision in URL" case.

The `setRecentlyOpened` callback does not need to change — `useLocalStorage` from `usehooks-ts` writes to whatever key the current key string resolves to. Switching revisions automatically re-renders the dialog with the new key, which starts empty (or with whatever recents the user previously stored under that exact `(repo, revision)` tuple).

Old keys (`` `recentlyOpenedFiles-<repo>` ``) become orphaned entries in `localStorage` and are ignored. No migration is required — the worst case is the user loses the recents accumulated under the old key, which is the bug being fixed.

## Files

- `packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.tsx` — the key-derivation change (one line, plus a 4-line comment explaining the rationale).
- `packages/web/src/app/(app)/browse/components/fileSearchCommandDialog.test.tsx` — 3 new vitest cases.
- `CHANGELOG.md` — one-sentence entry under `[Unreleased] → Fixed`.

## Why this is in scope

The component already reads `revisionName` from `useBrowseParams()` on the line above and uses it to fetch the file list (`getFiles({ repoName, revisionName: revisionName ?? 'HEAD' })`), so the data was already revision-scoped. The `localStorage` key was the only thing that wasn't. The fix is a single key-derivation change that brings the persistence layer in line with the data layer that's already there.

## Test coverage

3 vitest cases in `fileSearchCommandDialog.test.tsx`:

- **Scopes the recents localStorage key to the `(repo, revision)` tuple.** Asserts the key is `recentlyOpenedFiles-github.com/foo/bar-main` for `(github.com/foo/bar, main)`. The regression assertion for the bug.
- **Uses the `HEAD` fallback for the "no revision in URL" case.** The file-fetch on the next line uses `revisionName ?? 'HEAD'` as the default; the recents key needs to agree so the user sees a consistent recents list for the "default branch" view. Asserts the key is `recentlyOpenedFiles-github.com/foo/bar-HEAD` when `revisionName` is `undefined`.
- **Produces a different key for a different revision in the same repo.** The bug was: switching from `main` to `feature/foo` showed recents from `main`. After the fix, the keys differ, so the recents are naturally scoped. Asserts `main` and `feature/foo` produce different keys for the same repo.

The test stubs `useLocalStorage` from `usehooks-ts` to capture the key the component passes (without this, we'd be asserting on real `localStorage`, which jsdom does provide but is per-test mutable state that's harder to reason about). The other hooks the dialog uses (`useBrowseParams`, `useBrowseState`, `useQuery`, etc.) are stubbed so the test only exercises the key derivation.

3/3 tests pass; 7 pre-existing OpenTelemetry-setup failures in `ee/askmcp/...` and `ee/permissionSyncStatus/...` are unchanged by this PR (they fail to *load* due to the OTel SDK version mismatch, before any of my code runs).

## Backward compatibility

Pure behaviour change. Old keys' data is left in `localStorage` and ignored, so a user upgrading from a previous version simply starts with an empty recents list on their next branch switch. No data loss on the server side.

## Risks

Minimal. The default `'HEAD'` matches the file-fetch default on the next line, so the recents key and the file list key agree on the "no revision in URL" case. If a future change splits `'HEAD'` and `undefined` semantics, both sides will need to be updated in lockstep — but that's already true for the file fetch.

## Future work

- A "clear recents" UI button next to the recents list. Not in scope for this PR; the bug was about cross-revision leakage, not about retention control.
- Migrating recents to the server (Prisma `userRecentFile` table scoped by `(userId, repoId, revisionName)`). Punted: a `localStorage` key is the lowest-cost fix and matches the existing pattern. If a user clears their browser data they lose their recents, but they also lose their session, so this is fine.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-only localStorage key change in the browse file-search dialog; no auth, API, or server impact beyond users starting fresh recents per revision.
> 
> **Overview**
> Fixes browse **mod+p** file search showing **recently opened** paths from another branch after a revision switch (issue #1387).
> 
> **`FileSearchCommandDialog`** now persists recents under a `localStorage` key derived from **`[repoName, revisionName ?? 'HEAD']`** via `recentlyOpenedFiles::${JSON.stringify(...)}`, instead of repo name only. That aligns recents with the same revision default used for `getFiles`, and avoids ambiguous keys that a simple `repo-revision` string could collide on. Prior repo-only keys are left unused (no migration).
> 
> Adds **`fileSearchCommandDialog.test.tsx`** (Vitest) to lock the key format, `HEAD` when revision is missing, per-revision separation, and collision safety. **CHANGELOG** documents the fix under `[Unreleased]`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b0eb9aeeb8ef4f71c007c12faa8ad3c91c7d572. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Browse file-search suggestions and recently opened files are now scoped to the selected repository and revision.
  * Suggestions no longer carry over when switching branches or revisions.
  * Searches without a specified revision consistently use `HEAD`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->