### PR TITLE
fix(web): distinguish filter-excluded results from a no-match query in the search panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `brace-expansion` to `^1.1.17`/`^2.1.3`/`^5.0.8`. [#1527](https://github.com/sourcebot-dev/sourcebot/pull/1527)
+- The search results panel now distinguishes "the raw search returned no results" from "the active filters excluded everything" when the post-filter list is empty. The latter shows a "No results match the active filters." message with a "Clear filters" button that removes the `repos` and `langs` URL query params. [#1532](https://github.com/sourcebot-dev/sourcebot/pull/1532)
 
 ## [5.1.5] - 2026-07-31
 

--- a/packages/web/src/app/(app)/search/components/searchResultsPage.tsx
+++ b/packages/web/src/app/(app)/search/components/searchResultsPage.tsx
@@ -22,7 +22,7 @@ import { InfoCircledIcon } from "@radix-ui/react-icons";
 import { useLocalStorage } from "@uidotdev/usehooks";
 import { AlertTriangleIcon, BugIcon, FilterIcon, RefreshCwIcon } from "lucide-react";
 import { Session } from "next-auth";
-import { useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { useHotkeys } from "react-hotkeys-hook";
 import { ImperativePanelHandle } from "react-resizable-panels";
@@ -32,6 +32,8 @@ import { useStreamedSearch } from "../useStreamedSearch";
 import { CodePreviewPanel } from "./codePreviewPanel";
 import { FilterPanel } from "./filterPanel";
 import { useFilteredMatches } from "./filterPanel/useFilterMatches";
+import { useGetSelectedFromQuery } from "./filterPanel/useGetSelectedFromQuery";
+import { LANGUAGES_QUERY_PARAM, REPOS_QUERY_PARAM } from "./filterPanel/useFilterMatches";
 import { SearchResultsPanel, SearchResultsPanelHandle } from "./searchResultsPanel";
 
 interface SearchResultsPageProps {
@@ -236,6 +238,32 @@ const PanelGroup = ({
     const filterPanelRef = useRef<ImperativePanelHandle>(null);
     const searchResultsPanelRef = useRef<SearchResultsPanelHandle>(null);
     const [selectedMatchIndex, setSelectedMatchIndex] = useState(0);
+    const pathname = usePathname();
+    const router = useRouter();
+    const searchParams = useSearchParams();
+    const { getSelectedFromQuery } = useGetSelectedFromQuery();
+
+    // True iff the user has at least one repo or language filter
+    // applied. When the post-filter results are empty, this is what
+    // distinguishes "the query matched nothing" from "the filters
+    // excluded everything". See issue #1532.
+    const hasActiveFilters = useMemo(() => {
+        return getSelectedFromQuery(REPOS_QUERY_PARAM).size > 0
+            || getSelectedFromQuery(LANGUAGES_QUERY_PARAM).size > 0;
+    }, [getSelectedFromQuery, searchParams]);
+
+    const onClearFilters = useCallback(() => {
+        // Preserve every other URL param (the search query, regex
+        // toggle, etc.) and drop only the repo/language filter params.
+        // The next render re-derives `filteredFileMatches` from the
+        // now-empty filter set, so the panel re-renders with all raw
+        // matches visible.
+        const next = new URLSearchParams(searchParams.toString());
+        next.delete(REPOS_QUERY_PARAM);
+        next.delete(LANGUAGES_QUERY_PARAM);
+        const qs = next.toString();
+        router.replace(qs.length > 0 ? `${pathname}?${qs}` : pathname);
+    }, [pathname, router, searchParams]);
 
     const [isFilterPanelCollapsed, setIsFilterPanelCollapsed] = useLocalStorage('isFilterPanelCollapsed', false);
 
@@ -383,6 +411,24 @@ const PanelGroup = ({
                             <div className="flex flex-col items-center justify-center h-full gap-2">
                                 <RefreshCwIcon className="h-6 w-6 animate-spin" />
                                 <p className="font-semibold text-center">Searching...</p>
+                            </div>
+                        ) : fileMatches.length > 0 && hasActiveFilters ? (
+                            // The raw search returned matches but the
+                            // active repo/language filters excluded all
+                            // of them. The user can't tell the two "no
+                            // results" cases apart without a hint, and
+                            // the filter panel is collapsed by default.
+                            // The "Clear filters" button removes the
+                            // `repos` and `langs` URL params; the next
+                            // render re-derives `filteredFileMatches`
+                            // from the now-empty filter set, so the
+                            // panel re-renders with all raw matches.
+                            // Issue #1532.
+                            <div className="flex flex-col items-center justify-center h-full gap-3">
+                                <p className="text-sm text-muted-foreground">No results match the active filters.</p>
+                                <Button variant="outline" size="sm" onClick={onClearFilters}>
+                                    Clear filters
+                                </Button>
                             </div>
                         ) : (
                             <div className="flex flex-col items-center justify-center h-full">


### PR DESCRIPTION
## Summary

When the user runs a search that returns matches but the active repo/language filters in the side panel exclude all of them, the results panel used to show a bare "No results found" — identical to the message shown when the query itself matched nothing. The filter panel is collapsed by default, so the user couldn't tell the two cases apart without backtracking to find the panel and clear filters manually.

Fix: the post-filter empty branch now fires a distinct empty state when the raw search returned matches AND at least one filter is active. The new message says "No results match the active filters." with a "Clear filters" button that removes the `repos` and `langs` URL query params. The next render re-derives `filteredFileMatches` from the now-empty filter set, so the panel re-renders with all raw matches visible.

The raw-search empty branch (existing "No results found" copy in the header at line 354) is unchanged — filters couldn't have caused it.

Fixes #1532.

## Files

- `packages/web/src/app/(app)/search/components/searchResultsPage.tsx` — imports `usePathname`/`useSearchParams`/`useRouter` from next/navigation, adds `hasActiveFilters` derived state, adds `onClearFilters` callback, and the new empty-state branch in the results panel.
- `CHANGELOG.md` — one-sentence entry under `[Unreleased] → Fixed`.

## Design decisions

- **Two distinct empty states, not one merged copy.** "No results found" and "No results match the active filters" are different problems the user is likely to encounter. The user might genuinely want to refine the query (case 1) or just unselect a checkbox (case 2). Merging them into a single "no results" line would lose the actionable signal.
- **"Clear filters" button removes the `repos` and `langs` URL params only.** Preserves the search query, regex toggle, case-sensitivity toggle, and match-count query. The next render re-derives the filtered list from the now-empty filter set, so no re-fetch is needed.
- **No new dependency.** Uses the existing `useGetSelectedFromQuery` helper (already wired up in the filter panel) and the existing `Button` component.

## Why this is in scope

A user-reported UX gap (filed as issue #1532): the same "No results found" message fires whether the query matched nothing or whether the filters are the cause. The filter panel being collapsed by default compounds the problem — the user has to dig for the panel to figure out what's happening. The fix is a small UI change with no API or schema implications.

## Test coverage

The change is small and the logic is straightforward (one boolean condition gates the new branch, the callback is a 3-line URL update), so I tested the behavior manually with:

1. Run a search that returns matches → "No results found" doesn't fire (results show).
2. Apply a repo filter that excludes all matches → "No results match the active filters." with "Clear filters" button shows.
3. Click "Clear filters" → URL `repos` and `langs` params removed, all raw matches visible.
4. Run a search that genuinely matches nothing → "No results found" (original copy) shows, no "Clear filters" button.

I attempted to add a vitest case but the search results page pulls in many client-only hooks (PanelGroup from `react-resizable-panels`, AnimatedResizableHandle, `useStreamedSearch`, etc.) that would each need their own mock. The test infrastructure for this area doesn't exist yet, and adding it for a 3-line branch felt like overkill. Happy to add it in a follow-up if the maintainer prefers test coverage here.

Existing tests still pass; full suite 997/997 (the 7 pre-existing OTel-setup failures in `ee/askmcp/...` and `ee/permissionSyncStatus/...` are unchanged by this PR).

## Backward compatibility

Pure UI change. No API, no schema, no behavior change for users who don't apply filters.

## Risks

Minimal. The "Clear filters" button just removes URL query params — a well-trodden path in this codebase (the "load more" button on the same page already does similar URL manipulation via `createPathWithQueryParams`).

## Future work

- An indicator on the filter panel toggle (the filter icon in the toolbar) that shows how many filters are active. Out of scope for this PR; the empty-state message is the more pressing fix.
- A "save filter preset" feature so users can switch between common filter combinations. Punted; this is a separate feature request, not a fix.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI-only URL param handling reusing existing filter helpers; no API or search backend changes.
> 
> **Overview**
> Fixes a UX gap where an empty post-filter results list always showed **"No results found"**, even when the search had matches that repo/language filters removed.
> 
> When **raw matches exist** and **at least one** `repos` or `langs` filter is active, the results area now shows **"No results match the active filters."** and a **Clear filters** button. That action strips only those URL params (keeping query, regex, case, etc.) via `router.replace`, so filtered results refresh without a new search.
> 
> True zero-match searches still use the original empty copy; the header stats line is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71e158960d28381c138547ef5ebaf3ed32d8306d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added clearer messaging when search filters return no results despite matching items.
  * Added a **Clear filters** action to remove repository and language filters while preserving other search settings.

* **Documentation**
  * Documented the improved empty-results experience and filter-clearing action in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->