### PR TITLE
chore: upgrade golang.org/x/text to v0.39.0 to address CVE-2026-56852

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `brace-expansion` to `^1.1.17`/`^2.1.3`/`^5.0.8`. [#1527](https://github.com/sourcebot-dev/sourcebot/pull/1527)
+- Upgraded the bundled Zoekt `golang.org/x/text` dependency to `v0.39.0`. [#1535](https://github.com/sourcebot-dev/sourcebot/pull/1535)
 
 ## [5.1.5] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Upgraded `brace-expansion` to `^1.1.17`/`^2.1.3`/`^5.0.8`. [#1527](https://github.com/sourcebot-dev/sourcebot/pull/1527)
-- Upgraded the bundled Zoekt `golang.org/x/text` dependency to `v0.39.0`. [#1535](https://github.com/sourcebot-dev/sourcebot/pull/1535)
 
 ## [5.1.5] - 2026-07-31
 


### PR DESCRIPTION
Fixes SOU-1751

## Summary

- advance `vendor/zoekt` through [sourcebot-dev/zoekt#19](https://github.com/sourcebot-dev/zoekt/pull/19)
- upgrade the bundled `golang.org/x/text` from `v0.37.0` to the patched `v0.39.0`
- address CVE-2026-56852, where `norm.Iter` can enter an infinite loop on invalid UTF-8 input

The submodule advance also includes the intervening Zoekt workflow repair from [sourcebot-dev/zoekt#18](https://github.com/sourcebot-dev/zoekt/pull/18).

## Verification

- `go mod verify` in `vendor/zoekt`
- `go build -C vendor/zoekt -o /private/tmp/sourcebot-sou-1751-bin ./cmd/...`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dependency-only change in the Zoekt submodule with a targeted patch for a known CVE; risk is low assuming Zoekt builds and indexing behave as before.
> 
> **Overview**
> **Security dependency bump** for the vendored Zoekt search engine: the `vendor/zoekt` submodule is advanced (including upstream Zoekt workflow fixes from sourcebot-dev/zoekt#18–#19), and **`golang.org/x/text` is upgraded from v0.37.0 to v0.39.0**.
> 
> This addresses **CVE-2026-56852**, where `norm.Iter` could hang in an infinite loop on invalid UTF-8 input. No application logic changes in the main monorepo beyond the submodule pointer and transitive Go module versions used when building Zoekt binaries.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e090f258e4762b81c2b08a49aef3e86b5d1cf67f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->