### PR TITLE
fix: pass reusable workflow input from event

### DIFF
--- a/.github/scripts/test-cve-remediation.sh
+++ b/.github/scripts/test-cve-remediation.sh
@@ -5,6 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FILTER="$SCRIPT_DIR/filter-unlinked-cve-issues.jq"
 DISCOVERY_SCRIPT="$SCRIPT_DIR/find-unlinked-cve-issues.sh"
 WORKFLOW_FILE="$SCRIPT_DIR/../workflows/_cve-remediation.yml"
+CALLER_WORKFLOW_FILE="$SCRIPT_DIR/../workflows/cve-remediation.yml"
 
 assert_json() {
   local description="$1"
@@ -22,8 +23,9 @@ assert_json() {
 assert_workflow_contains() {
   local description="$1"
   local expected="$2"
+  local workflow_file="${3:-$WORKFLOW_FILE}"
 
-  if ! grep -Fq -- "$expected" "$WORKFLOW_FILE"; then
+  if ! grep -Fq -- "$expected" "$workflow_file"; then
     echo "FAIL: $description"
     echo "Expected workflow to contain: $expected"
     exit 1
@@ -33,8 +35,9 @@ assert_workflow_contains() {
 assert_workflow_not_contains() {
   local description="$1"
   local unexpected="$2"
+  local workflow_file="${3:-$WORKFLOW_FILE}"
 
-  if grep -Fq -- "$unexpected" "$WORKFLOW_FILE"; then
+  if grep -Fq -- "$unexpected" "$workflow_file"; then
     echo "FAIL: $description"
     echo "Expected workflow not to contain: $unexpected"
     exit 1
@@ -276,5 +279,13 @@ assert_workflow_not_contains \
 assert_workflow_not_contains \
   "does not use unavailable job workflow SHA context" \
   'job.workflow_sha'
+assert_workflow_contains \
+  "passes a numeric manual or scheduled issue limit through an allowed context" \
+  "fromJSON(github.event.inputs.max_issues || '50')" \
+  "$CALLER_WORKFLOW_FILE"
+assert_workflow_not_contains \
+  "does not use the unavailable inputs context in a reusable workflow call" \
+  '${{ inputs.max_issues' \
+  "$CALLER_WORKFLOW_FILE"
 
 echo "All CVE remediation tests passed."

--- a/.github/workflows/cve-remediation.yml
+++ b/.github/workflows/cve-remediation.yml
@@ -26,5 +26,5 @@ jobs:
   remediate:
     uses: ./.github/workflows/_cve-remediation.yml
     with:
-      max_issues: ${{ inputs.max_issues || 50 }}
+      max_issues: ${{ fromJSON(github.event.inputs.max_issues || '50') }}
     secrets: inherit


### PR DESCRIPTION
References SOU-1830.

GitHub only allows the github and needs contexts in a reusable-workflow job with block. Read the manual input through github.event.inputs and convert it with fromJSON so both workflow_dispatch and scheduled runs pass a number; scheduled runs retain the default of 50.

Validation:
- CVE remediation regression suite
- shell syntax
- YAML parsing
- actionlint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only change to satisfy GitHub Actions context rules; behavior intent (default 50, optional manual limit) stays the same.
> 
> **Overview**
> Fixes how **Nightly CVE Remediation** passes `max_issues` into the reusable `_cve-remediation.yml` job. GitHub only allows `github` and `needs` in a `uses:` block, so the caller no longer references `${{ inputs.max_issues }}`.
> 
> The caller now uses `${{ fromJSON(github.event.inputs.max_issues || '50') }}`, so manual runs honor the workflow_dispatch input and scheduled runs still get the numeric default of 50.
> 
> The CVE remediation regression script can assert against either workflow file and adds checks that the caller uses the allowed expression and does not reference the invalid `inputs` context.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 25fc4077125c3b6dcceca9883361b549455e5ffd. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed CVE remediation workflow handling for manually supplied issue limits.
  * Preserved the default limit of 50 issues when no custom value is provided.
  * Improved workflow validation to ensure issue limits are passed and interpreted correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->