### PR TITLE
fix: support MCP JSON Schema dialects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `socket.io-parser` to `^4.2.7`. [#1542](https://github.com/sourcebot-dev/sourcebot/pull/1542)
 - Upgraded `fast-uri` to `^3.1.5`. [#1541](https://github.com/sourcebot-dev/sourcebot/pull/1541)
 - Upgraded `ip-address` to `^10.4.0`. [#1540](https://github.com/sourcebot-dev/sourcebot/pull/1540)
+- [EE] Fixed Ask MCP connector tools failing to load when their input schemas use JSON Schema 2019-09 or 2020-12. [#1547](https://github.com/sourcebot-dev/sourcebot/pull/1547)
 
 ## [5.1.5] - 2026-07-31
 

--- a/packages/web/src/ee/features/chat/mcp/mcpJsonSchemaValidator.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpJsonSchemaValidator.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, test } from 'vitest';
+import {
+    compileMcpJsonSchemaValidator,
+    UnsupportedMcpJsonSchemaDialectError,
+    UnsupportedMcpJsonSchemaFeatureError,
+} from './mcpJsonSchemaValidator';
+
+describe('compileMcpJsonSchemaValidator', () => {
+    test('uses draft-07 when it is explicitly declared', () => {
+        const validate = compileMcpJsonSchemaValidator({
+            $schema: 'http://json-schema.org/draft-07/schema#',
+            type: 'array',
+            items: [{ type: 'string' }],
+            additionalItems: false,
+        });
+
+        expect(validate(['valid'])).toBe(true);
+        expect(validate(['valid', 'extra'])).toBe(false);
+    });
+
+    test('uses draft 2019-09 for its declared meta-schema', () => {
+        const validate = compileMcpJsonSchemaValidator({
+            $schema: 'https://json-schema.org/draft/2019-09/schema',
+            type: 'object',
+            properties: {
+                known: { type: 'string' },
+            },
+            unevaluatedProperties: false,
+        });
+
+        expect(validate({ known: 'value' })).toBe(true);
+        expect(validate({ known: 'value', extra: true })).toBe(false);
+        expect(validate.errors).toEqual(expect.arrayContaining([
+            expect.objectContaining({ keyword: 'unevaluatedProperties' }),
+        ]));
+    });
+
+    test.each([
+        ['when explicitly declared', 'https://json-schema.org/draft/2020-12/schema'],
+        ['by default when omitted', undefined],
+    ])('uses draft 2020-12 %s', (_name, dialect) => {
+        const validate = compileMcpJsonSchemaValidator({
+            ...(dialect ? { $schema: dialect } : {}),
+            type: 'array',
+            prefixItems: [{ type: 'string' }],
+            items: false,
+        });
+
+        expect(validate(['valid'])).toBe(true);
+        expect(validate([42])).toBe(false);
+        expect(validate(['valid', 'extra'])).toBe(false);
+    });
+
+    test('preserves all-errors validation and permits unknown keywords', () => {
+        const validate = compileMcpJsonSchemaValidator({
+            type: 'object',
+            required: ['first', 'second'],
+            unknownServerKeyword: true,
+        });
+
+        expect(validate({})).toBe(false);
+        expect(validate.errors?.filter(error => error.keyword === 'required')).toHaveLength(2);
+    });
+
+    test('does not conflict when separate server schemas reuse the same root ID', () => {
+        const first = compileMcpJsonSchemaValidator({
+            $id: 'https://schemas.example.com/tool-input',
+            type: 'string',
+        });
+        const second = compileMcpJsonSchemaValidator({
+            $id: 'https://schemas.example.com/tool-input',
+            type: 'number',
+        });
+
+        expect(first('value')).toBe(true);
+        expect(second(42)).toBe(true);
+    });
+
+    test.each([
+        'http://json-schema.org/draft-07/schema#',
+        'https://json-schema.org/draft/2019-09/schema',
+        'https://json-schema.org/draft/2020-12/schema',
+    ])('does not let a remote $id remove the %s meta-schema', (dialect) => {
+        const collidingSchema = compileMcpJsonSchemaValidator({
+            $schema: dialect,
+            $id: dialect,
+            type: 'object',
+        });
+
+        expect(collidingSchema({})).toBe(true);
+        expect(() => compileMcpJsonSchemaValidator({
+            $schema: dialect,
+            type: 'object',
+        })).not.toThrow();
+    });
+
+    test('resolves document-local 2020-12 references after compilation', () => {
+        const validate = compileMcpJsonSchemaValidator({
+            $schema: 'https://json-schema.org/draft/2020-12/schema',
+            $defs: {
+                identifier: { type: 'string', minLength: 1 },
+            },
+            type: 'object',
+            properties: {
+                id: { $ref: '#/$defs/identifier' },
+            },
+            required: ['id'],
+        });
+
+        expect(validate({ id: 'issue-id' })).toBe(true);
+        expect(validate({ id: '' })).toBe(false);
+    });
+
+    test('rejects Ajv asynchronous schemas instead of bypassing validation', () => {
+        expect(() => compileMcpJsonSchemaValidator({
+            $async: true,
+            type: 'object',
+        })).toThrow(UnsupportedMcpJsonSchemaFeatureError);
+    });
+
+    test.each([
+        'http://json-schema.org/draft-04/schema#',
+        'https://malicious.example/schema?access_token=secret-token',
+    ])('rejects unsupported dialects without echoing the declaration', (declaredDialect) => {
+        let thrown: unknown;
+        try {
+            compileMcpJsonSchemaValidator({
+                $schema: declaredDialect,
+                type: 'object',
+            });
+        } catch (error) {
+            thrown = error;
+        }
+
+        expect(thrown).toBeInstanceOf(UnsupportedMcpJsonSchemaDialectError);
+        expect(thrown).toMatchObject({
+            name: 'UnsupportedMcpJsonSchemaDialectError',
+            reason: 'unsupported_json_schema_dialect',
+        });
+        expect((thrown as Error).message).not.toContain(declaredDialect);
+        expect((thrown as Error).message).not.toContain('secret-token');
+    });
+
+    test('rejects a non-string declared dialect safely', () => {
+        expect(() => compileMcpJsonSchemaValidator({
+            $schema: 202012,
+            type: 'object',
+        })).toThrow(UnsupportedMcpJsonSchemaDialectError);
+    });
+});

--- a/packages/web/src/ee/features/chat/mcp/mcpJsonSchemaValidator.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpJsonSchemaValidator.ts
@@ -1,0 +1,116 @@
+import Ajv, { type AnySchema, type ErrorObject, type ValidateFunction } from 'ajv';
+import Ajv2019 from 'ajv/dist/2019.js';
+import Ajv2020 from 'ajv/dist/2020.js';
+
+const AJV_OPTIONS = {
+    addUsedSchema: false,
+    allErrors: true,
+    strict: false,
+} as const;
+
+const JSON_SCHEMA_DIALECT = {
+    DRAFT_07: 'draft-07',
+    DRAFT_2019_09: '2019-09',
+    DRAFT_2020_12: '2020-12',
+} as const;
+
+type JsonSchemaDialect = typeof JSON_SCHEMA_DIALECT[keyof typeof JSON_SCHEMA_DIALECT];
+
+const draft07Ajv = new Ajv(AJV_OPTIONS);
+const draft2019Ajv = new Ajv2019(AJV_OPTIONS);
+const draft2020Ajv = new Ajv2020(AJV_OPTIONS);
+
+const DIALECT_BY_META_SCHEMA_URI = new Map<string, JsonSchemaDialect>([
+    ['http://json-schema.org/draft-07/schema', JSON_SCHEMA_DIALECT.DRAFT_07],
+    ['https://json-schema.org/draft/2019-09/schema', JSON_SCHEMA_DIALECT.DRAFT_2019_09],
+    ['https://json-schema.org/draft/2020-12/schema', JSON_SCHEMA_DIALECT.DRAFT_2020_12],
+]);
+
+export class UnsupportedMcpJsonSchemaDialectError extends Error {
+    readonly reason = 'unsupported_json_schema_dialect';
+
+    constructor() {
+        super('MCP tool schema declares an unsupported JSON Schema dialect. Supported dialects are draft-07, 2019-09, and 2020-12.');
+        this.name = 'UnsupportedMcpJsonSchemaDialectError';
+    }
+}
+
+export class UnsupportedMcpJsonSchemaFeatureError extends Error {
+    readonly reason = 'unsupported_json_schema_feature';
+
+    constructor() {
+        super('MCP tool schema uses an unsupported JSON Schema extension.');
+        this.name = 'UnsupportedMcpJsonSchemaFeatureError';
+    }
+}
+
+/**
+ * Compiles an MCP tool schema with the Ajv implementation for its declared
+ * JSON Schema dialect. MCP 2025-11-25 defines 2020-12 as the default when a
+ * schema does not explicitly declare another dialect.
+ */
+export function compileMcpJsonSchemaValidator(schema: unknown): ValidateFunction {
+    rejectAsyncSchema(schema);
+    const dialect = getJsonSchemaDialect(schema);
+
+    switch (dialect) {
+        case JSON_SCHEMA_DIALECT.DRAFT_07:
+            return compileWithAjv(draft07Ajv, schema);
+        case JSON_SCHEMA_DIALECT.DRAFT_2019_09:
+            return compileWithAjv(draft2019Ajv, schema);
+        case JSON_SCHEMA_DIALECT.DRAFT_2020_12:
+            return compileWithAjv(draft2020Ajv, schema);
+    }
+}
+
+export function formatMcpJsonSchemaValidationErrors(
+    errors: ErrorObject[] | null | undefined,
+): string {
+    // Ajv's error representation and formatter are shared across dialects.
+    return draft2020Ajv.errorsText(errors);
+}
+
+function compileWithAjv(
+    ajv: Ajv | Ajv2019 | Ajv2020,
+    schema: unknown,
+): ValidateFunction {
+    // addUsedSchema: false prevents remote root $id values from entering Ajv's
+    // shared schema registry or conflicting across MCP servers.
+    return ajv.compile(schema as AnySchema);
+}
+
+function rejectAsyncSchema(schema: unknown): void {
+    if (
+        typeof schema === 'object'
+        && schema !== null
+        && (schema as Record<string, unknown>).$async === true
+    ) {
+        // $async is an Ajv extension rather than a JSON Schema keyword. The
+        // surrounding AI SDK validation contract is synchronous, so accepting
+        // it would treat a returned Promise as a successful validation.
+        throw new UnsupportedMcpJsonSchemaFeatureError();
+    }
+}
+
+function getJsonSchemaDialect(schema: unknown): JsonSchemaDialect {
+    if (typeof schema !== 'object' || schema === null || !Object.prototype.hasOwnProperty.call(schema, '$schema')) {
+        return JSON_SCHEMA_DIALECT.DRAFT_2020_12;
+    }
+
+    const declaredDialect = (schema as Record<string, unknown>).$schema;
+    if (typeof declaredDialect !== 'string') {
+        throw new UnsupportedMcpJsonSchemaDialectError();
+    }
+
+    // An empty URI fragment does not change the selected dialect. Normalizing
+    // it also accepts both forms used by draft-07 schemas in the wild.
+    const normalizedDialect = declaredDialect.endsWith('#')
+        ? declaredDialect.slice(0, -1)
+        : declaredDialect;
+    const dialect = DIALECT_BY_META_SCHEMA_URI.get(normalizedDialect);
+    if (!dialect) {
+        throw new UnsupportedMcpJsonSchemaDialectError();
+    }
+
+    return dialect;
+}

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
@@ -499,6 +499,7 @@ describe('getMcpTools', () => {
                 inputSchema: {
                     type: 'object',
                     properties: { title: { type: 'string' } },
+                    additionalProperties: false,
                 },
             },
         ]);
@@ -522,6 +523,173 @@ describe('getMcpTools', () => {
             const invalidResult = await schema.validate({ title: 'My Issue', bogus: 'field' });
             expect(invalidResult.success).toBe(false);
         }
+    });
+
+    test.each([
+        {
+            dialect: 'draft-07',
+            inputSchema: {
+                $schema: 'http://json-schema.org/draft-07/schema#',
+                type: 'object',
+                properties: {
+                    coordinates: {
+                        type: 'array',
+                        items: [{ type: 'string' }, { type: 'integer' }],
+                        additionalItems: false,
+                    },
+                },
+            },
+            validInput: { coordinates: ['north', 3] },
+            invalidInput: { coordinates: ['north', 3, 'extra'] },
+        },
+        {
+            dialect: '2019-09',
+            inputSchema: {
+                $schema: 'https://json-schema.org/draft/2019-09/schema',
+                type: 'object',
+                properties: {
+                    mode: { type: 'string' },
+                    token: { type: 'string' },
+                },
+                dependentRequired: { mode: ['token'] },
+            },
+            validInput: { mode: 'private', token: 'available' },
+            invalidInput: { mode: 'private' },
+        },
+        {
+            dialect: '2020-12',
+            inputSchema: {
+                $schema: 'https://json-schema.org/draft/2020-12/schema',
+                type: 'object',
+                properties: {
+                    coordinates: {
+                        type: 'array',
+                        prefixItems: [{ type: 'string' }, { type: 'integer' }],
+                        items: false,
+                    },
+                },
+            },
+            validInput: { coordinates: ['north', 3] },
+            invalidInput: { coordinates: ['north', 'not-an-integer'] },
+        },
+        {
+            dialect: '2020-12 by default',
+            inputSchema: {
+                type: 'object',
+                properties: {
+                    coordinates: {
+                        type: 'array',
+                        prefixItems: [{ type: 'string' }, { type: 'integer' }],
+                        items: false,
+                    },
+                },
+            },
+            validInput: { coordinates: ['north', 3] },
+            invalidInput: { coordinates: ['north', 3, 'extra'] },
+        },
+        {
+            dialect: '2020-12 composition',
+            inputSchema: {
+                $schema: 'https://json-schema.org/draft/2020-12/schema',
+                type: 'object',
+                allOf: [{
+                    properties: { title: { type: 'string' } },
+                    required: ['title'],
+                }],
+                unevaluatedProperties: false,
+            },
+            validInput: { title: 'Composed schema' },
+            invalidInput: { title: 'Composed schema', extra: true },
+        },
+    ])('validates tool input using its declared $dialect dialect', async ({
+        inputSchema,
+        validInput,
+        invalidInput,
+    }) => {
+        const mockClient = createMockMcpClient([{
+            name: 'dialect_tool',
+            inputSchema,
+        }]);
+        mockCreateMCPClient.mockResolvedValue(mockClient);
+
+        const result = await getMcpTools([
+            createMockClient({ serverName: 'DialectServer' }),
+        ]);
+        const tool = result.tools['mcp_dialectserver__dialect_tool'];
+        const schema = tool.inputSchema as {
+            validate?: (value: unknown) => Promise<{ success: boolean; error?: Error }>;
+        };
+
+        await expect(schema.validate?.(validInput)).resolves.toMatchObject({ success: true });
+        await expect(schema.validate?.(invalidInput)).resolves.toMatchObject({ success: false });
+        expect(result.failedServers).toEqual([]);
+    });
+
+    test('isolates an unsupported schema dialect without logging its URI', async () => {
+        const unsupportedDialect = 'https://schema.example.com/private?token=schema-secret';
+        const badClient = createMockMcpClient([
+            {
+                name: 'valid_tool_before_failure',
+                inputSchema: { type: 'object' },
+            },
+            {
+                name: 'bad_tool',
+                inputSchema: {
+                    $schema: unsupportedDialect,
+                    type: 'object',
+                },
+            },
+        ]);
+        const goodClient = createMockMcpClient([{
+            name: 'good_tool',
+            inputSchema: { type: 'object' },
+        }]);
+        mockCreateMCPClient
+            .mockResolvedValueOnce(badClient)
+            .mockResolvedValueOnce(goodClient);
+
+        const result = await getMcpTools([
+            createMockClient({ serverName: 'UnsupportedServer' }),
+            createMockClient({ serverName: 'WorkingServer' }),
+        ]);
+
+        expect(result.failedServers).toEqual(['UnsupportedServer']);
+        expect(Object.keys(result.tools)).toEqual(['mcp_workingserver__good_tool']);
+        expect(result.toolDisplayNames).toEqual({
+            'mcp_workingserver__good_tool': 'good_tool',
+        });
+        expect(mockLogger.error).toHaveBeenCalledWith('Failed to get tools from MCP server.', {
+            serverId: 'server-id',
+            sanitizedName: 'unsupportedserver',
+            error: { errorClass: 'UnsupportedMcpJsonSchemaDialectError' },
+        });
+        expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(unsupportedDialect);
+        expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('schema-secret');
+    });
+
+    test('isolates malformed supported schemas without logging remote references', async () => {
+        const remoteReference = 'https://schemas.example.com/input?token=reference-secret';
+        const badClient = createMockMcpClient([{
+            name: 'bad_reference_tool',
+            inputSchema: {
+                $schema: 'https://json-schema.org/draft/2020-12/schema',
+                type: 'object',
+                properties: {
+                    input: { $ref: remoteReference },
+                },
+            },
+        }]);
+        mockCreateMCPClient.mockResolvedValue(badClient);
+
+        const result = await getMcpTools([
+            createMockClient({ serverName: 'MalformedServer' }),
+        ]);
+
+        expect(result.failedServers).toEqual(['MalformedServer']);
+        expect(result.tools).toEqual({});
+        expect(mockLogger.error).toHaveBeenCalledOnce();
+        expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(remoteReference);
+        expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain('reference-secret');
     });
 
     test('tool execute wrapper propagates non-timeout errors', async () => {

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
@@ -1,9 +1,9 @@
 import { createMCPClient, type MCPClient } from '@ai-sdk/mcp';
 import { McpToolSet } from './mcpClientFactory';
 import { createLogger, env } from '@sourcebot/shared';
-import Ajv from 'ajv';
+import type { AnySchemaObject } from 'ajv';
 import { jsonSchema, ToolExecutionOptions } from 'ai';
-import type { JSONSchema7, JSONSchema7Definition } from 'json-schema';
+import type { JSONSchema7 } from 'json-schema';
 import { createHash } from 'crypto';
 import { getExternalMcpErrorLogFields } from './externalMcpError';
 import { getMcpFaviconUrl } from '@/features/chat/mcp/utils';
@@ -18,9 +18,12 @@ import {
     getMcpServerToolPermission,
     getMcpServerToolPermissionsByServerId,
 } from './mcpToolPermissions';
+import {
+    compileMcpJsonSchemaValidator,
+    formatMcpJsonSchemaValidationErrors,
+} from './mcpJsonSchemaValidator';
 
 const logger = createLogger('mcp-tool-sets');
-const ajv = new Ajv({ allErrors: true, strict: false });
 const MCP_LIST_TOOLS_CACHE_TTL_SECONDS = 60 * 60;
 const MODEL_TOOL_NAME_MAX_LENGTH = 64;
 type ListToolsResult = Awaited<ReturnType<MCPClient['listTools']>>;
@@ -202,6 +205,8 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
 
     for (const client of clients) {
         const { serverId, serverName, sanitizedName, serverUrl, transport } = client;
+        const clientTools: McpToolsResult['tools'] = {};
+        const clientToolDisplayNames: Record<string, string> = {};
         try {
             const mcpClient = await Promise.race([
                 createMCPClient({ transport }),
@@ -243,21 +248,25 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                 }
                 const needsApproval = permission === McpServerToolPermission.NEEDS_APPROVAL;
 
-                // The @ai-sdk/mcp library sets additionalProperties: false in the JSON schema
-                // sent to the model, but does NOT provide a validate function — so the AI SDK
-                // skips server-side validation entirely. We compile the schema with ajv to
-                // enforce parameter names at runtime, which allows experimental_repairToolCall
-                // to fire on InvalidToolInputError.
+                // @ai-sdk/mcp provides the schema sent to the model, but no validate
+                // function, so the AI SDK otherwise skips runtime input validation. Compile
+                // the server's schema without rewriting its semantics and honor its declared
+                // JSON Schema dialect.
                 const rawSchema = def?.inputSchema ?? { type: 'object', properties: {} };
-                const schema = {
+                const schemaProperties = rawSchema.properties ?? {};
+                const schema: AnySchemaObject = {
                     ...rawSchema,
                     type: 'object' as const,
-                    properties: (rawSchema.properties ?? {}) as Record<string, JSONSchema7Definition>,
-                    additionalProperties: false,
-                } satisfies JSONSchema7;
-                const validate = ajv.compile(schema);
-                const validProperties = Object.keys(schema.properties);
-                const validatedInputSchema = jsonSchema(schema, {
+                    properties: schemaProperties,
+                };
+                const validate = compileMcpJsonSchemaValidator(schema);
+                const validProperties = Object.keys(schemaProperties);
+                const validPropertiesHint = validProperties.length > 0
+                    ? `. The top-level parameter names declared by this tool are: [${validProperties.join(', ')}]`
+                    : '';
+                // The AI SDK currently types this boundary as draft-07 even though MCP
+                // 2025-11-25 defines 2020-12 as the default JSON Schema dialect.
+                const validatedInputSchema = jsonSchema(schema as JSONSchema7, {
                     validate: async (value: unknown) => {
                         if (validate(value)) {
                             return { success: true as const, value };
@@ -265,7 +274,7 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                         return {
                             success: false as const,
                             error: new Error(
-                                `${ajv.errorsText(validate.errors)}. The valid parameter names for this tool are: [${validProperties.join(', ')}]`
+                                `${formatMcpJsonSchemaValidationErrors(validate.errors)}${validPropertiesHint}`
                             ),
                         };
                     },
@@ -275,7 +284,7 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                 const rawQualifiedName = `${prefix}__${toolName}`;
                 const qualifiedName = sanitizeMcpToolNameForModel(rawQualifiedName);
                 const timeoutMs = env.SOURCEBOT_MCP_TOOL_CALL_TIMEOUT_MS;
-                toolDisplayNames[qualifiedName] = toolName;
+                clientToolDisplayNames[qualifiedName] = toolName;
 
                 const executeWithTimeout = (async (input: unknown, options: ToolExecutionOptions) => {
                     const startTime = Date.now();
@@ -328,7 +337,7 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                     }
                 }) as typeof originalExecute;
 
-                allTools[qualifiedName] = {
+                clientTools[qualifiedName] = {
                     ...tool,
                     execute: executeWithTimeout,
                     // The @ai-sdk/mcp package bundles its own copy of @ai-sdk/provider-utils,
@@ -343,6 +352,11 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
             }
 
             const faviconUrl = getMcpFaviconUrl(serverUrl, serverName);
+
+            // Expose a server's tools atomically. If any schema is malformed or uses an
+            // unsupported dialect, no partially constructed tools from that server survive.
+            Object.assign(allTools, clientTools);
+            Object.assign(toolDisplayNames, clientToolDisplayNames);
             if (faviconUrl) {
                 serverFaviconUrls[sanitizedName] = faviconUrl;
             }


### PR DESCRIPTION
- Compile MCP tool schemas using their declared JSON Schema dialect: draft-07, 2019-09, or 2020-12.
- Default schemas without `$schema` to 2020-12, as required by the MCP specification.
- Register each server’s tools atomically so a schema failure cannot leave that server partially loaded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes runtime MCP tool schema compilation and which tools load in Ask EE; behavior shifts for connectors that relied on the old draft-07-only path or forced additionalProperties, though failures are isolated per server.
> 
> **Overview**
> Fixes **Ask MCP connectors** failing to load when tool `inputSchema` declares **JSON Schema 2019-09 or 2020-12** (MCP’s default when `$schema` is omitted).
> 
> **Validation** no longer uses a single draft-07 Ajv instance or forces `additionalProperties: false` on every tool. Schemas are compiled with the matching Ajv dialect (`draft-07`, `2019-09`, `2020-12`), with guards for unsupported dialects, `$async`, and shared `$id` collisions (`addUsedSchema: false`).
> 
> **Tool loading** is **per-server atomic**: if any tool schema is unsupported or fails to compile, that server is marked failed and **no partial tools** from that server are exposed. Error logging avoids echoing sensitive schema URIs or tokens.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 434fb045493f8bdee14381938411e3274e3e904c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added JSON Schema validation support for drafts 07, 2019-09, and 2020-12, with automatic draft selection and 2020-12 as the default.
  * Added clearer validation errors, including parameter-name hints.
  * Added support for schema composition keywords and local references.

* **Bug Fixes**
  * Unsupported, malformed, or asynchronous schemas are now rejected safely.
  * Failed MCP servers no longer expose partially created tools.
  * Sensitive schema URLs, tokens, and remote references are excluded from logs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->