### PR TITLE
feat(web): recover from MCP connector authentication failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- [EE] Added guided reconnection for MCP connector authentication failures during Ask Sourcebot agent turns. [#1548](https://github.com/sourcebot-dev/sourcebot/pull/1548)
+
 ### Removed
 - Removed the Langfuse integration. [#1536](https://github.com/sourcebot-dev/sourcebot/pull/1536)
 

--- a/packages/web/src/app/api/(client)/client.ts
+++ b/packages/web/src/app/api/(client)/client.ts
@@ -320,7 +320,7 @@ export const getOffers = async (): Promise<OffersResponse | ServiceError> => {
     return result as OffersResponse | ServiceError;
 }
 
-export const connectMcpToAsk = async (body: { serverId: string; returnTo?: string }): Promise<ConnectMcpResponse | ServiceError> => {
+export const connectMcpToAsk = async (body: { serverId: string; returnTo?: string; forceAuthorization?: boolean }): Promise<ConnectMcpResponse | ServiceError> => {
     const result = await fetch('/api/ee/askmcp/connect', {
         method: 'POST',
         headers: {

--- a/packages/web/src/app/api/(server)/ee/askmcp/connect/route.test.ts
+++ b/packages/web/src/app/api/(server)/ee/askmcp/connect/route.test.ts
@@ -48,7 +48,7 @@ vi.mock('@ai-sdk/mcp', () => ({
 const { POST } = await import('./route');
 const { getMcpOAuthReturnToFromState } = await import('@/ee/features/chat/mcp/mcpOAuthReturnTo');
 
-function createRequest(body: { serverId: string; returnTo?: string } = { serverId: 'server-1' }) {
+function createRequest(body: { serverId: string; returnTo?: string; forceAuthorization?: boolean } = { serverId: 'server-1' }) {
     return new NextRequest('https://sourcebot.example.com/api/ee/askmcp/connect', {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -226,6 +226,60 @@ describe('POST /api/ee/askmcp/connect', () => {
             data: {
                 state: expect.stringContaining('sourcebot_mcp.'),
             },
+        });
+    });
+
+    test('forces an interactive OAuth redirect for reconnect recovery', async () => {
+        const prisma = createPrismaMock();
+        const tx = createTransactionMock();
+        tx.userMcpServer.findUnique.mockResolvedValue({
+            tokens: 'encrypted:{"access_token":"stale-token"}',
+            codeVerifier: null,
+            state: null,
+        });
+        mocks.authContext = {
+            org: { id: 1 },
+            user: { id: 'user-1' },
+            prisma,
+        };
+        mocks.unsafePrisma.$transaction.mockImplementation(async (callback, _options) => callback(tx));
+        mocks.mcpAuth.mockImplementation(async (provider) => {
+            await expect(provider.tokens()).resolves.toBeUndefined();
+            provider.authorizationUrl = 'https://oauth.example.com/authorize';
+            return 'REDIRECT';
+        });
+
+        const response = await POST(createRequest({
+            serverId: 'server-1',
+            returnTo: '/chat/abc123',
+            forceAuthorization: true,
+        }));
+
+        expect(await response.json()).toEqual({
+            authorizationUrl: 'https://oauth.example.com/authorize',
+        });
+    });
+
+    test('does not report a forced reconnect as successful without an OAuth redirect', async () => {
+        const prisma = createPrismaMock();
+        const tx = createTransactionMock();
+        mocks.authContext = {
+            org: { id: 1 },
+            user: { id: 'user-1' },
+            prisma,
+        };
+        mocks.unsafePrisma.$transaction.mockImplementation(async (callback, _options) => callback(tx));
+        mocks.mcpAuth.mockResolvedValue('AUTHORIZED');
+
+        const response = await POST(createRequest({
+            serverId: 'server-1',
+            returnTo: '/chat/abc123',
+            forceAuthorization: true,
+        }));
+
+        expect(response.status).toBe(502);
+        expect(await response.json()).toMatchObject({
+            message: 'Could not start connector reauthorization.',
         });
     });
 

--- a/packages/web/src/app/api/(server)/ee/askmcp/connect/route.ts
+++ b/packages/web/src/app/api/(server)/ee/askmcp/connect/route.ts
@@ -24,6 +24,7 @@ import { getEnabledMcpOAuthScopeNames } from '@/ee/features/chat/mcp/oauthScopeU
 const bodySchema = z.object({
     serverId: z.string(),
     returnTo: z.string().optional(),
+    forceAuthorization: z.boolean().optional().default(false),
 });
 const logger = createLogger('mcp-connect');
 const MCP_AUTH_FETCH_TIMEOUT_MS = Math.min(env.SOURCEBOT_MCP_TOOL_CALL_TIMEOUT_MS, 30000);
@@ -146,6 +147,7 @@ export const POST = apiHandler(async (request: NextRequest) => {
                     callbackReturnTo,
                     allowClientRegistration: true,
                     requestedOAuthScopes: getEnabledMcpOAuthScopeNames(mcpServer.oauthScopes),
+                    forceAuthorization: parsed.data.forceAuthorization,
                 });
 
                 let authResult: Awaited<ReturnType<typeof mcpAuth>>;
@@ -200,13 +202,25 @@ export const POST = apiHandler(async (request: NextRequest) => {
             throw error;
         }
 
-        if (connectResult.authResult === 'AUTHORIZED') {
+        if (connectResult.authResult === 'AUTHORIZED' && !parsed.data.forceAuthorization) {
             // Already has valid tokens (e.g., refreshed)
             void captureEvent('ask_mcp_connector_connection_completed', {
                 ...eventProperties,
                 alreadyAuthorized: true,
             });
             return { authorizationUrl: null } satisfies ConnectMcpResponse;
+        }
+
+        if (connectResult.authResult === 'AUTHORIZED') {
+            void captureEvent('ask_mcp_connector_connection_failed', {
+                ...eventProperties,
+                failureReason: 'missing_authorization_url',
+            });
+            throw new ServiceErrorException({
+                statusCode: StatusCodes.BAD_GATEWAY,
+                errorCode: ErrorCode.UNEXPECTED_ERROR,
+                message: 'Could not start connector reauthorization.',
+            });
         }
 
         if (!connectResult.authorizationUrl) {

--- a/packages/web/src/ee/features/chat/agent.test.ts
+++ b/packages/web/src/ee/features/chat/agent.test.ts
@@ -321,6 +321,50 @@ describe('createMessageStream approval continuation', () => {
         });
     });
 
+    test('streams the connector ID when its tools fail to load', async () => {
+        const { getConnectedMcpClients } = await import('@/ee/features/chat/mcp/mcpClientFactory');
+        const { getMcpTools } = await import('@/ee/features/chat/mcp/mcpToolSets');
+        vi.mocked(getConnectedMcpClients).mockResolvedValueOnce([
+            { serverId: 'server-linear', serverName: 'Linear' },
+        ] as never);
+        vi.mocked(getMcpTools).mockResolvedValueOnce({
+            tools: {},
+            failedServers: [{ serverId: 'server-linear', serverName: 'Linear' }],
+            serverFaviconUrls: {},
+            toolDisplayNames: {},
+            cleanup: vi.fn(),
+        });
+        mockAi.streamText.mockReturnValue(createFakeStreamResult());
+
+        await createMessageStream({
+            chatId: 'chat-id',
+            messages: [createUserMessage()],
+            selectedRepos: [],
+            disabledMcpServerIds: [],
+            prisma: {},
+            model: {},
+            modelName: 'test-model',
+            promptCacheStrategy: noopStrategy,
+            onFinish: vi.fn(),
+            onError: () => 'error',
+            userId: 'user-id',
+            orgId: 1,
+        } as unknown as Parameters<typeof createMessageStream>[0]);
+
+        const execute = mockAi.latestCreateUIMessageStreamOptions?.execute;
+        if (!execute) {
+            throw new Error('Expected createUIMessageStream to capture execute callback.');
+        }
+
+        const write = vi.fn();
+        await execute({ writer: { merge: vi.fn(), write } });
+
+        expect(write).toHaveBeenCalledWith({
+            type: 'data-mcp-failed-server',
+            data: { serverId: 'server-linear', serverName: 'Linear' },
+        });
+    });
+
     test.each([
         ['dynamic', dynamicApprovalRespondedPart],
         ['static', staticApprovalRespondedPart],

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -401,7 +401,7 @@ export const createMessageStream = async ({
                 },
                 onMcpAuthRequired: (failure) => {
                     // Transient: consumed live by the client to surface the
-                    // inline reconnect UI, never folded into persisted parts.
+                    // connector reconnect UI, never folded into persisted parts.
                     writer.write({
                         type: 'data-mcp-auth-required',
                         data: failure,

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -393,10 +393,10 @@ export const createMessageStream = async ({
                         data: { modelToolName, rawToolName },
                     });
                 },
-                onMcpServerFailed: (serverName) => {
+                onMcpServerFailed: (server) => {
                     writer.write({
                         type: 'data-mcp-failed-server',
-                        data: { serverName },
+                        data: server,
                     });
                 },
                 onMcpAuthRequired: (failure) => {
@@ -536,7 +536,7 @@ interface AgentOptions {
     onWriteSource: (source: Source) => void;
     onMcpServerDiscovered: (sanitizedName: string, faviconUrl: string) => void;
     onMcpToolDiscovered: (modelToolName: string, rawToolName: string) => void;
-    onMcpServerFailed: (serverName: string) => void;
+    onMcpServerFailed: (server: { serverId: string; serverName: string }) => void;
     // Fired at most once per connector per response when a tool call fails
     // with a reconnect-required authentication failure.
     onMcpAuthRequired: (failure: McpToolAuthFailure) => void;
@@ -646,8 +646,8 @@ const createAgentStream = async ({
         }
     }
 
-    for (const serverName of mcpToolSetsObj.failedServers) {
-        onMcpServerFailed(serverName);
+    for (const server of mcpToolSetsObj.failedServers) {
+        onMcpServerFailed(server);
     }
 
     const mcpRegistry = buildMcpToolRegistry(mcpToolSetsObj.tools);

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -26,6 +26,12 @@ import { addLineNumbers, fileReferenceToString, formatAttachmentsForPrompt, getA
 import { createTools } from "./tools";
 import { getConnectedMcpClients } from "@/ee/features/chat/mcp/mcpClientFactory";
 import { getMcpTools, McpToolsResult } from "@/ee/features/chat/mcp/mcpToolSets";
+import {
+    createMcpAuthInterruptionDirective,
+    denyApprovedToolApprovalsForAuthInterruption,
+    getMcpAuthRequiredFailureFromAssistantMessage,
+    McpToolAuthFailure,
+} from "@/ee/features/chat/mcp/mcpAuthFailure";
 import { buildMcpToolRegistry, McpToolRegistryEntry } from "@/ee/features/chat/mcp/mcpToolRegistry";
 import { PromptCacheStrategy, mergeProviderOptions, detectPromptCacheBreak, detectUnexpectedCacheMiss } from "./promptCaching";
 import { hasEntitlement } from '@/lib/entitlements';
@@ -332,9 +338,21 @@ export const createMessageStream = async ({
         ? (lastMsg.metadata as SBChatMessageMetadata | undefined)
         : undefined;
 
+    // When the response was interrupted by a reconnect-required authentication
+    // failure (detected via the safe tool error's marker text), the
+    // continuation must run its final step with tool use disabled. Any
+    // approval that was still approved is rewritten to a denial: once the
+    // response is authentication-terminal, later approval actions are invalid.
+    const priorMcpAuthFailure = hasApprovalContinuationReady
+        ? getMcpAuthRequiredFailureFromAssistantMessage(lastMsg)
+        : undefined;
+
     if (hasApprovalContinuationReady) {
+        const continuationMessage = priorMcpAuthFailure
+            ? denyApprovedToolApprovalsForAuthInterruption(lastMsg, priorMcpAuthFailure.serverName)
+            : lastMsg;
         const fullLastTurn = await convertToModelMessages(
-            [lastMsg],
+            [continuationMessage],
             { ignoreIncompleteToolCalls: true }
         );
         messageHistory = [...messageHistory, ...fullLastTurn];
@@ -381,6 +399,16 @@ export const createMessageStream = async ({
                         data: { serverName },
                     });
                 },
+                onMcpAuthRequired: (failure) => {
+                    // Transient: consumed live by the client to surface the
+                    // inline reconnect UI, never folded into persisted parts.
+                    writer.write({
+                        type: 'data-mcp-auth-required',
+                        data: failure,
+                        transient: true,
+                    });
+                },
+                priorMcpAuthFailure,
                 traceId,
                 chatId,
                 prisma,
@@ -509,6 +537,13 @@ interface AgentOptions {
     onMcpServerDiscovered: (sanitizedName: string, faviconUrl: string) => void;
     onMcpToolDiscovered: (modelToolName: string, rawToolName: string) => void;
     onMcpServerFailed: (serverName: string) => void;
+    // Fired at most once per connector per response when a tool call fails
+    // with a reconnect-required authentication failure.
+    onMcpAuthRequired: (failure: McpToolAuthFailure) => void;
+    // Set when the incoming messages show this response was already
+    // interrupted by an authentication failure (approval continuation): the
+    // stream must run its final step with tool use disabled from step one.
+    priorMcpAuthFailure?: { serverName: string };
     traceId: string;
     chatId: string;
     prisma: PrismaClient;
@@ -529,6 +564,8 @@ const createAgentStream = async ({
     onMcpServerDiscovered,
     onMcpToolDiscovered,
     onMcpServerFailed,
+    onMcpAuthRequired,
+    priorMcpAuthFailure,
     traceId,
     chatId,
     prisma,
@@ -564,6 +601,15 @@ const createAgentStream = async ({
         }))
     ).filter((source) => source !== undefined);
 
+    // Mutable, response-scoped authentication failure state. `serverName` is
+    // the first failed connector's display name (V1 supports recovery for a
+    // single failed connector). Failures are deduplicated by connector so the
+    // client sees at most one transient event per connector per response.
+    const mcpAuthFailureState: { failure?: { serverName: string } } = {
+        ...(priorMcpAuthFailure ? { failure: { serverName: priorMcpAuthFailure.serverName } } : {}),
+    };
+    const reportedMcpAuthFailureServerIds = new Set<string>();
+
     let mcpToolSetsObj: McpToolsResult = { tools: {}, failedServers: [], serverFaviconUrls: {}, toolDisplayNames: {}, cleanup: async () => {} };
     if (userId && orgId && await hasEntitlement('ask') && disabledMcpServerIds !== undefined) {
         try {
@@ -573,6 +619,16 @@ const createAgentStream = async ({
                 chatId,
                 traceId,
                 source: 'sourcebot-ask-agent',
+            }, {
+                onAuthFailure: (failure) => {
+                    if (!mcpAuthFailureState.failure) {
+                        mcpAuthFailureState.failure = { serverName: failure.serverName };
+                    }
+                    if (!reportedMcpAuthFailureServerIds.has(failure.serverId)) {
+                        reportedMcpAuthFailureServerIds.add(failure.serverId);
+                        onMcpAuthRequired(failure);
+                    }
+                },
             });
 
             for (const [sanitizedName, faviconUrl] of Object.entries(mcpToolSetsObj.serverFaviconUrls)) {
@@ -715,13 +771,33 @@ const createAgentStream = async ({
             // rebuilds the step's messages each time as the original input plus
             // its own accumulated response messages. Re-applying the moving tail marker
             // to the new last message each step is safe and does not accumulate.
-            prepareStep: (tailMarker || hasMcpTools) ? ({ steps, messages }) => {
+            prepareStep: (tailMarker || hasMcpTools || mcpAuthFailureState.failure) ? ({ steps, messages }) => {
                 const stepMessages = (tailMarker && messages.length > 0)
                     ? messages.map((message, index) =>
                         index === messages.length - 1
                             ? { ...message, providerOptions: mergeProviderOptions(message.providerOptions, tailMarker) }
                             : message)
                     : undefined;
+
+                // Once a reconnect-required authentication failure occurs, the
+                // response is terminal for tool use: every remaining step runs
+                // with tool calling disabled (`toolChoice: 'none'` keeps the
+                // tool definitions byte-stable for prompt caching) plus an
+                // ephemeral directive to summarize completed work and prompt
+                // the user to reconnect. In-flight tool calls of the failing
+                // step have already run to completion by the time this fires.
+                if (mcpAuthFailureState.failure) {
+                    return {
+                        messages: [
+                            ...(stepMessages ?? messages),
+                            {
+                                role: 'user' as const,
+                                content: createMcpAuthInterruptionDirective(mcpAuthFailureState.failure.serverName),
+                            },
+                        ],
+                        toolChoice: 'none' as const,
+                    };
+                }
 
                 if (!hasMcpTools) {
                     return stepMessages ? { messages: stepMessages } : {};

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -29,6 +29,8 @@ import { generateAndUpdateChatNameFromMessage } from '@/ee/features/chat/actions
 import { isServiceError } from '@/lib/utils';
 import { NotConfiguredErrorBanner } from '@/features/chat/components/notConfiguredErrorBanner';
 import { McpServerIconContext, McpServerIconMap, McpToolNameContext, McpToolNameMap } from '../../mcpDisplayMetadataContext';
+import { McpReconnectContext } from '../../mcpReconnectContext';
+import { McpAuthRequiredData, useMcpReconnectController } from './useMcpReconnectController';
 import { ToolApprovalProvider } from '../../toolApprovalContext';
 import useCaptureEvent from '@/hooks/useCaptureEvent';
 import { SignInPromptBanner } from './signInPromptBanner';
@@ -153,6 +155,11 @@ export const ChatThread = ({
         disabledMcpServerIds: disabledMcpRef.current,
     }), []);
 
+    // The reconnect controller is created after useChat (it needs the chat's
+    // messages and status), so transient auth-required events received in
+    // onData are forwarded to it through a ref.
+    const onMcpAuthRequiredRef = useRef<((data: McpAuthRequiredData) => void) | null>(null);
+
     // Transport with dynamic body, resolved on every request, including auto-resends
     // triggered by sendAutomaticallyWhen after tool approval.
     // eslint-disable-next-line react-hooks/refs -- DefaultChatTransport stores the body callback and invokes it during requests, not during render.
@@ -202,6 +209,9 @@ export const ChatThread = ({
                     return [...prev, dataPart.data.serverName];
                 });
                 setIsFailedMcpBannerVisible(true);
+            }
+            if (dataPart.type === 'data-mcp-auth-required') {
+                onMcpAuthRequiredRef.current?.(dataPart.data);
             }
         }
     });
@@ -275,6 +285,23 @@ export const ChatThread = ({
         enabled: shouldGuardNavigation,
         confirm: () => window.confirm("You have unsaved changes that will be lost."),
     });
+
+    const {
+        contextValue: mcpReconnectContextValue,
+        onAuthRequired: onMcpAuthRequired,
+    } = useMcpReconnectController({
+        status,
+        messages,
+        isTurnInProgress,
+        addToolApprovalResponse,
+        sendMessage,
+        selectedSearchScopes,
+        disabledMcpServerIds,
+    });
+
+    useEffect(() => {
+        onMcpAuthRequiredRef.current = onMcpAuthRequired;
+    }, [onMcpAuthRequired]);
 
     // When the chat is finished, refresh the page to update the chat history.
     const prevStatus = usePrevious(status);
@@ -395,6 +422,7 @@ export const ChatThread = ({
 
     return (
         <ToolApprovalProvider value={addToolApprovalResponse}>
+        <McpReconnectContext.Provider value={mcpReconnectContextValue}>
         <McpServerIconContext.Provider value={mcpServerIconMap}>
         <McpToolNameContext.Provider value={mcpToolNameMap}>
         <ChatPaneDropzone
@@ -547,6 +575,7 @@ export const ChatThread = ({
         </ChatPaneDropzone>
         </McpToolNameContext.Provider>
         </McpServerIconContext.Provider>
+        </McpReconnectContext.Provider>
         </ToolApprovalProvider>
     );
 }

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -30,7 +30,7 @@ import { isServiceError } from '@/lib/utils';
 import { NotConfiguredErrorBanner } from '@/features/chat/components/notConfiguredErrorBanner';
 import { McpServerIconContext, McpServerIconMap, McpToolNameContext, McpToolNameMap } from '../../mcpDisplayMetadataContext';
 import { McpReconnectContext } from '../../mcpReconnectContext';
-import { McpAuthRequiredData, useMcpReconnectController } from './useMcpReconnectController';
+import { McpAuthRequiredData, McpServerLoadFailureData, useMcpReconnectController } from './useMcpReconnectController';
 import { McpReconnectBanner } from './mcpReconnectBanner';
 import { ToolApprovalProvider } from '../../toolApprovalContext';
 import useCaptureEvent from '@/hooks/useCaptureEvent';
@@ -122,19 +122,7 @@ export const ChatThread = ({
         return map;
     });
 
-    const [failedMcpServers, setFailedMcpServers] = useState<string[]>(() => {
-        const names: string[] = [];
-        initialMessages?.forEach((message) => {
-            message.parts
-                .filter((part) => part.type === 'data-mcp-failed-server')
-                .forEach((part) => {
-                    if (!names.includes(part.data.serverName)) {
-                        names.push(part.data.serverName);
-                    }
-                });
-        });
-        return names;
-    });
+    const [failedMcpServers, setFailedMcpServers] = useState<McpServerLoadFailureData[]>([]);
     const [isFailedMcpBannerVisible, setIsFailedMcpBannerVisible] = useState(false);
 
     const { selectedLanguageModel } = useSelectedLanguageModel();
@@ -150,6 +138,37 @@ export const ChatThread = ({
     useEffect(() => { modelRef.current = selectedLanguageModel; }, [selectedLanguageModel]);
     useEffect(() => { disabledMcpRef.current = disabledMcpServerIds; }, [disabledMcpServerIds]);
 
+    const forceDisableMcpServer = useCallback((serverId: string) => {
+        if (disabledMcpRef.current.includes(serverId)) {
+            return;
+        }
+
+        const nextDisabledServerIds = [...disabledMcpRef.current, serverId];
+        disabledMcpRef.current = nextDisabledServerIds;
+        onDisabledMcpServerIdsChange(nextDisabledServerIds);
+    }, [onDisabledMcpServerIdsChange]);
+
+    const reenableMcpServer = useCallback((serverId: string) => {
+        if (!disabledMcpRef.current.includes(serverId)) {
+            return;
+        }
+
+        const nextDisabledServerIds = disabledMcpRef.current.filter((id) => id !== serverId);
+        disabledMcpRef.current = nextDisabledServerIds;
+        onDisabledMcpServerIdsChange(nextDisabledServerIds);
+    }, [onDisabledMcpServerIdsChange]);
+
+    const registerFailedMcpServer = useCallback((server: McpServerLoadFailureData) => {
+        setFailedMcpServers((prev) => {
+            if (prev.some((candidate) => candidate.serverId === server.serverId)) {
+                return prev;
+            }
+            return [...prev, server];
+        });
+        setIsFailedMcpBannerVisible(true);
+        forceDisableMcpServer(server.serverId);
+    }, [forceDisableMcpServer]);
+
     const getTransportBody = useCallback(() => ({
         selectedSearchScopes: searchScopesRef.current,
         languageModel: modelRef.current,
@@ -160,6 +179,7 @@ export const ChatThread = ({
     // messages and status), so transient auth-required events received in
     // onData are forwarded to it through a ref.
     const onMcpAuthRequiredRef = useRef<((data: McpAuthRequiredData) => void) | null>(null);
+    const onMcpServerLoadFailedRef = useRef<((data: McpServerLoadFailureData) => void) | null>(null);
 
     // Transport with dynamic body, resolved on every request, including auto-resends
     // triggered by sendAutomaticallyWhen after tool approval.
@@ -203,13 +223,8 @@ export const ChatThread = ({
                 }));
             }
             if (dataPart.type === 'data-mcp-failed-server') {
-                setFailedMcpServers((prev) => {
-                    if (prev.includes(dataPart.data.serverName)) {
-                        return prev;
-                    }
-                    return [...prev, dataPart.data.serverName];
-                });
-                setIsFailedMcpBannerVisible(true);
+                registerFailedMcpServer(dataPart.data);
+                onMcpServerLoadFailedRef.current?.(dataPart.data);
             }
             if (dataPart.type === 'data-mcp-auth-required') {
                 onMcpAuthRequiredRef.current?.(dataPart.data);
@@ -290,6 +305,7 @@ export const ChatThread = ({
     const {
         contextValue: mcpReconnectContextValue,
         onAuthRequired: onMcpAuthRequired,
+        onServerLoadFailed: onMcpServerLoadFailed,
     } = useMcpReconnectController({
         status,
         messages,
@@ -302,7 +318,30 @@ export const ChatThread = ({
 
     useEffect(() => {
         onMcpAuthRequiredRef.current = onMcpAuthRequired;
-    }, [onMcpAuthRequired]);
+        onMcpServerLoadFailedRef.current = onMcpServerLoadFailed;
+    }, [onMcpAuthRequired, onMcpServerLoadFailed]);
+
+    const handledLoadReconnectsRef = useRef(new Set<string>());
+    useEffect(() => {
+        for (const state of Object.values(mcpReconnectContextValue.reconnectStates)) {
+            if (state.source !== 'tool-load') {
+                continue;
+            }
+
+            if (state.status === 'reconnected') {
+                if (handledLoadReconnectsRef.current.has(state.serverId)) {
+                    continue;
+                }
+                handledLoadReconnectsRef.current.add(state.serverId);
+                setFailedMcpServers((prev) => prev.filter((server) => server.serverId !== state.serverId));
+                reenableMcpServer(state.serverId);
+                continue;
+            }
+
+            handledLoadReconnectsRef.current.delete(state.serverId);
+            registerFailedMcpServer({ serverId: state.serverId, serverName: state.serverName });
+        }
+    }, [mcpReconnectContextValue.reconnectStates, reenableMcpServer, registerFailedMcpServer]);
 
     // When the chat is finished, refresh the page to update the chat history.
     const prevStatus = usePrevious(status);
@@ -439,7 +478,7 @@ export const ChatThread = ({
                 />
             )}
             <McpFailedServersBanner
-                serverNames={failedMcpServers}
+                servers={failedMcpServers}
                 isVisible={isFailedMcpBannerVisible}
                 onClose={() => setIsFailedMcpBannerVisible(false)}
             />
@@ -546,6 +585,7 @@ export const ChatThread = ({
                                         isContextSelectorOpen={isContextSelectorOpen}
                                         onContextSelectorOpenChanged={setIsContextSelectorOpen}
                                         disabledMcpServerIds={disabledMcpServerIds}
+                                        unavailableMcpServerIds={failedMcpServers.map((server) => server.serverId)}
                                         onDisabledMcpServerIdsChange={onDisabledMcpServerIdsChange}
                                         isAuthenticated={isAuthenticated}
                                     />

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -31,6 +31,7 @@ import { NotConfiguredErrorBanner } from '@/features/chat/components/notConfigur
 import { McpServerIconContext, McpServerIconMap, McpToolNameContext, McpToolNameMap } from '../../mcpDisplayMetadataContext';
 import { McpReconnectContext } from '../../mcpReconnectContext';
 import { McpAuthRequiredData, useMcpReconnectController } from './useMcpReconnectController';
+import { McpReconnectBanner } from './mcpReconnectBanner';
 import { ToolApprovalProvider } from '../../toolApprovalContext';
 import useCaptureEvent from '@/hooks/useCaptureEvent';
 import { SignInPromptBanner } from './signInPromptBanner';
@@ -442,6 +443,7 @@ export const ChatThread = ({
                 isVisible={isFailedMcpBannerVisible}
                 onClose={() => setIsFailedMcpBannerVisible(false)}
             />
+            <McpReconnectBanner />
 
             <div className="relative h-full w-full p-4 overflow-hidden min-h-0">
                 <div

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -311,9 +311,6 @@ export const ChatThread = ({
         messages,
         isTurnInProgress,
         addToolApprovalResponse,
-        sendMessage,
-        selectedSearchScopes,
-        disabledMcpServerIds,
     });
 
     useEffect(() => {

--- a/packages/web/src/ee/features/chat/components/chatThread/detailsCard.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/detailsCard.tsx
@@ -548,6 +548,7 @@ export const StepPartRenderer = ({ part, toolTokenUsageMap }: { part: SBChatMess
         case 'data-mcp-server':
         case 'data-mcp-tool':
         case 'data-mcp-failed-server':
+        case 'data-mcp-auth-required':
         case 'data-attachment':
         case 'file':
         case 'source-document':

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.test.tsx
@@ -20,9 +20,7 @@ const createContext = (
         },
     },
     isReconnectAllowed,
-    isContinueAllowed: false,
     reconnect,
-    continueAfterReconnect: vi.fn(),
 });
 
 const renderBanner = (context: McpReconnectContextValue) => render(

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.test.tsx
@@ -1,0 +1,61 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import { McpReconnectContext, McpReconnectContextValue } from '@/ee/features/chat/mcpReconnectContext';
+import { McpFailedServersBanner } from './mcpFailedServersBanner';
+
+afterEach(cleanup);
+
+const reconnect = vi.fn();
+
+const createContext = (
+    status: 'authentication-required' | 'reconnecting' = 'authentication-required',
+    isReconnectAllowed = true,
+): McpReconnectContextValue => ({
+    reconnectStates: {
+        'server-1': {
+            serverId: 'server-1',
+            serverName: 'Linear',
+            source: 'tool-load',
+            status,
+        },
+    },
+    isReconnectAllowed,
+    isContinueAllowed: false,
+    reconnect,
+    continueAfterReconnect: vi.fn(),
+});
+
+const renderBanner = (context: McpReconnectContextValue) => render(
+    <McpReconnectContext.Provider value={context}>
+        <McpFailedServersBanner
+            servers={[{ serverId: 'server-1', serverName: 'Linear' }]}
+            isVisible={true}
+            onClose={vi.fn()}
+        />
+    </McpReconnectContext.Provider>,
+);
+
+describe('McpFailedServersBanner', () => {
+    test('offers reconnect for the connector whose tools failed to load', () => {
+        renderBanner(createContext());
+
+        expect(screen.getByText('Connector "Linear" failed to load tools')).toBeTruthy();
+        fireEvent.click(screen.getByRole('button', { name: 'Reconnect Linear' }));
+
+        expect(reconnect).toHaveBeenCalledWith('server-1');
+    });
+
+    test('keeps reconnect disabled until the assistant response settles', () => {
+        renderBanner(createContext('authentication-required', false));
+
+        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+
+    test('shows progress while reauthorization starts', () => {
+        renderBanner(createContext('reconnecting'));
+
+        const button = screen.getByRole('button', { name: /Reconnecting/ }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+});

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpFailedServersBanner.tsx
@@ -1,33 +1,65 @@
 'use client';
 
 import { Button } from '@/components/ui/button';
-import { AlertTriangle, X } from 'lucide-react';
+import { useMcpReconnect } from '@/ee/features/chat/mcpReconnectContext';
+import { AlertTriangle, Loader2, X } from 'lucide-react';
+
+interface FailedMcpServer {
+    serverId: string;
+    serverName: string;
+}
 
 interface McpFailedServersBannerProps {
-    serverNames: string[];
+    servers: FailedMcpServer[];
     isVisible: boolean;
     onClose: () => void;
 }
 
-export const McpFailedServersBanner = ({ serverNames, isVisible, onClose }: McpFailedServersBannerProps) => {
-    if (!isVisible || serverNames.length === 0) {
+export const McpFailedServersBanner = ({ servers, isVisible, onClose }: McpFailedServersBannerProps) => {
+    const reconnectContext = useMcpReconnect();
+
+    if (!isVisible || servers.length === 0) {
         return null;
     }
 
-    const message = serverNames.length === 1
-        ? `Connector "${serverNames[0]}" failed to load tools`
-        : `${serverNames.length} connectors failed to load tools`;
+    const message = servers.length === 1
+        ? `Connector "${servers[0].serverName}" failed to load tools`
+        : `${servers.length} connectors failed to load tools`;
+    const isAnyReconnectStarting = Object.values(reconnectContext?.reconnectStates ?? {})
+        .some((state) => state.status === 'reconnecting');
 
     return (
-        <div className="bg-yellow-50 border-b border-yellow-200 dark:bg-yellow-950/20 dark:border-yellow-800">
-            <div className="max-w-5xl mx-auto px-4 py-3">
-                <div className="flex items-center justify-between">
-                    <div className="flex items-center gap-2">
-                        <AlertTriangle className="h-4 w-4 text-yellow-600 dark:text-yellow-400" />
-                        <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
-                            {message}
-                        </span>
-                    </div>
+        <div role="alert" className="border-b border-yellow-200 bg-yellow-50 dark:border-yellow-800 dark:bg-yellow-950/20">
+            <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
+                <div className="flex min-w-0 items-center gap-2">
+                    <AlertTriangle className="h-4 w-4 shrink-0 text-yellow-600 dark:text-yellow-400" />
+                    <span className="text-sm font-medium text-yellow-800 dark:text-yellow-200">
+                        {message}
+                    </span>
+                </div>
+                <div className="ml-6 flex items-center gap-2 self-start sm:ml-0 sm:self-auto">
+                    {servers.map((server) => {
+                        const reconnectState = reconnectContext?.reconnectStates[server.serverId];
+                        const isReconnecting = reconnectState?.status === 'reconnecting';
+
+                        return (
+                            <Button
+                                key={server.serverId}
+                                size="sm"
+                                disabled={!reconnectState || isAnyReconnectStarting || !reconnectContext?.isReconnectAllowed}
+                                onClick={() => reconnectContext?.reconnect(server.serverId)}
+                            >
+                                {isReconnecting ? (
+                                    <>
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        Reconnecting...
+                                    </>
+                                ) : (
+                                    <>Reconnect {server.serverName}</>
+                                )}
+                            </Button>
+                        );
+                    })}
                     <Button
                         variant="ghost"
                         size="sm"

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
@@ -24,9 +24,7 @@ const createReconnectContext = (
 ): McpReconnectContextValue => ({
     reconnectStates: { [state.serverId]: state },
     isReconnectAllowed: true,
-    isContinueAllowed: false,
     reconnect: vi.fn(),
-    continueAfterReconnect: vi.fn(),
     ...overrides,
 });
 
@@ -68,35 +66,18 @@ describe('McpReconnectBanner', () => {
         expect(button.disabled).toBe(true);
     });
 
-    test('shows the continue action after reconnecting', () => {
-        const contextValue = createReconnectContext(
-            createReconnectState({ status: 'reconnected' }),
-            { isContinueAllowed: true },
-        );
-        renderBanner(contextValue);
-
-        expect(screen.getByRole('status')).toBeTruthy();
-        expect(screen.getByText('Linear reconnected')).toBeTruthy();
-
-        fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
-        expect(contextValue.continueAfterReconnect).toHaveBeenCalledWith('server-1');
-    });
-
-    test('does not offer Continue when automatic continuation is unavailable', () => {
+    test('does not render a success banner after reconnecting', () => {
         const contextValue = createReconnectContext(createReconnectState({ status: 'reconnected' }));
-        renderBanner(contextValue);
+        const { container } = renderBanner(contextValue);
 
-        expect(screen.getByText('Connection restored.')).toBeTruthy();
-        expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+        expect(container.childElementCount).toBe(0);
     });
 
     test('does not render without a reconnect failure', () => {
         const contextValue: McpReconnectContextValue = {
             reconnectStates: {},
             isReconnectAllowed: true,
-            isContinueAllowed: false,
             reconnect: vi.fn(),
-            continueAfterReconnect: vi.fn(),
         };
         const { container } = renderBanner(contextValue);
 

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
@@ -1,0 +1,104 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, test, vi } from 'vitest';
+import {
+    McpReconnectContext,
+    McpReconnectContextValue,
+    McpReconnectState,
+} from '@/ee/features/chat/mcpReconnectContext';
+import { McpReconnectBanner } from './mcpReconnectBanner';
+
+afterEach(cleanup);
+
+const createReconnectState = (overrides: Partial<McpReconnectState> = {}): McpReconnectState => ({
+    serverId: 'server-1',
+    serverName: 'Linear',
+    toolCallId: 'tool-call-1',
+    status: 'authentication-required',
+    ...overrides,
+});
+
+const createReconnectContext = (
+    state: McpReconnectState,
+    overrides: Partial<McpReconnectContextValue> = {},
+): McpReconnectContextValue => ({
+    reconnectStates: { [state.serverId]: state },
+    isReconnectAllowed: true,
+    isContinueAllowed: false,
+    reconnect: vi.fn(),
+    continueAfterReconnect: vi.fn(),
+    ...overrides,
+});
+
+const renderBanner = (contextValue: McpReconnectContextValue) => render(
+    <McpReconnectContext.Provider value={contextValue}>
+        <McpReconnectBanner />
+    </McpReconnectContext.Provider>
+);
+
+describe('McpReconnectBanner', () => {
+    test('warns about the authentication failure and exposes the reconnect action', () => {
+        const contextValue = createReconnectContext(createReconnectState());
+        renderBanner(contextValue);
+
+        expect(screen.getByRole('alert')).toBeTruthy();
+        expect(screen.getByText('Linear authentication failed')).toBeTruthy();
+        expect(screen.getByText('Reconnect Linear to continue using its tools.')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Reconnect Linear' }));
+        expect(contextValue.reconnect).toHaveBeenCalledWith('server-1');
+    });
+
+    test('keeps reconnect disabled until the assistant response settles', () => {
+        const contextValue = createReconnectContext(
+            createReconnectState(),
+            { isReconnectAllowed: false },
+        );
+        renderBanner(contextValue);
+
+        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+
+    test('shows progress while the reconnect flow starts', () => {
+        const contextValue = createReconnectContext(createReconnectState({ status: 'reconnecting' }));
+        renderBanner(contextValue);
+
+        const button = screen.getByRole('button', { name: /Reconnecting/ }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+
+    test('shows the continue action after reconnecting', () => {
+        const contextValue = createReconnectContext(
+            createReconnectState({ status: 'reconnected' }),
+            { isContinueAllowed: true },
+        );
+        renderBanner(contextValue);
+
+        expect(screen.getByRole('status')).toBeTruthy();
+        expect(screen.getByText('Linear reconnected')).toBeTruthy();
+
+        fireEvent.click(screen.getByRole('button', { name: 'Continue' }));
+        expect(contextValue.continueAfterReconnect).toHaveBeenCalledWith('server-1');
+    });
+
+    test('does not offer Continue when automatic continuation is unavailable', () => {
+        const contextValue = createReconnectContext(createReconnectState({ status: 'reconnected' }));
+        renderBanner(contextValue);
+
+        expect(screen.getByText('Connection restored.')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+    });
+
+    test('does not render without a reconnect failure', () => {
+        const contextValue: McpReconnectContextValue = {
+            reconnectStates: {},
+            isReconnectAllowed: true,
+            isContinueAllowed: false,
+            reconnect: vi.fn(),
+            continueAfterReconnect: vi.fn(),
+        };
+        const { container } = renderBanner(contextValue);
+
+        expect(container.childElementCount).toBe(0);
+    });
+});

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx
@@ -13,6 +13,7 @@ const createReconnectState = (overrides: Partial<McpReconnectState> = {}): McpRe
     serverId: 'server-1',
     serverName: 'Linear',
     toolCallId: 'tool-call-1',
+    source: 'tool-call',
     status: 'authentication-required',
     ...overrides,
 });
@@ -97,6 +98,13 @@ describe('McpReconnectBanner', () => {
             reconnect: vi.fn(),
             continueAfterReconnect: vi.fn(),
         };
+        const { container } = renderBanner(contextValue);
+
+        expect(container.childElementCount).toBe(0);
+    });
+
+    test('leaves tool-load failures to the failed-connectors banner', () => {
+        const contextValue = createReconnectContext(createReconnectState({ source: 'tool-load' }));
         const { container } = renderBanner(contextValue);
 
         expect(container.childElementCount).toBe(0);

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { Button } from '@/components/ui/button';
+import { useMcpReconnect } from '@/ee/features/chat/mcpReconnectContext';
+import { AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
+
+export const McpReconnectBanner = () => {
+    const reconnectContext = useMcpReconnect();
+    const reconnectStates = Object.values(reconnectContext?.reconnectStates ?? {});
+
+    if (!reconnectContext || reconnectStates.length === 0) {
+        return null;
+    }
+
+    return (
+        <div>
+            {reconnectStates.map((state) => {
+                if (state.status === 'reconnected') {
+                    return (
+                        <div
+                            key={state.serverId}
+                            role="status"
+                            className="border-b border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20"
+                        >
+                            <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                                <div className="flex items-start gap-2">
+                                    <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-600 dark:text-green-400" />
+                                    <div>
+                                        <p className="text-sm font-medium text-green-800 dark:text-green-200">
+                                            {state.serverName} reconnected
+                                        </p>
+                                        <p className="text-sm text-green-700 dark:text-green-300">
+                                            {reconnectContext.isContinueAllowed
+                                                ? 'Continue to retry your request.'
+                                                : 'Connection restored.'}
+                                        </p>
+                                    </div>
+                                </div>
+                                {reconnectContext.isContinueAllowed && (
+                                    <Button
+                                        size="sm"
+                                        className="self-start sm:self-auto"
+                                        onClick={() => reconnectContext.continueAfterReconnect(state.serverId)}
+                                    >
+                                        Continue
+                                    </Button>
+                                )}
+                            </div>
+                        </div>
+                    );
+                }
+
+                const isReconnecting = state.status === 'reconnecting';
+                return (
+                    <div
+                        key={state.serverId}
+                        role="alert"
+                        className="border-b border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/20"
+                    >
+                        <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
+                            <div className="flex items-start gap-2">
+                                <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-600 dark:text-red-400" />
+                                <div>
+                                    <p className="text-sm font-medium text-red-800 dark:text-red-200">
+                                        {state.serverName} authentication failed
+                                    </p>
+                                    <p className="text-sm text-red-700 dark:text-red-300">
+                                        Reconnect {state.serverName} to continue using its tools.
+                                    </p>
+                                </div>
+                            </div>
+                            <Button
+                                size="sm"
+                                className="self-start sm:self-auto"
+                                disabled={isReconnecting || !reconnectContext.isReconnectAllowed}
+                                onClick={() => reconnectContext.reconnect(state.serverId)}
+                            >
+                                {isReconnecting ? (
+                                    <>
+                                        <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                                        Reconnecting...
+                                    </>
+                                ) : (
+                                    <>Reconnect {state.serverName}</>
+                                )}
+                            </Button>
+                        </div>
+                    </div>
+                );
+            })}
+        </div>
+    );
+};

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
@@ -2,12 +2,12 @@
 
 import { Button } from '@/components/ui/button';
 import { useMcpReconnect } from '@/ee/features/chat/mcpReconnectContext';
-import { AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
+import { AlertCircle, Loader2 } from 'lucide-react';
 
 export const McpReconnectBanner = () => {
     const reconnectContext = useMcpReconnect();
     const reconnectStates = Object.values(reconnectContext?.reconnectStates ?? {})
-        .filter((state) => state.source !== 'tool-load');
+        .filter((state) => state.source !== 'tool-load' && state.status !== 'reconnected');
 
     if (!reconnectContext || reconnectStates.length === 0) {
         return null;
@@ -16,41 +16,6 @@ export const McpReconnectBanner = () => {
     return (
         <div>
             {reconnectStates.map((state) => {
-                if (state.status === 'reconnected') {
-                    return (
-                        <div
-                            key={state.serverId}
-                            role="status"
-                            className="border-b border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20"
-                        >
-                            <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
-                                <div className="flex min-w-0 items-start gap-2">
-                                    <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-600 dark:text-green-400" />
-                                    <div>
-                                        <p className="text-sm font-medium text-green-800 dark:text-green-200">
-                                            {state.serverName} reconnected
-                                        </p>
-                                        <p className="text-sm text-green-700 dark:text-green-300">
-                                            {reconnectContext.isContinueAllowed
-                                                ? 'Continue to retry your request.'
-                                                : 'Connection restored.'}
-                                        </p>
-                                    </div>
-                                </div>
-                                {reconnectContext.isContinueAllowed && (
-                                    <Button
-                                        size="sm"
-                                        className="ml-6 self-start sm:ml-0 sm:self-auto"
-                                        onClick={() => reconnectContext.continueAfterReconnect(state.serverId)}
-                                    >
-                                        Continue
-                                    </Button>
-                                )}
-                            </div>
-                        </div>
-                    );
-                }
-
                 const isReconnecting = state.status === 'reconnecting';
                 return (
                     <div

--- a/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/mcpReconnectBanner.tsx
@@ -6,7 +6,8 @@ import { AlertCircle, CheckCircle, Loader2 } from 'lucide-react';
 
 export const McpReconnectBanner = () => {
     const reconnectContext = useMcpReconnect();
-    const reconnectStates = Object.values(reconnectContext?.reconnectStates ?? {});
+    const reconnectStates = Object.values(reconnectContext?.reconnectStates ?? {})
+        .filter((state) => state.source !== 'tool-load');
 
     if (!reconnectContext || reconnectStates.length === 0) {
         return null;
@@ -22,8 +23,8 @@ export const McpReconnectBanner = () => {
                             role="status"
                             className="border-b border-green-200 bg-green-50 dark:border-green-800 dark:bg-green-950/20"
                         >
-                            <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                                <div className="flex items-start gap-2">
+                            <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
+                                <div className="flex min-w-0 items-start gap-2">
                                     <CheckCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-green-600 dark:text-green-400" />
                                     <div>
                                         <p className="text-sm font-medium text-green-800 dark:text-green-200">
@@ -39,7 +40,7 @@ export const McpReconnectBanner = () => {
                                 {reconnectContext.isContinueAllowed && (
                                     <Button
                                         size="sm"
-                                        className="self-start sm:self-auto"
+                                        className="ml-6 self-start sm:ml-0 sm:self-auto"
                                         onClick={() => reconnectContext.continueAfterReconnect(state.serverId)}
                                     >
                                         Continue
@@ -57,8 +58,8 @@ export const McpReconnectBanner = () => {
                         role="alert"
                         className="border-b border-red-200 bg-red-50 dark:border-red-800 dark:bg-red-950/20"
                     >
-                        <div className="mx-auto flex max-w-5xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-between">
-                            <div className="flex items-start gap-2">
+                        <div className="mx-auto flex max-w-3xl flex-col gap-3 px-4 py-3 sm:flex-row sm:items-center sm:justify-center sm:gap-6">
+                            <div className="flex min-w-0 items-start gap-2">
                                 <AlertCircle className="mt-0.5 h-4 w-4 flex-shrink-0 text-red-600 dark:text-red-400" />
                                 <div>
                                     <p className="text-sm font-medium text-red-800 dark:text-red-200">
@@ -71,7 +72,7 @@ export const McpReconnectBanner = () => {
                             </div>
                             <Button
                                 size="sm"
-                                className="self-start sm:self-auto"
+                                className="ml-6 self-start sm:ml-0 sm:self-auto"
                                 disabled={isReconnecting || !reconnectContext.isReconnectAllowed}
                                 onClick={() => reconnectContext.reconnect(state.serverId)}
                             >

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
@@ -71,9 +71,7 @@ const createReconnectContext = (
 ): McpReconnectContextValue => ({
     reconnectStates: { [state.serverId]: state },
     isReconnectAllowed: true,
-    isContinueAllowed: false,
     reconnect: vi.fn(),
-    continueAfterReconnect: vi.fn(),
     ...overrides,
 });
 

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
@@ -1,8 +1,13 @@
-import { render, screen } from '@testing-library/react';
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
 import type { DynamicToolUIPart } from 'ai';
-import { describe, expect, test } from 'vitest';
+import { afterEach, describe, expect, test, vi } from 'vitest';
 import { McpToolNameContext } from '@/ee/features/chat/mcpDisplayMetadataContext';
+import { McpReconnectContext, McpReconnectContextValue, McpReconnectState } from '@/ee/features/chat/mcpReconnectContext';
 import { getMcpToolDisplayParts, McpToolComponent } from './mcpToolComponent';
+
+// React Testing Library's automatic cleanup relies on vitest globals, which
+// this project does not enable.
+afterEach(cleanup);
 
 describe('getMcpToolDisplayParts', () => {
     test('maps provider-safe MCP tool names back to raw tool names for display', () => {
@@ -48,5 +53,147 @@ describe('McpToolComponent', () => {
         expect(screen.getByText('backstage: catalog.query-catalog-entities')).toBeTruthy();
         expect(screen.getByText('Request (backstage: catalog.query-catalog-entities)')).toBeTruthy();
         expect(screen.queryByText('backstage: catalog_query-catalog-entities')).toBeNull();
+    });
+});
+
+const createErrorPart = (toolCallId = 'tool-call-1'): DynamicToolUIPart => ({
+    type: 'dynamic-tool',
+    toolName: 'mcp_linear__list_issues',
+    toolCallId,
+    state: 'output-error',
+    input: { query: 'open issues' },
+    errorText: 'Authentication required: the connection to "Linear" is no longer authorized.',
+} as DynamicToolUIPart);
+
+const createReconnectContext = (
+    state: McpReconnectState,
+    overrides: Partial<McpReconnectContextValue> = {},
+): McpReconnectContextValue => ({
+    reconnectStates: { [state.serverId]: state },
+    isReconnectAllowed: true,
+    isContinueAllowed: false,
+    reconnect: vi.fn(),
+    continueAfterReconnect: vi.fn(),
+    ...overrides,
+});
+
+const createReconnectState = (overrides: Partial<McpReconnectState> = {}): McpReconnectState => ({
+    serverId: 'server-1',
+    serverName: 'Linear',
+    toolCallId: 'tool-call-1',
+    status: 'authentication-required',
+    ...overrides,
+});
+
+describe('McpToolComponent reconnect recovery UI', () => {
+    test('shows the concise reconnect message and an enabled Reconnect action once the response settles', () => {
+        const contextValue = createReconnectContext(createReconnectState());
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        expect(screen.getByText('Linear needs to be reconnected.')).toBeTruthy();
+        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
+        expect(button.disabled).toBe(false);
+
+        fireEvent.click(button);
+        expect(contextValue.reconnect).toHaveBeenCalledWith('server-1');
+    });
+
+    test('keeps Reconnect disabled while the assistant response has not settled', () => {
+        const contextValue = createReconnectContext(createReconnectState(), { isReconnectAllowed: false });
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+
+    test('shows a loading state while OAuth is starting', () => {
+        const contextValue = createReconnectContext(createReconnectState({ status: 'reconnecting' }));
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        const button = screen.getByRole('button', { name: /Reconnecting/ }) as HTMLButtonElement;
+        expect(button.disabled).toBe(true);
+    });
+
+    test('shows Reconnected and Continue after a successful reconnect', () => {
+        const contextValue = createReconnectContext(
+            createReconnectState({ status: 'reconnected' }),
+            { isContinueAllowed: true },
+        );
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        expect(screen.getByText('Reconnected')).toBeTruthy();
+        const button = screen.getByRole('button', { name: 'Continue' });
+        fireEvent.click(button);
+        expect(contextValue.continueAfterReconnect).toHaveBeenCalledWith('server-1');
+    });
+
+    test('hides Continue when it is not allowed (e.g. multiple failed connectors)', () => {
+        const contextValue = createReconnectContext(
+            createReconnectState({ status: 'reconnected' }),
+            { isContinueAllowed: false },
+        );
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        expect(screen.getByText('Reconnected')).toBeTruthy();
+        expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+    });
+
+    test('keeps the technical error inside the expandable details section', () => {
+        const contextValue = createReconnectContext(createReconnectState());
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart()} />
+            </McpReconnectContext.Provider>
+        );
+
+        expect(screen.queryByText(/is no longer authorized/)).toBeNull();
+        fireEvent.click(screen.getByText('Details'));
+        expect(screen.getByText(/is no longer authorized/)).toBeTruthy();
+    });
+
+    test('only decorates the tool result whose call failed authentication', () => {
+        const contextValue = createReconnectContext(createReconnectState());
+
+        render(
+            <McpReconnectContext.Provider value={contextValue}>
+                <McpToolComponent part={createErrorPart('tool-call-other')} />
+            </McpReconnectContext.Provider>
+        );
+
+        expect(screen.queryByText('Linear needs to be reconnected.')).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reconnect Linear' })).toBeNull();
+    });
+
+    test('falls back to the plain error rendering without a reconnect provider', () => {
+        render(<McpToolComponent part={createErrorPart()} />);
+
+        expect(screen.queryByText('Linear needs to be reconnected.')).toBeNull();
+        expect(screen.getByText(/failed:/)).toBeTruthy();
     });
 });

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
@@ -86,7 +86,7 @@ const createReconnectState = (overrides: Partial<McpReconnectState> = {}): McpRe
 });
 
 describe('McpToolComponent reconnect recovery UI', () => {
-    test('shows the concise reconnect message and an enabled Reconnect action once the response settles', () => {
+    test('keeps the concise authentication error in details without duplicating the banner action', () => {
         const contextValue = createReconnectContext(createReconnectState());
 
         render(
@@ -96,71 +96,7 @@ describe('McpToolComponent reconnect recovery UI', () => {
         );
 
         expect(screen.getByText('Linear needs to be reconnected.')).toBeTruthy();
-        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
-        expect(button.disabled).toBe(false);
-
-        fireEvent.click(button);
-        expect(contextValue.reconnect).toHaveBeenCalledWith('server-1');
-    });
-
-    test('keeps Reconnect disabled while the assistant response has not settled', () => {
-        const contextValue = createReconnectContext(createReconnectState(), { isReconnectAllowed: false });
-
-        render(
-            <McpReconnectContext.Provider value={contextValue}>
-                <McpToolComponent part={createErrorPart()} />
-            </McpReconnectContext.Provider>
-        );
-
-        const button = screen.getByRole('button', { name: 'Reconnect Linear' }) as HTMLButtonElement;
-        expect(button.disabled).toBe(true);
-    });
-
-    test('shows a loading state while OAuth is starting', () => {
-        const contextValue = createReconnectContext(createReconnectState({ status: 'reconnecting' }));
-
-        render(
-            <McpReconnectContext.Provider value={contextValue}>
-                <McpToolComponent part={createErrorPart()} />
-            </McpReconnectContext.Provider>
-        );
-
-        const button = screen.getByRole('button', { name: /Reconnecting/ }) as HTMLButtonElement;
-        expect(button.disabled).toBe(true);
-    });
-
-    test('shows Reconnected and Continue after a successful reconnect', () => {
-        const contextValue = createReconnectContext(
-            createReconnectState({ status: 'reconnected' }),
-            { isContinueAllowed: true },
-        );
-
-        render(
-            <McpReconnectContext.Provider value={contextValue}>
-                <McpToolComponent part={createErrorPart()} />
-            </McpReconnectContext.Provider>
-        );
-
-        expect(screen.getByText('Reconnected')).toBeTruthy();
-        const button = screen.getByRole('button', { name: 'Continue' });
-        fireEvent.click(button);
-        expect(contextValue.continueAfterReconnect).toHaveBeenCalledWith('server-1');
-    });
-
-    test('hides Continue when it is not allowed (e.g. multiple failed connectors)', () => {
-        const contextValue = createReconnectContext(
-            createReconnectState({ status: 'reconnected' }),
-            { isContinueAllowed: false },
-        );
-
-        render(
-            <McpReconnectContext.Provider value={contextValue}>
-                <McpToolComponent part={createErrorPart()} />
-            </McpReconnectContext.Provider>
-        );
-
-        expect(screen.getByText('Reconnected')).toBeTruthy();
-        expect(screen.queryByRole('button', { name: 'Continue' })).toBeNull();
+        expect(screen.queryByRole('button', { name: 'Reconnect Linear' })).toBeNull();
     });
 
     test('keeps the technical error inside the expandable details section', () => {

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
@@ -81,6 +81,7 @@ const createReconnectState = (overrides: Partial<McpReconnectState> = {}): McpRe
     serverId: 'server-1',
     serverName: 'Linear',
     toolCallId: 'tool-call-1',
+    source: 'tool-call',
     status: 'authentication-required',
     ...overrides,
 });

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.tsx
@@ -3,12 +3,11 @@
 import { CopyIconButton } from "@/app/(app)/components/copyIconButton";
 import { McpFavicon } from "@/ee/features/chat/mcp/components/mcpFavicon";
 import { McpToolNameMap, useMcpServerIconMap, useMcpToolNameMap } from "@/ee/features/chat/mcpDisplayMetadataContext";
-import { getMcpReconnectStateForToolCall, McpReconnectState, useMcpReconnect } from "@/ee/features/chat/mcpReconnectContext";
+import { getMcpReconnectStateForToolCall, useMcpReconnect } from "@/ee/features/chat/mcpReconnectContext";
 import { cn } from "@/lib/utils";
-import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { DynamicToolUIPart } from "ai";
-import { CheckCircle, ChevronDown, Loader2, XCircle } from "lucide-react";
+import { CheckCircle, ChevronDown, XCircle } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { JsonHighlighter, unescapeJsonStrings } from "./jsonHighlighter";
 import { ToolTokenBadge } from "./toolTokenBadge";
@@ -178,9 +177,6 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
                     </button>
                 )}
             </div>
-            {reconnectState && (
-                <McpReconnectActions state={reconnectState} />
-            )}
             {hasInput && isExpanded && (
                 <div className="rounded-lg border border-border text-xs overflow-y-auto max-h-72">
                     <ResultSection label={`Request (${display.displayName})`} onCopy={onCopyRequest}>
@@ -201,54 +197,6 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
         </div>
     );
 };
-
-const McpReconnectActions = ({ state }: { state: McpReconnectState }) => {
-    const reconnectContext = useMcpReconnect();
-    if (!reconnectContext) {
-        return null;
-    }
-
-    if (state.status === 'reconnected') {
-        return (
-            <div className="flex items-center gap-3">
-                <span className="text-sm text-muted-foreground flex items-center gap-1.5">
-                    <CheckCircle className="w-3.5 h-3.5 text-green-600 flex-shrink-0" />
-                    Reconnected
-                </span>
-                {reconnectContext.isContinueAllowed && (
-                    <Button
-                        size="sm"
-                        onClick={() => reconnectContext.continueAfterReconnect(state.serverId)}
-                    >
-                        Continue
-                    </Button>
-                )}
-            </div>
-        );
-    }
-
-    const isReconnecting = state.status === 'reconnecting';
-    return (
-        <div className="flex items-center">
-            <Button
-                size="sm"
-                variant="outline"
-                disabled={isReconnecting || !reconnectContext.isReconnectAllowed}
-                onClick={() => reconnectContext.reconnect(state.serverId)}
-            >
-                {isReconnecting ? (
-                    <>
-                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
-                        Reconnecting...
-                    </>
-                ) : (
-                    <>Reconnect {state.serverName}</>
-                )}
-            </Button>
-        </div>
-    );
-};
-
 
 const ResultSection = ({ label, onCopy, children }: { label: string; onCopy: () => boolean; children: React.ReactNode }) => (
     <div className="flex flex-col gap-1.5">

--- a/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/tools/mcpToolComponent.tsx
@@ -3,10 +3,12 @@
 import { CopyIconButton } from "@/app/(app)/components/copyIconButton";
 import { McpFavicon } from "@/ee/features/chat/mcp/components/mcpFavicon";
 import { McpToolNameMap, useMcpServerIconMap, useMcpToolNameMap } from "@/ee/features/chat/mcpDisplayMetadataContext";
+import { getMcpReconnectStateForToolCall, McpReconnectState, useMcpReconnect } from "@/ee/features/chat/mcpReconnectContext";
 import { cn } from "@/lib/utils";
+import { Button } from "@/components/ui/button";
 import { Separator } from "@/components/ui/separator";
 import { DynamicToolUIPart } from "ai";
-import { CheckCircle, ChevronDown, XCircle } from "lucide-react";
+import { CheckCircle, ChevronDown, Loader2, XCircle } from "lucide-react";
 import { useCallback, useMemo, useState } from "react";
 import { JsonHighlighter, unescapeJsonStrings } from "./jsonHighlighter";
 import { ToolTokenBadge } from "./toolTokenBadge";
@@ -55,6 +57,11 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
     const display = getMcpToolDisplayParts(part.toolName, rawToolNames);
     const faviconUrl = display.serverName ? iconMap[display.serverName] : undefined;
 
+    const reconnectContext = useMcpReconnect();
+    const reconnectState = reconnectContext && part.state === 'output-error'
+        ? getMcpReconnectStateForToolCall(reconnectContext.reconnectStates, part.toolCallId)
+        : undefined;
+
     const hasInput = part.state !== 'input-streaming';
 
     const requestText = useMemo(
@@ -90,6 +97,14 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
 
     const renderStatus = () => {
         if (part.state === 'output-error') {
+            if (reconnectState) {
+                return (
+                    <span className="text-sm flex-1 text-destructive flex items-center gap-1.5">
+                        <McpFavicon faviconUrl={faviconUrl} className="w-3 h-3" />
+                        {reconnectState.serverName} needs to be reconnected.
+                    </span>
+                );
+            }
             return (
                 <span className="text-sm flex-1 text-destructive flex items-center gap-1.5">
                     <McpFavicon faviconUrl={faviconUrl} className="w-3 h-3" />
@@ -163,6 +178,9 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
                     </button>
                 )}
             </div>
+            {reconnectState && (
+                <McpReconnectActions state={reconnectState} />
+            )}
             {hasInput && isExpanded && (
                 <div className="rounded-lg border border-border text-xs overflow-y-auto max-h-72">
                     <ResultSection label={`Request (${display.displayName})`} onCopy={onCopyRequest}>
@@ -180,6 +198,53 @@ export const McpToolComponent = ({ part, estimatedOutputTokens }: { part: Dynami
                     )}
                 </div>
             )}
+        </div>
+    );
+};
+
+const McpReconnectActions = ({ state }: { state: McpReconnectState }) => {
+    const reconnectContext = useMcpReconnect();
+    if (!reconnectContext) {
+        return null;
+    }
+
+    if (state.status === 'reconnected') {
+        return (
+            <div className="flex items-center gap-3">
+                <span className="text-sm text-muted-foreground flex items-center gap-1.5">
+                    <CheckCircle className="w-3.5 h-3.5 text-green-600 flex-shrink-0" />
+                    Reconnected
+                </span>
+                {reconnectContext.isContinueAllowed && (
+                    <Button
+                        size="sm"
+                        onClick={() => reconnectContext.continueAfterReconnect(state.serverId)}
+                    >
+                        Continue
+                    </Button>
+                )}
+            </div>
+        );
+    }
+
+    const isReconnecting = state.status === 'reconnecting';
+    return (
+        <div className="flex items-center">
+            <Button
+                size="sm"
+                variant="outline"
+                disabled={isReconnecting || !reconnectContext.isReconnectAllowed}
+                onClick={() => reconnectContext.reconnect(state.serverId)}
+            >
+                {isReconnecting ? (
+                    <>
+                        <Loader2 className="w-3.5 h-3.5 animate-spin" />
+                        Reconnecting...
+                    </>
+                ) : (
+                    <>Reconnect {state.serverName}</>
+                )}
+            </Button>
         </div>
     );
 };

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
@@ -184,6 +184,26 @@ describe('useMcpReconnectController', () => {
         expect(mocks.connectMcpToAsk).not.toHaveBeenCalled();
     });
 
+    test('resets reconnect state when starting the OAuth flow rejects', async () => {
+        mocks.connectMcpToAsk.mockRejectedValue(new Error('Network error'));
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+
+        await act(async () => {
+            result.current.contextValue.reconnect('server-1');
+        });
+
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+        expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('authentication-required');
+        expect(mocks.toast).toHaveBeenCalledWith({
+            description: 'Failed to reconnect Linear.',
+            variant: 'destructive',
+        });
+    });
+
     test('shows a success toast when reconnection completes without an OAuth redirect', async () => {
         mocks.connectMcpToAsk.mockResolvedValue({ authorizationUrl: null });
         mocks.getMcpServersWithStatus.mockResolvedValue([
@@ -266,6 +286,27 @@ describe('useMcpReconnectController', () => {
             expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
         });
         expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+    });
+
+    test('resets reconnect state when the OAuth return status check rejects', async () => {
+        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+            createdAt: Date.now(),
+        }));
+        mocks.getMcpServersWithStatus.mockRejectedValue(new Error('Network error'));
+
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        await waitFor(() => {
+            expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('authentication-required');
+        });
+        expect(mocks.toast).toHaveBeenCalledWith({
+            description: 'Linear was not reconnected.',
+            variant: 'destructive',
+        });
     });
 
     test('restores the source of a failed tool-load reconnect after OAuth', async () => {

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
@@ -5,7 +5,6 @@ import { ReactNode } from 'react';
 import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
 import { MCP_RECONNECT_SESSION_STORAGE_KEY } from '@/features/chat/constants';
 import { SBChatMessage } from '@/features/chat/types';
-import { getUserMessageText } from '@/features/chat/utils';
 import { useMcpReconnectController } from './useMcpReconnectController';
 
 const mocks = vi.hoisted(() => ({
@@ -44,16 +43,12 @@ const createWrapper = () => {
 };
 
 const addToolApprovalResponse = vi.fn();
-const sendMessage = vi.fn();
 
 const renderController = (initialProps: HookProps) =>
     renderHook(
         (props: HookProps) => useMcpReconnectController({
             ...props,
             addToolApprovalResponse,
-            sendMessage,
-            selectedSearchScopes: [],
-            disabledMcpServerIds: [],
         }),
         { initialProps, wrapper: createWrapper() },
     );
@@ -189,6 +184,28 @@ describe('useMcpReconnectController', () => {
         expect(mocks.connectMcpToAsk).not.toHaveBeenCalled();
     });
 
+    test('shows a success toast when reconnection completes without an OAuth redirect', async () => {
+        mocks.connectMcpToAsk.mockResolvedValue({ authorizationUrl: null });
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
+        ]);
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+
+        await act(async () => {
+            result.current.contextValue.reconnect('server-1');
+        });
+
+        await waitFor(() => {
+            expect(mocks.toast).toHaveBeenCalledWith({
+                description: 'Successfully reconnected to Linear.',
+            });
+        });
+    });
+
     test('tracks a failed tool load without treating it as a failed tool call', () => {
         const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
 
@@ -202,7 +219,6 @@ describe('useMcpReconnectController', () => {
             source: 'tool-load',
             status: 'authentication-required',
         });
-        expect(result.current.contextValue.isContinueAllowed).toBe(false);
         expect(addToolApprovalResponse).not.toHaveBeenCalled();
     });
 
@@ -224,7 +240,6 @@ describe('useMcpReconnectController', () => {
             expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
         });
         expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
-        expect(result.current.contextValue.isContinueAllowed).toBe(true);
     });
 
     test('restores the source of a failed tool-load reconnect after OAuth', async () => {
@@ -245,7 +260,6 @@ describe('useMcpReconnectController', () => {
             expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
         });
         expect(result.current.contextValue.reconnectStates['server-1']?.source).toBe('tool-load');
-        expect(result.current.contextValue.isContinueAllowed).toBe(false);
     });
 
     test('falls back to authentication-required when the OAuth return did not reconnect the connector', async () => {
@@ -265,53 +279,5 @@ describe('useMcpReconnectController', () => {
         await waitFor(() => {
             expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('authentication-required');
         });
-        expect(result.current.contextValue.isContinueAllowed).toBe(false);
-    });
-
-    test('Continue sends a visible user turn naming the reconnected connector and resets the state', async () => {
-        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
-            serverId: 'server-1',
-            serverName: 'Linear',
-            toolCallId: 'tool-call-1',
-            returnTo: '/chat/abc123',
-            createdAt: Date.now(),
-        }));
-        mocks.getMcpServersWithStatus.mockResolvedValue([
-            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
-        ]);
-
-        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
-        await waitFor(() => {
-            expect(result.current.contextValue.isContinueAllowed).toBe(true);
-        });
-
-        act(() => {
-            result.current.contextValue.continueAfterReconnect('server-1');
-        });
-
-        expect(sendMessage).toHaveBeenCalledTimes(1);
-        const sentMessage = sendMessage.mock.calls[0][0];
-        expect(sentMessage.role).toBe('user');
-        expect(getUserMessageText(sentMessage as SBChatMessage)).toBe(
-            'Continue the previous request now that Linear is reconnected. Do not repeat operations that already completed.'
-        );
-        expect(result.current.contextValue.reconnectStates).toEqual({});
-    });
-
-    test('Continue is unavailable when more than one connector failed authentication', () => {
-        const { result, rerender } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
-
-        act(() => {
-            result.current.onAuthRequired(AUTH_FAILURE);
-            result.current.onAuthRequired({ serverId: 'server-2', serverName: 'Jira', toolCallId: 'tool-call-3' });
-        });
-        rerender({ status: 'ready', messages: [], isTurnInProgress: false });
-
-        expect(result.current.contextValue.isContinueAllowed).toBe(false);
-
-        act(() => {
-            result.current.contextValue.continueAfterReconnect('server-1');
-        });
-        expect(sendMessage).not.toHaveBeenCalled();
     });
 });

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
@@ -206,6 +206,32 @@ describe('useMcpReconnectController', () => {
         });
     });
 
+    test('stops automatically denying approvals after all failed tool calls reconnect', async () => {
+        mocks.connectMcpToAsk.mockResolvedValue({ authorizationUrl: null });
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
+        ]);
+        const { result, rerender } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+
+        await act(async () => {
+            result.current.contextValue.reconnect('server-1');
+        });
+        await waitFor(() => {
+            expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
+        });
+
+        rerender({
+            status: 'ready',
+            messages: [assistantMessageWithPendingApproval()],
+            isTurnInProgress: false,
+        });
+        expect(addToolApprovalResponse).not.toHaveBeenCalled();
+    });
+
     test('tracks a failed tool load without treating it as a failed tool call', () => {
         const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
 

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
@@ -1,0 +1,275 @@
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ChatStatus } from 'ai';
+import { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+import { MCP_RECONNECT_SESSION_STORAGE_KEY } from '@/features/chat/constants';
+import { SBChatMessage } from '@/features/chat/types';
+import { getUserMessageText } from '@/features/chat/utils';
+import { useMcpReconnectController } from './useMcpReconnectController';
+
+const mocks = vi.hoisted(() => ({
+    connectMcpToAsk: vi.fn(),
+    getMcpServersWithStatus: vi.fn(),
+    toast: vi.fn(),
+}));
+
+vi.mock('@/app/api/(client)/client', () => ({
+    connectMcpToAsk: mocks.connectMcpToAsk,
+    getMcpServersWithStatus: mocks.getMcpServersWithStatus,
+}));
+
+vi.mock('@/components/hooks/use-toast', () => ({
+    useToast: () => ({ toast: mocks.toast }),
+}));
+
+const AUTH_FAILURE = {
+    serverId: 'server-1',
+    serverName: 'Linear',
+    toolCallId: 'tool-call-1',
+};
+
+interface HookProps {
+    status: ChatStatus;
+    messages: SBChatMessage[];
+    isTurnInProgress: boolean;
+}
+
+const createWrapper = () => {
+    const queryClient = new QueryClient();
+    const Wrapper = ({ children }: { children: ReactNode }) => (
+        <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+    );
+    return Wrapper;
+};
+
+const addToolApprovalResponse = vi.fn();
+const sendMessage = vi.fn();
+
+const renderController = (initialProps: HookProps) =>
+    renderHook(
+        (props: HookProps) => useMcpReconnectController({
+            ...props,
+            addToolApprovalResponse,
+            sendMessage,
+            selectedSearchScopes: [],
+            disabledMcpServerIds: [],
+        }),
+        { initialProps, wrapper: createWrapper() },
+    );
+
+const assistantMessageWithPendingApproval = (): SBChatMessage => ({
+    id: 'assistant-1',
+    role: 'assistant',
+    parts: [
+        { type: 'step-start' },
+        {
+            type: 'dynamic-tool',
+            toolName: 'mcp_linear__save_comment',
+            toolCallId: 'tool-call-2',
+            state: 'approval-requested',
+            input: {},
+            approval: { id: 'approval-1' },
+        },
+    ] as SBChatMessage['parts'],
+});
+
+beforeEach(() => {
+    vi.clearAllMocks();
+    window.sessionStorage.clear();
+    window.history.pushState({}, '', '/chat/abc123');
+});
+
+afterEach(cleanup);
+
+describe('useMcpReconnectController', () => {
+    test('deduplicates repeated failures from the same connector, keeping the first tool call', () => {
+        const { result } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+            result.current.onAuthRequired({ ...AUTH_FAILURE, toolCallId: 'tool-call-9' });
+        });
+
+        const states = Object.values(result.current.contextValue.reconnectStates);
+        expect(states).toHaveLength(1);
+        expect(states[0]).toMatchObject({
+            serverId: 'server-1',
+            toolCallId: 'tool-call-1',
+            status: 'authentication-required',
+        });
+    });
+
+    test('automatically denies pending tool approvals exactly once', () => {
+        const messages = [assistantMessageWithPendingApproval()];
+        const { result, rerender } = renderController({ status: 'ready', messages, isTurnInProgress: true });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+
+        expect(addToolApprovalResponse).toHaveBeenCalledTimes(1);
+        expect(addToolApprovalResponse).toHaveBeenCalledWith(expect.objectContaining({
+            id: 'approval-1',
+            approved: false,
+        }));
+
+        rerender({ status: 'ready', messages: [...messages], isTurnInProgress: true });
+        expect(addToolApprovalResponse).toHaveBeenCalledTimes(1);
+    });
+
+    test('keeps Reconnect disabled until the interrupted response settles across stream gaps', () => {
+        const { result, rerender } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+        expect(result.current.contextValue.isReconnectAllowed).toBe(false);
+
+        // A stream can report ready between phases while the turn is still in
+        // progress (e.g. waiting on the denial continuation).
+        rerender({ status: 'ready', messages: [], isTurnInProgress: true });
+        expect(result.current.contextValue.isReconnectAllowed).toBe(false);
+
+        rerender({ status: 'ready', messages: [], isTurnInProgress: false });
+        expect(result.current.contextValue.isReconnectAllowed).toBe(true);
+    });
+
+    test('starts the OAuth flow, saving the pending reconnect and redirecting in the current tab', async () => {
+        mocks.connectMcpToAsk.mockResolvedValue({ authorizationUrl: 'https://auth.example.com/authorize' });
+        const originalLocation = window.location;
+        Object.defineProperty(window, 'location', {
+            configurable: true,
+            value: { ...originalLocation, pathname: '/chat/abc123', search: '', href: 'http://localhost/chat/abc123' },
+        });
+
+        try {
+            const { result, rerender } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
+            act(() => {
+                result.current.onAuthRequired(AUTH_FAILURE);
+            });
+            rerender({ status: 'ready', messages: [], isTurnInProgress: false });
+
+            await act(async () => {
+                result.current.contextValue.reconnect('server-1');
+            });
+
+            await waitFor(() => {
+                expect(mocks.connectMcpToAsk).toHaveBeenCalledWith({ serverId: 'server-1', returnTo: '/chat/abc123' });
+            });
+
+            const stored = JSON.parse(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY) ?? '{}');
+            expect(stored).toMatchObject({
+                serverId: 'server-1',
+                serverName: 'Linear',
+                toolCallId: 'tool-call-1',
+                returnTo: '/chat/abc123',
+            });
+            expect(window.location.href).toBe('https://auth.example.com/authorize');
+            expect(result.current.contextValue.reconnectStates['server-1'].status).toBe('reconnecting');
+        } finally {
+            Object.defineProperty(window, 'location', { configurable: true, value: originalLocation });
+        }
+    });
+
+    test('does not start the OAuth flow while the response is still settling', () => {
+        const { result } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+        });
+
+        act(() => {
+            result.current.contextValue.reconnect('server-1');
+        });
+
+        expect(mocks.connectMcpToAsk).not.toHaveBeenCalled();
+    });
+
+    test('restores the pending reconnect after the OAuth return and confirms via the status query', async () => {
+        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+            createdAt: Date.now(),
+        }));
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
+        ]);
+
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        await waitFor(() => {
+            expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
+        });
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+        expect(result.current.contextValue.isContinueAllowed).toBe(true);
+    });
+
+    test('falls back to authentication-required when the OAuth return did not reconnect the connector', async () => {
+        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+            createdAt: Date.now(),
+        }));
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: false, isAuthExpired: false },
+        ]);
+
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        await waitFor(() => {
+            expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('authentication-required');
+        });
+        expect(result.current.contextValue.isContinueAllowed).toBe(false);
+    });
+
+    test('Continue sends a visible user turn naming the reconnected connector and resets the state', async () => {
+        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+            createdAt: Date.now(),
+        }));
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
+        ]);
+
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+        await waitFor(() => {
+            expect(result.current.contextValue.isContinueAllowed).toBe(true);
+        });
+
+        act(() => {
+            result.current.contextValue.continueAfterReconnect('server-1');
+        });
+
+        expect(sendMessage).toHaveBeenCalledTimes(1);
+        const sentMessage = sendMessage.mock.calls[0][0];
+        expect(sentMessage.role).toBe('user');
+        expect(getUserMessageText(sentMessage as SBChatMessage)).toBe(
+            'Continue the previous request now that Linear is reconnected. Do not repeat operations that already completed.'
+        );
+        expect(result.current.contextValue.reconnectStates).toEqual({});
+    });
+
+    test('Continue is unavailable when more than one connector failed authentication', () => {
+        const { result, rerender } = renderController({ status: 'streaming', messages: [], isTurnInProgress: true });
+
+        act(() => {
+            result.current.onAuthRequired(AUTH_FAILURE);
+            result.current.onAuthRequired({ serverId: 'server-2', serverName: 'Jira', toolCallId: 'tool-call-3' });
+        });
+        rerender({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        expect(result.current.contextValue.isContinueAllowed).toBe(false);
+
+        act(() => {
+            result.current.contextValue.continueAfterReconnect('server-1');
+        });
+        expect(sendMessage).not.toHaveBeenCalled();
+    });
+});

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx
@@ -155,7 +155,11 @@ describe('useMcpReconnectController', () => {
             });
 
             await waitFor(() => {
-                expect(mocks.connectMcpToAsk).toHaveBeenCalledWith({ serverId: 'server-1', returnTo: '/chat/abc123' });
+                expect(mocks.connectMcpToAsk).toHaveBeenCalledWith({
+                    serverId: 'server-1',
+                    returnTo: '/chat/abc123',
+                    forceAuthorization: true,
+                });
             });
 
             const stored = JSON.parse(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY) ?? '{}');
@@ -185,6 +189,23 @@ describe('useMcpReconnectController', () => {
         expect(mocks.connectMcpToAsk).not.toHaveBeenCalled();
     });
 
+    test('tracks a failed tool load without treating it as a failed tool call', () => {
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        act(() => {
+            result.current.onServerLoadFailed({ serverId: 'server-1', serverName: 'Linear' });
+        });
+
+        expect(result.current.contextValue.reconnectStates['server-1']).toMatchObject({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            source: 'tool-load',
+            status: 'authentication-required',
+        });
+        expect(result.current.contextValue.isContinueAllowed).toBe(false);
+        expect(addToolApprovalResponse).not.toHaveBeenCalled();
+    });
+
     test('restores the pending reconnect after the OAuth return and confirms via the status query', async () => {
         window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
             serverId: 'server-1',
@@ -204,6 +225,27 @@ describe('useMcpReconnectController', () => {
         });
         expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
         expect(result.current.contextValue.isContinueAllowed).toBe(true);
+    });
+
+    test('restores the source of a failed tool-load reconnect after OAuth', async () => {
+        window.sessionStorage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            source: 'tool-load',
+            returnTo: '/chat/abc123',
+            createdAt: Date.now(),
+        }));
+        mocks.getMcpServersWithStatus.mockResolvedValue([
+            { id: 'server-1', name: 'Linear', isConnected: true, isAuthExpired: false },
+        ]);
+
+        const { result } = renderController({ status: 'ready', messages: [], isTurnInProgress: false });
+
+        await waitFor(() => {
+            expect(result.current.contextValue.reconnectStates['server-1']?.status).toBe('reconnected');
+        });
+        expect(result.current.contextValue.reconnectStates['server-1']?.source).toBe('tool-load');
+        expect(result.current.contextValue.isContinueAllowed).toBe(false);
     });
 
     test('falls back to authentication-required when the OAuth return did not reconnect the connector', async () => {

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
@@ -120,7 +120,8 @@ export function useMcpReconnectController({
     // Automatically deny every tool approval still pending in the interrupted
     // response. Later approval actions are invalid: the parts flip to
     // approval-responded, which removes the approval UI.
-    const hasAuthFailure = Object.values(reconnectStates).some((state) => state.source !== 'tool-load');
+    const hasAuthFailure = Object.values(reconnectStates)
+        .some((state) => state.source !== 'tool-load' && state.status !== 'reconnected');
     useEffect(() => {
         if (!hasAuthFailure) {
             return;

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
@@ -27,6 +27,11 @@ export interface McpAuthRequiredData {
     toolCallId: string;
 }
 
+export interface McpServerLoadFailureData {
+    serverId: string;
+    serverName: string;
+}
+
 interface UseMcpReconnectControllerOptions {
     status: ChatStatus;
     messages: SBChatMessage[];
@@ -38,11 +43,11 @@ interface UseMcpReconnectControllerOptions {
 }
 
 // Orchestrates the client side of MCP connector reauthentication for a chat
-// thread: tracks per-connector reconnect state from transient
-// `data-mcp-auth-required` events, automatically denies tool approvals still
-// pending in the interrupted response, gates the Reconnect action until the
+// thread: tracks per-connector reconnect state from tool-call authentication
+// failures and tool-load failures, automatically denies tool approvals still
+// pending in an interrupted response, gates the Reconnect action until the
 // response has settled, restores pending reconnect metadata after the OAuth
-// round trip, and sends the follow-up user turn on Continue.
+// round trip, and sends the follow-up user turn on Continue when applicable.
 export function useMcpReconnectController({
     status,
     messages,
@@ -54,6 +59,7 @@ export function useMcpReconnectController({
 }: UseMcpReconnectControllerOptions): {
     contextValue: McpReconnectContextValue;
     onAuthRequired: (data: McpAuthRequiredData) => void;
+    onServerLoadFailed: (data: McpServerLoadFailureData) => void;
 } {
     const [reconnectStates, setReconnectStates] = useState<Record<string, McpReconnectState>>({});
     // Response-scoped finalizing flag: set when an authentication failure is
@@ -82,7 +88,8 @@ export function useMcpReconnectController({
         setReconnectStates((prev) => {
             // Repeated failures from the same connector reference the first
             // failure's reconnect state (and its tool call).
-            if (prev[data.serverId]) {
+            const existing = prev[data.serverId];
+            if (existing && existing.status !== 'reconnected') {
                 return prev;
             }
             return {
@@ -91,6 +98,25 @@ export function useMcpReconnectController({
                     serverId: data.serverId,
                     serverName: data.serverName,
                     toolCallId: data.toolCallId,
+                    source: 'tool-call',
+                    status: 'authentication-required',
+                },
+            };
+        });
+    }, []);
+
+    const onServerLoadFailed = useCallback((data: McpServerLoadFailureData) => {
+        setReconnectStates((prev) => {
+            const existing = prev[data.serverId];
+            if (existing && existing.status !== 'reconnected') {
+                return prev;
+            }
+            return {
+                ...prev,
+                [data.serverId]: {
+                    serverId: data.serverId,
+                    serverName: data.serverName,
+                    source: 'tool-load',
                     status: 'authentication-required',
                 },
             };
@@ -100,7 +126,7 @@ export function useMcpReconnectController({
     // Automatically deny every tool approval still pending in the interrupted
     // response. Later approval actions are invalid: the parts flip to
     // approval-responded, which removes the approval UI.
-    const hasAuthFailure = Object.keys(reconnectStates).length > 0;
+    const hasAuthFailure = Object.values(reconnectStates).some((state) => state.source !== 'tool-load');
     useEffect(() => {
         if (!hasAuthFailure) {
             return;
@@ -159,11 +185,13 @@ export function useMcpReconnectController({
                 serverId: pending.serverId,
                 serverName: pending.serverName,
                 toolCallId: pending.toolCallId,
+                source: pending.source,
                 status: 'reconnecting',
             },
         });
 
         (async () => {
+            await invalidateMcpConfigurationQueries(queryClient);
             const servers = await getMcpServersWithStatus();
             const server = isServiceError(servers)
                 ? undefined
@@ -179,7 +207,7 @@ export function useMcpReconnectController({
                 });
             }
         })();
-    }, [setReconnectStatus, toast]);
+    }, [queryClient, setReconnectStatus, toast]);
 
     const isReconnectAllowed = !isTurnInProgress && !isAuthFinalizing;
     const isReconnectAllowedRef = useRef(isReconnectAllowed);
@@ -194,7 +222,9 @@ export function useMcpReconnectController({
 
     const reconnect = useCallback(async (serverId: string) => {
         const state = reconnectStatesRef.current[serverId];
-        if (!state || state.status === 'reconnecting' || !isReconnectAllowedRef.current) {
+        const isAnotherReconnectStarting = Object.values(reconnectStatesRef.current)
+            .some((candidate) => candidate.status === 'reconnecting');
+        if (!state || isAnotherReconnectStarting || !isReconnectAllowedRef.current) {
             return;
         }
 
@@ -207,15 +237,20 @@ export function useMcpReconnectController({
             return;
         }
 
+        reconnectStatesRef.current = {
+            ...reconnectStatesRef.current,
+            [serverId]: { ...state, status: 'reconnecting' },
+        };
         setReconnectStatus(serverId, 'reconnecting');
         saveMcpPendingReconnect({
             serverId,
             serverName: state.serverName,
             toolCallId: state.toolCallId,
+            source: state.source,
             returnTo,
         });
 
-        const result = await connectMcpToAsk({ serverId, returnTo });
+        const result = await connectMcpToAsk({ serverId, returnTo, forceAuthorization: true });
 
         if (isServiceError(result)) {
             clearMcpPendingReconnect();
@@ -232,10 +267,8 @@ export function useMcpReconnectController({
             return;
         }
 
-        // No authorization URL: the stored credentials are still considered
-        // authorized (e.g. a refresh succeeded out of band). Confirm via the
-        // status endpoint; if the connector still is not usable, this is the
-        // known V1-unsupported corner case and the user can retry.
+        // Defensive fallback for older or alternate endpoint implementations
+        // that complete reconnection without returning an authorization URL.
         clearMcpPendingReconnect();
         await invalidateMcpConfigurationQueries(queryClient);
         const servers = await getMcpServersWithStatus();
@@ -254,7 +287,10 @@ export function useMcpReconnectController({
         }
     }, [queryClient, setReconnectStatus, toast]);
 
-    const stateList = useMemo(() => Object.values(reconnectStates), [reconnectStates]);
+    const stateList = useMemo(
+        () => Object.values(reconnectStates).filter((state) => state.source !== 'tool-load'),
+        [reconnectStates],
+    );
     // Continue is only supported when exactly one connector failed
     // authentication in the response, and it has been reconnected.
     const isContinueAllowed =
@@ -291,5 +327,5 @@ export function useMcpReconnectController({
         continueAfterReconnect,
     }), [reconnectStates, isReconnectAllowed, isContinueAllowed, reconnect, continueAfterReconnect]);
 
-    return { contextValue, onAuthRequired };
+    return { contextValue, onAuthRequired, onServerLoadFailed };
 }

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
@@ -14,9 +14,9 @@ import {
     consumeMcpPendingReconnectForPath,
     saveMcpPendingReconnect,
 } from '@/features/chat/mcpReconnect';
-import { CreateUIMessage, ChatStatus, ChatAddToolApproveResponseFunction } from 'ai';
-import { SBChatMessage, SearchScope } from '@/features/chat/types';
-import { createUIMessage, getLastStepParts, isSBChatToolPart } from '@/features/chat/utils';
+import { ChatStatus, ChatAddToolApproveResponseFunction } from 'ai';
+import { SBChatMessage } from '@/features/chat/types';
+import { getLastStepParts, isSBChatToolPart } from '@/features/chat/utils';
 import { isServiceError } from '@/lib/utils';
 import { useQueryClient } from '@tanstack/react-query';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
@@ -37,9 +37,6 @@ interface UseMcpReconnectControllerOptions {
     messages: SBChatMessage[];
     isTurnInProgress: boolean;
     addToolApprovalResponse: ChatAddToolApproveResponseFunction;
-    sendMessage: (message: CreateUIMessage<SBChatMessage>) => void;
-    selectedSearchScopes: SearchScope[];
-    disabledMcpServerIds: string[];
 }
 
 // Orchestrates the client side of MCP connector reauthentication for a chat
@@ -47,15 +44,12 @@ interface UseMcpReconnectControllerOptions {
 // failures and tool-load failures, automatically denies tool approvals still
 // pending in an interrupted response, gates the Reconnect action until the
 // response has settled, restores pending reconnect metadata after the OAuth
-// round trip, and sends the follow-up user turn on Continue when applicable.
+// round trip, and confirms that the connector is usable again.
 export function useMcpReconnectController({
     status,
     messages,
     isTurnInProgress,
     addToolApprovalResponse,
-    sendMessage,
-    selectedSearchScopes,
-    disabledMcpServerIds,
 }: UseMcpReconnectControllerOptions): {
     contextValue: McpReconnectContextValue;
     onAuthRequired: (data: McpAuthRequiredData) => void;
@@ -168,7 +162,8 @@ export function useMcpReconnectController({
     // Restore pending reconnect metadata after returning from the OAuth
     // redirect, then confirm the connector actually reconnected via the
     // status endpoint. Runs once per mount; reads only sessionStorage, so it
-    // does not race the OAuth status toast's query-parameter cleanup.
+    // does not race the OAuth status toast's query-parameter cleanup. The
+    // app-level OAuth status toast owns the success feedback for this path.
     useEffect(() => {
         if (hasRestoredPendingReconnect.current) {
             return;
@@ -278,6 +273,7 @@ export function useMcpReconnectController({
 
         if (server?.isConnected && !server.isAuthExpired) {
             setReconnectStatus(serverId, 'reconnected');
+            toast({ description: `Successfully reconnected to ${state.serverName}.` });
         } else {
             setReconnectStatus(serverId, 'authentication-required');
             toast({
@@ -287,45 +283,11 @@ export function useMcpReconnectController({
         }
     }, [queryClient, setReconnectStatus, toast]);
 
-    const stateList = useMemo(
-        () => Object.values(reconnectStates).filter((state) => state.source !== 'tool-load'),
-        [reconnectStates],
-    );
-    // Continue is only supported when exactly one connector failed
-    // authentication in the response, and it has been reconnected.
-    const isContinueAllowed =
-        isReconnectAllowed &&
-        stateList.length === 1 &&
-        stateList[0].status === 'reconnected';
-    const isContinueAllowedRef = useRef(isContinueAllowed);
-    useEffect(() => {
-        isContinueAllowedRef.current = isContinueAllowed;
-    }, [isContinueAllowed]);
-
-    const continueAfterReconnect = useCallback((serverId: string) => {
-        const state = reconnectStatesRef.current[serverId];
-        if (!state || state.status !== 'reconnected' || !isContinueAllowedRef.current) {
-            return;
-        }
-
-        sendMessage(createUIMessage(
-            `Continue the previous request now that ${state.serverName} is reconnected. Do not repeat operations that already completed.`,
-            [],
-            selectedSearchScopes,
-            disabledMcpServerIds,
-        ));
-
-        setReconnectStates({});
-        deniedApprovalIdsRef.current.clear();
-    }, [sendMessage, selectedSearchScopes, disabledMcpServerIds]);
-
     const contextValue = useMemo<McpReconnectContextValue>(() => ({
         reconnectStates,
         isReconnectAllowed,
-        isContinueAllowed,
         reconnect,
-        continueAfterReconnect,
-    }), [reconnectStates, isReconnectAllowed, isContinueAllowed, reconnect, continueAfterReconnect]);
+    }), [reconnectStates, isReconnectAllowed, reconnect]);
 
     return { contextValue, onAuthRequired, onServerLoadFailed };
 }

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
@@ -187,15 +187,23 @@ export function useMcpReconnectController({
         });
 
         (async () => {
-            await invalidateMcpConfigurationQueries(queryClient);
-            const servers = await getMcpServersWithStatus();
-            const server = isServiceError(servers)
-                ? undefined
-                : servers.find((candidate) => candidate.id === pending.serverId);
+            try {
+                await invalidateMcpConfigurationQueries(queryClient);
+                const servers = await getMcpServersWithStatus();
+                const server = isServiceError(servers)
+                    ? undefined
+                    : servers.find((candidate) => candidate.id === pending.serverId);
 
-            if (server?.isConnected && !server.isAuthExpired) {
-                setReconnectStatus(pending.serverId, 'reconnected');
-            } else {
+                if (server?.isConnected && !server.isAuthExpired) {
+                    setReconnectStatus(pending.serverId, 'reconnected');
+                } else {
+                    setReconnectStatus(pending.serverId, 'authentication-required');
+                    toast({
+                        description: `${pending.serverName} was not reconnected.`,
+                        variant: 'destructive',
+                    });
+                }
+            } catch {
                 setReconnectStatus(pending.serverId, 'authentication-required');
                 toast({
                     description: `${pending.serverName} was not reconnected.`,
@@ -224,61 +232,70 @@ export function useMcpReconnectController({
             return;
         }
 
-        const returnTo = createMcpOAuthDraftPath(window.location.pathname, window.location.search);
-        if (!returnTo) {
-            toast({
-                description: 'Failed to start the reconnect flow for this page.',
-                variant: 'destructive',
+        try {
+            const returnTo = createMcpOAuthDraftPath(window.location.pathname, window.location.search);
+            if (!returnTo) {
+                toast({
+                    description: 'Failed to start the reconnect flow for this page.',
+                    variant: 'destructive',
+                });
+                return;
+            }
+
+            reconnectStatesRef.current = {
+                ...reconnectStatesRef.current,
+                [serverId]: { ...state, status: 'reconnecting' },
+            };
+            setReconnectStatus(serverId, 'reconnecting');
+            saveMcpPendingReconnect({
+                serverId,
+                serverName: state.serverName,
+                toolCallId: state.toolCallId,
+                source: state.source,
+                returnTo,
             });
-            return;
-        }
 
-        reconnectStatesRef.current = {
-            ...reconnectStatesRef.current,
-            [serverId]: { ...state, status: 'reconnecting' },
-        };
-        setReconnectStatus(serverId, 'reconnecting');
-        saveMcpPendingReconnect({
-            serverId,
-            serverName: state.serverName,
-            toolCallId: state.toolCallId,
-            source: state.source,
-            returnTo,
-        });
+            const result = await connectMcpToAsk({ serverId, returnTo, forceAuthorization: true });
 
-        const result = await connectMcpToAsk({ serverId, returnTo, forceAuthorization: true });
+            if (isServiceError(result)) {
+                clearMcpPendingReconnect();
+                setReconnectStatus(serverId, 'authentication-required');
+                toast({
+                    description: `Failed to reconnect ${state.serverName}. ${result.message}`,
+                    variant: 'destructive',
+                });
+                return;
+            }
 
-        if (isServiceError(result)) {
+            if (result.authorizationUrl) {
+                window.location.href = result.authorizationUrl;
+                return;
+            }
+
+            // Defensive fallback for older or alternate endpoint implementations
+            // that complete reconnection without returning an authorization URL.
+            clearMcpPendingReconnect();
+            await invalidateMcpConfigurationQueries(queryClient);
+            const servers = await getMcpServersWithStatus();
+            const server = isServiceError(servers)
+                ? undefined
+                : servers.find((candidate) => candidate.id === serverId);
+
+            if (server?.isConnected && !server.isAuthExpired) {
+                setReconnectStatus(serverId, 'reconnected');
+                toast({ description: `Successfully reconnected to ${state.serverName}.` });
+            } else {
+                setReconnectStatus(serverId, 'authentication-required');
+                toast({
+                    description: `${state.serverName} was not reconnected.`,
+                    variant: 'destructive',
+                });
+            }
+        } catch {
             clearMcpPendingReconnect();
             setReconnectStatus(serverId, 'authentication-required');
             toast({
-                description: `Failed to reconnect ${state.serverName}. ${result.message}`,
-                variant: 'destructive',
-            });
-            return;
-        }
-
-        if (result.authorizationUrl) {
-            window.location.href = result.authorizationUrl;
-            return;
-        }
-
-        // Defensive fallback for older or alternate endpoint implementations
-        // that complete reconnection without returning an authorization URL.
-        clearMcpPendingReconnect();
-        await invalidateMcpConfigurationQueries(queryClient);
-        const servers = await getMcpServersWithStatus();
-        const server = isServiceError(servers)
-            ? undefined
-            : servers.find((candidate) => candidate.id === serverId);
-
-        if (server?.isConnected && !server.isAuthExpired) {
-            setReconnectStatus(serverId, 'reconnected');
-            toast({ description: `Successfully reconnected to ${state.serverName}.` });
-        } else {
-            setReconnectStatus(serverId, 'authentication-required');
-            toast({
-                description: `${state.serverName} was not reconnected.`,
+                description: `Failed to reconnect ${state.serverName}.`,
                 variant: 'destructive',
             });
         }

--- a/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
+++ b/packages/web/src/ee/features/chat/components/chatThread/useMcpReconnectController.ts
@@ -1,0 +1,295 @@
+'use client';
+
+import { useToast } from '@/components/hooks/use-toast';
+import { connectMcpToAsk, getMcpServersWithStatus } from '@/app/api/(client)/client';
+import { invalidateMcpConfigurationQueries } from '@/ee/features/chat/mcp/queryKeys';
+import {
+    McpReconnectContextValue,
+    McpReconnectState,
+    McpReconnectStatus,
+} from '@/ee/features/chat/mcpReconnectContext';
+import { createMcpOAuthDraftPath } from '@/features/chat/mcpOAuthDraft';
+import {
+    clearMcpPendingReconnect,
+    consumeMcpPendingReconnectForPath,
+    saveMcpPendingReconnect,
+} from '@/features/chat/mcpReconnect';
+import { CreateUIMessage, ChatStatus, ChatAddToolApproveResponseFunction } from 'ai';
+import { SBChatMessage, SearchScope } from '@/features/chat/types';
+import { createUIMessage, getLastStepParts, isSBChatToolPart } from '@/features/chat/utils';
+import { isServiceError } from '@/lib/utils';
+import { useQueryClient } from '@tanstack/react-query';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+
+export interface McpAuthRequiredData {
+    serverId: string;
+    serverName: string;
+    toolCallId: string;
+}
+
+interface UseMcpReconnectControllerOptions {
+    status: ChatStatus;
+    messages: SBChatMessage[];
+    isTurnInProgress: boolean;
+    addToolApprovalResponse: ChatAddToolApproveResponseFunction;
+    sendMessage: (message: CreateUIMessage<SBChatMessage>) => void;
+    selectedSearchScopes: SearchScope[];
+    disabledMcpServerIds: string[];
+}
+
+// Orchestrates the client side of MCP connector reauthentication for a chat
+// thread: tracks per-connector reconnect state from transient
+// `data-mcp-auth-required` events, automatically denies tool approvals still
+// pending in the interrupted response, gates the Reconnect action until the
+// response has settled, restores pending reconnect metadata after the OAuth
+// round trip, and sends the follow-up user turn on Continue.
+export function useMcpReconnectController({
+    status,
+    messages,
+    isTurnInProgress,
+    addToolApprovalResponse,
+    sendMessage,
+    selectedSearchScopes,
+    disabledMcpServerIds,
+}: UseMcpReconnectControllerOptions): {
+    contextValue: McpReconnectContextValue;
+    onAuthRequired: (data: McpAuthRequiredData) => void;
+} {
+    const [reconnectStates, setReconnectStates] = useState<Record<string, McpReconnectState>>({});
+    // Response-scoped finalizing flag: set when an authentication failure is
+    // reported mid-stream and cleared only once the whole assistant response
+    // (including approval-denial continuations and the final tools-disabled
+    // step) has settled. Covers the gaps between network streams where the
+    // chat status alone reads as ready.
+    const [isAuthFinalizing, setIsAuthFinalizing] = useState(false);
+    const deniedApprovalIdsRef = useRef(new Set<string>());
+    const hasRestoredPendingReconnect = useRef(false);
+    const { toast } = useToast();
+    const queryClient = useQueryClient();
+
+    const setReconnectStatus = useCallback((serverId: string, reconnectStatus: McpReconnectStatus) => {
+        setReconnectStates((prev) => {
+            const existing = prev[serverId];
+            if (!existing) {
+                return prev;
+            }
+            return { ...prev, [serverId]: { ...existing, status: reconnectStatus } };
+        });
+    }, []);
+
+    const onAuthRequired = useCallback((data: McpAuthRequiredData) => {
+        setIsAuthFinalizing(true);
+        setReconnectStates((prev) => {
+            // Repeated failures from the same connector reference the first
+            // failure's reconnect state (and its tool call).
+            if (prev[data.serverId]) {
+                return prev;
+            }
+            return {
+                ...prev,
+                [data.serverId]: {
+                    serverId: data.serverId,
+                    serverName: data.serverName,
+                    toolCallId: data.toolCallId,
+                    status: 'authentication-required',
+                },
+            };
+        });
+    }, []);
+
+    // Automatically deny every tool approval still pending in the interrupted
+    // response. Later approval actions are invalid: the parts flip to
+    // approval-responded, which removes the approval UI.
+    const hasAuthFailure = Object.keys(reconnectStates).length > 0;
+    useEffect(() => {
+        if (!hasAuthFailure) {
+            return;
+        }
+
+        const latestMessage = messages.at(-1);
+        if (latestMessage?.role !== 'assistant') {
+            return;
+        }
+
+        const pendingApprovalParts = getLastStepParts(latestMessage.parts)
+            .filter(isSBChatToolPart)
+            .filter((part) => part.state === 'approval-requested');
+
+        for (const part of pendingApprovalParts) {
+            if (deniedApprovalIdsRef.current.has(part.approval.id)) {
+                continue;
+            }
+            deniedApprovalIdsRef.current.add(part.approval.id);
+            addToolApprovalResponse({
+                id: part.approval.id,
+                approved: false,
+                reason: 'Denied automatically: a connector needs to be reconnected before more tools can run.',
+            });
+        }
+    }, [hasAuthFailure, messages, addToolApprovalResponse]);
+
+    // Clear the finalizing flag once the response has fully settled. A failed
+    // stream also clears it so the user is not locked out of reconnecting.
+    useEffect(() => {
+        if (!isAuthFinalizing) {
+            return;
+        }
+        if (status === 'error' || (status === 'ready' && !isTurnInProgress)) {
+            setIsAuthFinalizing(false);
+        }
+    }, [isAuthFinalizing, status, isTurnInProgress]);
+
+    // Restore pending reconnect metadata after returning from the OAuth
+    // redirect, then confirm the connector actually reconnected via the
+    // status endpoint. Runs once per mount; reads only sessionStorage, so it
+    // does not race the OAuth status toast's query-parameter cleanup.
+    useEffect(() => {
+        if (hasRestoredPendingReconnect.current) {
+            return;
+        }
+        hasRestoredPendingReconnect.current = true;
+
+        const pending = consumeMcpPendingReconnectForPath(`${window.location.pathname}${window.location.search}`);
+        if (!pending) {
+            return;
+        }
+
+        setReconnectStates({
+            [pending.serverId]: {
+                serverId: pending.serverId,
+                serverName: pending.serverName,
+                toolCallId: pending.toolCallId,
+                status: 'reconnecting',
+            },
+        });
+
+        (async () => {
+            const servers = await getMcpServersWithStatus();
+            const server = isServiceError(servers)
+                ? undefined
+                : servers.find((candidate) => candidate.id === pending.serverId);
+
+            if (server?.isConnected && !server.isAuthExpired) {
+                setReconnectStatus(pending.serverId, 'reconnected');
+            } else {
+                setReconnectStatus(pending.serverId, 'authentication-required');
+                toast({
+                    description: `${pending.serverName} was not reconnected.`,
+                    variant: 'destructive',
+                });
+            }
+        })();
+    }, [setReconnectStatus, toast]);
+
+    const isReconnectAllowed = !isTurnInProgress && !isAuthFinalizing;
+    const isReconnectAllowedRef = useRef(isReconnectAllowed);
+    useEffect(() => {
+        isReconnectAllowedRef.current = isReconnectAllowed;
+    }, [isReconnectAllowed]);
+
+    const reconnectStatesRef = useRef(reconnectStates);
+    useEffect(() => {
+        reconnectStatesRef.current = reconnectStates;
+    }, [reconnectStates]);
+
+    const reconnect = useCallback(async (serverId: string) => {
+        const state = reconnectStatesRef.current[serverId];
+        if (!state || state.status === 'reconnecting' || !isReconnectAllowedRef.current) {
+            return;
+        }
+
+        const returnTo = createMcpOAuthDraftPath(window.location.pathname, window.location.search);
+        if (!returnTo) {
+            toast({
+                description: 'Failed to start the reconnect flow for this page.',
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        setReconnectStatus(serverId, 'reconnecting');
+        saveMcpPendingReconnect({
+            serverId,
+            serverName: state.serverName,
+            toolCallId: state.toolCallId,
+            returnTo,
+        });
+
+        const result = await connectMcpToAsk({ serverId, returnTo });
+
+        if (isServiceError(result)) {
+            clearMcpPendingReconnect();
+            setReconnectStatus(serverId, 'authentication-required');
+            toast({
+                description: `Failed to reconnect ${state.serverName}. ${result.message}`,
+                variant: 'destructive',
+            });
+            return;
+        }
+
+        if (result.authorizationUrl) {
+            window.location.href = result.authorizationUrl;
+            return;
+        }
+
+        // No authorization URL: the stored credentials are still considered
+        // authorized (e.g. a refresh succeeded out of band). Confirm via the
+        // status endpoint; if the connector still is not usable, this is the
+        // known V1-unsupported corner case and the user can retry.
+        clearMcpPendingReconnect();
+        await invalidateMcpConfigurationQueries(queryClient);
+        const servers = await getMcpServersWithStatus();
+        const server = isServiceError(servers)
+            ? undefined
+            : servers.find((candidate) => candidate.id === serverId);
+
+        if (server?.isConnected && !server.isAuthExpired) {
+            setReconnectStatus(serverId, 'reconnected');
+        } else {
+            setReconnectStatus(serverId, 'authentication-required');
+            toast({
+                description: `${state.serverName} was not reconnected.`,
+                variant: 'destructive',
+            });
+        }
+    }, [queryClient, setReconnectStatus, toast]);
+
+    const stateList = useMemo(() => Object.values(reconnectStates), [reconnectStates]);
+    // Continue is only supported when exactly one connector failed
+    // authentication in the response, and it has been reconnected.
+    const isContinueAllowed =
+        isReconnectAllowed &&
+        stateList.length === 1 &&
+        stateList[0].status === 'reconnected';
+    const isContinueAllowedRef = useRef(isContinueAllowed);
+    useEffect(() => {
+        isContinueAllowedRef.current = isContinueAllowed;
+    }, [isContinueAllowed]);
+
+    const continueAfterReconnect = useCallback((serverId: string) => {
+        const state = reconnectStatesRef.current[serverId];
+        if (!state || state.status !== 'reconnected' || !isContinueAllowedRef.current) {
+            return;
+        }
+
+        sendMessage(createUIMessage(
+            `Continue the previous request now that ${state.serverName} is reconnected. Do not repeat operations that already completed.`,
+            [],
+            selectedSearchScopes,
+            disabledMcpServerIds,
+        ));
+
+        setReconnectStates({});
+        deniedApprovalIdsRef.current.clear();
+    }, [sendMessage, selectedSearchScopes, disabledMcpServerIds]);
+
+    const contextValue = useMemo<McpReconnectContextValue>(() => ({
+        reconnectStates,
+        isReconnectAllowed,
+        isContinueAllowed,
+        reconnect,
+        continueAfterReconnect,
+    }), [reconnectStates, isReconnectAllowed, isContinueAllowed, reconnect, continueAfterReconnect]);
+
+    return { contextValue, onAuthRequired };
+}

--- a/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, test } from 'vitest';
 import { ErrorCode } from '@/lib/errorCodes';
-import { McpServersLoadError, shouldRetryMcpServersLoad, splitMcpServersForChatMenu } from './connectorsMenu';
+import { getMcpServerToggleState, McpServersLoadError, shouldRetryMcpServersLoad, splitMcpServersForChatMenu } from './connectorsMenu';
 
 describe('splitMcpServersForChatMenu', () => {
     test('keeps connected and expired servers separate from connectable approved servers', () => {
@@ -14,6 +14,17 @@ describe('splitMcpServersForChatMenu', () => {
 
         expect(connectedServers.map((server) => server.id)).toEqual(['connected', 'expired']);
         expect(connectableServers.map((server) => server.id)).toEqual(['approved']);
+    });
+
+    test('keeps an unavailable connector in the toggle list even if its credentials were invalidated', () => {
+        const servers = [
+            { id: 'unavailable', isConnected: false, isAuthExpired: false },
+        ];
+
+        const { connectedServers, connectableServers } = splitMcpServersForChatMenu(servers, ['unavailable']);
+
+        expect(connectedServers.map((server) => server.id)).toEqual(['unavailable']);
+        expect(connectableServers).toEqual([]);
     });
 });
 
@@ -34,5 +45,31 @@ describe('shouldRetryMcpServersLoad', () => {
         expect(shouldRetryMcpServersLoad(0, error)).toBe(true);
         expect(shouldRetryMcpServersLoad(2, error)).toBe(true);
         expect(shouldRetryMcpServersLoad(3, error)).toBe(false);
+    });
+});
+
+describe('getMcpServerToggleState', () => {
+    test('forces an unavailable connector off and disables its toggle', () => {
+        expect(getMcpServerToggleState(
+            { id: 'server-1', isAuthExpired: false },
+            [],
+            ['server-1'],
+        )).toEqual({
+            isUnavailable: true,
+            isDisabled: true,
+            isEnabled: false,
+        });
+    });
+
+    test('automatically returns the connector to enabled after it is available again', () => {
+        expect(getMcpServerToggleState(
+            { id: 'server-1', isAuthExpired: false },
+            [],
+            [],
+        )).toEqual({
+            isUnavailable: false,
+            isDisabled: false,
+            isEnabled: true,
+        });
     });
 });

--- a/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.tsx
+++ b/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.tsx
@@ -42,6 +42,7 @@ interface ConnectorsMenuProps {
     selectedSearchScopes: SearchScope[];
     onSelectedSearchScopesChange: (items: SearchScope[]) => void;
     disabledMcpServerIds: string[];
+    unavailableMcpServerIds?: string[];
     onDisabledMcpServerIdsChange: (ids: string[]) => void;
     isAuthenticated: boolean;
 }
@@ -65,10 +66,30 @@ export function shouldRetryMcpServersLoad(failureCount: number, error: Error) {
     return failureCount < 3;
 }
 
-export function splitMcpServersForChatMenu<T extends ChatMenuMcpServer>(servers: T[]) {
+export function splitMcpServersForChatMenu<T extends ChatMenuMcpServer & { id: string }>(
+    servers: T[],
+    unavailableMcpServerIds: string[] = [],
+) {
     return {
-        connectedServers: servers.filter((server) => server.isConnected || server.isAuthExpired),
-        connectableServers: servers.filter((server) => !server.isConnected && !server.isAuthExpired),
+        connectedServers: servers.filter((server) =>
+            server.isConnected || server.isAuthExpired || unavailableMcpServerIds.includes(server.id)),
+        connectableServers: servers.filter((server) =>
+            !server.isConnected && !server.isAuthExpired && !unavailableMcpServerIds.includes(server.id)),
+    };
+}
+
+export function getMcpServerToggleState(
+    server: { id: string; isAuthExpired: boolean },
+    disabledMcpServerIds: string[],
+    unavailableMcpServerIds: string[],
+) {
+    const isUnavailable = unavailableMcpServerIds.includes(server.id);
+    const isDisabled = server.isAuthExpired || isUnavailable;
+
+    return {
+        isUnavailable,
+        isDisabled,
+        isEnabled: !isDisabled && !disabledMcpServerIds.includes(server.id),
     };
 }
 
@@ -86,6 +107,7 @@ export const ConnectorsMenu = ({
     selectedSearchScopes,
     onSelectedSearchScopesChange,
     disabledMcpServerIds,
+    unavailableMcpServerIds = [],
     onDisabledMcpServerIdsChange,
     isAuthenticated,
 }: ConnectorsMenuProps) => {
@@ -150,6 +172,10 @@ export const ConnectorsMenu = ({
     }, [editor, onDisabledMcpServerIdsChange, onSelectedSearchScopesChange]);
 
     const onToggle = (serverId: string, checked: boolean) => {
+        if (unavailableMcpServerIds.includes(serverId)) {
+            return;
+        }
+
         if (checked) {
             onDisabledMcpServerIdsChange(disabledMcpServerIds.filter((id) => id !== serverId));
         } else {
@@ -215,7 +241,7 @@ export const ConnectorsMenu = ({
         }
     };
 
-    const { connectedServers, connectableServers } = splitMcpServersForChatMenu(servers);
+    const { connectedServers, connectableServers } = splitMcpServersForChatMenu(servers, unavailableMcpServerIds);
     const hasServers = connectedServers.length > 0 || connectableServers.length > 0;
     const isAuthenticationError = error instanceof McpServersLoadError && error.serviceError.errorCode === ErrorCode.NOT_AUTHENTICATED;
     const shouldShowLoginConnectorItem = !isAuthenticated || isAuthenticationError;
@@ -262,26 +288,38 @@ export const ConnectorsMenu = ({
                                 ) : (
                                     <>
                                         {connectedServers.map((server) => {
-                                            const isEnabled = !server.isAuthExpired && !disabledMcpServerIds.includes(server.id);
+                                            const { isDisabled, isEnabled, isUnavailable } = getMcpServerToggleState(
+                                                server,
+                                                disabledMcpServerIds,
+                                                unavailableMcpServerIds,
+                                            );
                                             return (
                                                 <DropdownMenuItem
                                                     key={server.id}
                                                     onSelect={(e) => e.preventDefault()}
-                                                    disabled={server.isAuthExpired}
+                                                    disabled={isDisabled}
                                                     className="flex items-center justify-between gap-2"
                                                 >
                                                     <div className="flex items-center gap-2 min-w-0">
-                                                        {server.isAuthExpired ? (
+                                                        {isDisabled ? (
                                                             <AlertTriangleIcon className="w-4 h-4 shrink-0 text-yellow-500" />
                                                         ) : (
                                                             <McpFavicon faviconUrl={server.faviconUrl} className="w-4 h-4 rounded-sm" />
                                                         )}
-                                                        <span className="truncate text-sm">{server.name}</span>
+                                                        <span className="min-w-0">
+                                                            <span className="block truncate text-sm">{server.name}</span>
+                                                            {isUnavailable && (
+                                                                <span className="block truncate text-[10px] text-muted-foreground">
+                                                                    Reconnect required
+                                                                </span>
+                                                            )}
+                                                        </span>
                                                     </div>
                                                     <Switch
                                                         checked={isEnabled}
                                                         onCheckedChange={(checked) => onToggle(server.id, checked)}
-                                                        disabled={server.isAuthExpired}
+                                                        disabled={isDisabled}
+                                                        aria-label={isUnavailable ? `${server.name} unavailable until reconnected` : undefined}
                                                         className="scale-75"
                                                     />
                                                 </DropdownMenuItem>

--- a/packages/web/src/ee/features/chat/mcp/mcpAuthFailure.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpAuthFailure.test.ts
@@ -1,0 +1,195 @@
+import { UnauthorizedError } from '@ai-sdk/mcp';
+import { describe, expect, test } from 'vitest';
+import { SBChatMessage } from '@/features/chat/types';
+import {
+    createMcpAuthInterruptionDirective,
+    createMcpAuthRequiredToolErrorText,
+    denyApprovedToolApprovalsForAuthInterruption,
+    getMcpAuthRequiredFailureFromAssistantMessage,
+    getMcpAuthRequiredServerNameFromErrorText,
+    isMcpAuthRequiredToolErrorText,
+    isReconnectRequiredMcpAuthFailure,
+    McpAuthRequiredError,
+} from './mcpAuthFailure';
+
+describe('isReconnectRequiredMcpAuthFailure', () => {
+    test('classifies an UnauthorizedError from the MCP SDK as reconnectable', () => {
+        expect(isReconnectRequiredMcpAuthFailure(new UnauthorizedError('Unauthorized'))).toBe(true);
+    });
+
+    test('classifies a 401 response as reconnectable', () => {
+        const error = Object.assign(new Error('HTTP 401'), { statusCode: 401 });
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(true);
+    });
+
+    test('classifies a nested response status of 401 as reconnectable', () => {
+        const error = Object.assign(new Error('request failed'), { response: { status: 401 } });
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(true);
+    });
+
+    test('classifies invalid_grant as reconnectable even with the token endpoint 400 status', () => {
+        const error = Object.assign(new Error('Token refresh failed: invalid_grant'), {
+            error: 'invalid_grant',
+            statusCode: 400,
+        });
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(true);
+    });
+
+    test('classifies an invalid_grant mention in the message as reconnectable', () => {
+        expect(isReconnectRequiredMcpAuthFailure(new Error('server responded with invalid_grant'))).toBe(true);
+    });
+
+    test('does not classify a 403 that still carries its status as reconnectable', () => {
+        const error = Object.assign(new Error('Forbidden'), { statusCode: 403 });
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(false);
+    });
+
+    test('does not classify an unauthorized-named error with a non-401 status as reconnectable', () => {
+        const error = Object.assign(new Error('Forbidden'), { statusCode: 403 });
+        error.name = 'UnauthorizedError';
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(false);
+    });
+
+    test('does not classify a 500 response as reconnectable', () => {
+        const error = Object.assign(new Error('Internal server error'), { statusCode: 500 });
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(false);
+    });
+
+    test('does not classify a timeout as reconnectable', () => {
+        expect(isReconnectRequiredMcpAuthFailure(new Error('MCP tool "mcp_linear__list_issues" timed out after 30000ms'))).toBe(false);
+    });
+
+    test('does not classify an abort as reconnectable', () => {
+        const error = new Error('The operation was aborted');
+        error.name = 'AbortError';
+        expect(isReconnectRequiredMcpAuthFailure(error)).toBe(false);
+    });
+
+    test('does not classify a generic error or non-error value as reconnectable', () => {
+        expect(isReconnectRequiredMcpAuthFailure(new Error('connection refused'))).toBe(false);
+        expect(isReconnectRequiredMcpAuthFailure(undefined)).toBe(false);
+        expect(isReconnectRequiredMcpAuthFailure('unauthorized')).toBe(false);
+    });
+});
+
+describe('MCP auth-required tool error text', () => {
+    test('round-trips the server name through the marker text', () => {
+        const text = createMcpAuthRequiredToolErrorText('Linear');
+        expect(isMcpAuthRequiredToolErrorText(text)).toBe(true);
+        expect(getMcpAuthRequiredServerNameFromErrorText(text)).toBe('Linear');
+    });
+
+    test('round-trips a server name containing quotes', () => {
+        const text = createMcpAuthRequiredToolErrorText('My "Cool" Server');
+        expect(getMcpAuthRequiredServerNameFromErrorText(text)).toBe('My "Cool" Server');
+    });
+
+    test('McpAuthRequiredError carries the marker text as its message', () => {
+        const error = new McpAuthRequiredError('Linear');
+        expect(isMcpAuthRequiredToolErrorText(error.message)).toBe(true);
+        expect(getMcpAuthRequiredServerNameFromErrorText(error.message)).toBe('Linear');
+    });
+
+    test('rejects unrelated error text', () => {
+        expect(isMcpAuthRequiredToolErrorText(undefined)).toBe(false);
+        expect(isMcpAuthRequiredToolErrorText('Authentication required: token missing')).toBe(false);
+        expect(getMcpAuthRequiredServerNameFromErrorText('some other failure')).toBeUndefined();
+    });
+});
+
+const createAssistantMessage = (parts: SBChatMessage['parts']): SBChatMessage => ({
+    id: 'assistant-1',
+    role: 'assistant',
+    parts,
+});
+
+describe('getMcpAuthRequiredFailureFromAssistantMessage', () => {
+    test('detects the interruption from a marked tool error part', () => {
+        const message = createAssistantMessage([
+            { type: 'step-start' },
+            {
+                type: 'dynamic-tool',
+                toolName: 'mcp_linear__list_issues',
+                toolCallId: 'tool-call-1',
+                state: 'output-error',
+                input: {},
+                errorText: createMcpAuthRequiredToolErrorText('Linear'),
+            },
+        ] as SBChatMessage['parts']);
+
+        expect(getMcpAuthRequiredFailureFromAssistantMessage(message)).toEqual({ serverName: 'Linear' });
+    });
+
+    test('ignores unrelated tool errors and non-assistant messages', () => {
+        const message = createAssistantMessage([
+            {
+                type: 'dynamic-tool',
+                toolName: 'mcp_linear__list_issues',
+                toolCallId: 'tool-call-1',
+                state: 'output-error',
+                input: {},
+                errorText: 'HTTP 500: internal error',
+            },
+        ] as SBChatMessage['parts']);
+
+        expect(getMcpAuthRequiredFailureFromAssistantMessage(message)).toBeUndefined();
+        expect(getMcpAuthRequiredFailureFromAssistantMessage(undefined)).toBeUndefined();
+        expect(getMcpAuthRequiredFailureFromAssistantMessage({
+            id: 'user-1',
+            role: 'user',
+            parts: [{ type: 'text', text: 'hello' }],
+        } as SBChatMessage)).toBeUndefined();
+    });
+});
+
+describe('denyApprovedToolApprovalsForAuthInterruption', () => {
+    test('rewrites approved approvals to denials and leaves everything else untouched', () => {
+        const message = createAssistantMessage([
+            {
+                type: 'dynamic-tool',
+                toolName: 'mcp_linear__save_comment',
+                toolCallId: 'tool-call-1',
+                state: 'approval-responded',
+                input: {},
+                approval: { id: 'approval-1', approved: true },
+            },
+            {
+                type: 'dynamic-tool',
+                toolName: 'mcp_linear__save_issue',
+                toolCallId: 'tool-call-2',
+                state: 'approval-responded',
+                input: {},
+                approval: { id: 'approval-2', approved: false, reason: 'User denied' },
+            },
+            {
+                type: 'dynamic-tool',
+                toolName: 'mcp_linear__list_issues',
+                toolCallId: 'tool-call-3',
+                state: 'output-available',
+                input: {},
+                output: {},
+            },
+        ] as SBChatMessage['parts']);
+
+        const result = denyApprovedToolApprovalsForAuthInterruption(message, 'Linear');
+
+        const [rewritten, alreadyDenied, unrelated] = result.parts;
+        expect(rewritten).toMatchObject({
+            state: 'approval-responded',
+            approval: { id: 'approval-1', approved: false },
+        });
+        expect((rewritten as { approval: { reason?: string } }).approval.reason).toContain('Linear');
+        expect(alreadyDenied).toBe(message.parts[1]);
+        expect(unrelated).toBe(message.parts[2]);
+        // The input message is not mutated.
+        expect(message.parts[0]).toMatchObject({ approval: { approved: true } });
+    });
+});
+
+describe('createMcpAuthInterruptionDirective', () => {
+    test('names the failed connector and forbids further tool use', () => {
+        const directive = createMcpAuthInterruptionDirective('Linear');
+        expect(directive).toContain('Linear');
+        expect(directive).toContain('Do not attempt any more tool calls');
+    });
+});

--- a/packages/web/src/ee/features/chat/mcp/mcpAuthFailure.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpAuthFailure.ts
@@ -1,0 +1,156 @@
+import { SBChatMessage } from '@/features/chat/types';
+import { getExternalMcpErrorLogFields } from './externalMcpError';
+
+// The tool error text doubles as the marker that lets a continuation request
+// (a new HTTP request carrying the persisted messages) detect that this
+// response was interrupted by an authentication failure, without persisting
+// any dedicated reconnect state. Keep the prefix and marker stable.
+const MCP_AUTH_REQUIRED_ERROR_PREFIX = 'Authentication required: the connection to ';
+const MCP_AUTH_REQUIRED_ERROR_MARKER = 'is no longer authorized';
+
+export interface McpToolAuthFailure {
+    serverId: string;
+    serverName: string;
+    toolCallId: string;
+}
+
+/**
+ * Classifies whether an error from an external MCP tool call is a
+ * reconnectable authentication failure: the user's stored credentials no
+ * longer work and a new OAuth authorization is required.
+ *
+ * Supported failures are `invalid_grant` (a failed token refresh), `401`
+ * responses, and bare `UnauthorizedError`s from the MCP SDK (which is also
+ * what a failed refresh surfaces as after the transport retries). Errors that
+ * still carry a non-401 status (notably `403`) are not reconnectable, nor are
+ * timeouts or unavailable servers.
+ *
+ * Classification uses only the log-safe fields extracted by
+ * `getExternalMcpErrorLogFields` — never raw messages or bodies from the
+ * external boundary.
+ */
+export function isReconnectRequiredMcpAuthFailure(error: unknown): boolean {
+    const fields = getExternalMcpErrorLogFields(error);
+
+    // A failed token refresh reports `invalid_grant`, typically alongside the
+    // token endpoint's 400 status, so it must be checked before the status.
+    if (fields.oauthError === 'invalid_grant') {
+        return true;
+    }
+
+    if (fields.statusCode !== undefined) {
+        return fields.statusCode === 401;
+    }
+
+    // A bare UnauthorizedError does not reveal whether it came from a 401, a
+    // failed refresh, or a transformed 403; V1 accepts this ambiguity (see the
+    // reauthentication plan) and treats it as reconnectable.
+    return fields.errorClass === 'UnauthorizedError' || fields.errorName === 'UnauthorizedError';
+}
+
+export function createMcpAuthRequiredToolErrorText(serverName: string): string {
+    return `${MCP_AUTH_REQUIRED_ERROR_PREFIX}"${serverName}" ${MCP_AUTH_REQUIRED_ERROR_MARKER}. ` +
+        `Tool use has ended for this response. Do not attempt further tool calls: summarize the work that already completed, ` +
+        `explain that ${serverName} needs to be reconnected, and ask the user to reconnect it before continuing.`;
+}
+
+/**
+ * The safe error thrown in place of the original (potentially
+ * secret-carrying) external error when a tool call fails authentication. Its
+ * message is what the model and the tool result's error text see.
+ */
+export class McpAuthRequiredError extends Error {
+    constructor(serverName: string) {
+        super(createMcpAuthRequiredToolErrorText(serverName));
+        this.name = 'McpAuthRequiredError';
+    }
+}
+
+export function isMcpAuthRequiredToolErrorText(text: string | undefined): boolean {
+    return text !== undefined &&
+        text.startsWith(MCP_AUTH_REQUIRED_ERROR_PREFIX) &&
+        text.includes(MCP_AUTH_REQUIRED_ERROR_MARKER);
+}
+
+export function getMcpAuthRequiredServerNameFromErrorText(text: string | undefined): string | undefined {
+    if (text === undefined || !isMcpAuthRequiredToolErrorText(text)) {
+        return undefined;
+    }
+
+    const suffix = text.slice(MCP_AUTH_REQUIRED_ERROR_PREFIX.length);
+    const markerIndex = suffix.lastIndexOf(` ${MCP_AUTH_REQUIRED_ERROR_MARKER}`);
+    if (markerIndex === -1) {
+        return undefined;
+    }
+
+    const quoted = suffix.slice(0, markerIndex);
+    if (quoted.length < 2 || !quoted.startsWith('"') || !quoted.endsWith('"')) {
+        return undefined;
+    }
+
+    return quoted.slice(1, -1);
+}
+
+/**
+ * Detects whether the given trailing assistant message was interrupted by a
+ * reconnect-required authentication failure, by scanning its tool error parts
+ * for the marker text. Used by continuation requests to re-enter the
+ * tools-disabled final step without any persisted reconnect state.
+ */
+export function getMcpAuthRequiredFailureFromAssistantMessage(
+    message: SBChatMessage | undefined,
+): { serverName: string } | undefined {
+    if (!message || message.role !== 'assistant') {
+        return undefined;
+    }
+
+    for (const part of message.parts) {
+        if (part.type === 'dynamic-tool' && part.state === 'output-error') {
+            const serverName = getMcpAuthRequiredServerNameFromErrorText(part.errorText);
+            if (serverName !== undefined) {
+                return { serverName };
+            }
+        }
+    }
+
+    return undefined;
+}
+
+/**
+ * Rewrites any still-approved tool approvals on the message to denials. Once a
+ * response is interrupted by an authentication failure, later approval actions
+ * are invalid: the client denies pending approvals automatically, and this
+ * guards the server side against an approval that raced through anyway.
+ */
+export function denyApprovedToolApprovalsForAuthInterruption(
+    message: SBChatMessage,
+    serverName: string,
+): SBChatMessage {
+    return {
+        ...message,
+        parts: message.parts.map((part) => {
+            if (part.type === 'dynamic-tool' && part.state === 'approval-responded' && part.approval.approved) {
+                return {
+                    ...part,
+                    approval: {
+                        ...part.approval,
+                        approved: false,
+                        reason: `Denied automatically: ${serverName} needs to be reconnected before more tools can run.`,
+                    },
+                };
+            }
+            return part;
+        }),
+    };
+}
+
+/**
+ * The ephemeral directive appended to the model messages for the final,
+ * tools-disabled step of an authentication-interrupted response. It is never
+ * persisted; it only shapes the final model call.
+ */
+export function createMcpAuthInterruptionDirective(serverName: string): string {
+    return `[SYSTEM NOTIFICATION] Authentication with the "${serverName}" connector failed and tool use has been disabled for the remainder of this response. ` +
+        `Do not attempt any more tool calls. Respond now with your required structured answer: briefly summarize the work you completed before the interruption, ` +
+        `explain that the connection to ${serverName} is no longer authorized, and ask the user to reconnect ${serverName} before continuing.`;
+}

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
@@ -653,7 +653,7 @@ describe('getMcpTools', () => {
             createMockClient({ serverName: 'WorkingServer' }),
         ]);
 
-        expect(result.failedServers).toEqual(['UnsupportedServer']);
+        expect(result.failedServers).toEqual([{ serverId: 'server-id', serverName: 'UnsupportedServer' }]);
         expect(Object.keys(result.tools)).toEqual(['mcp_workingserver__good_tool']);
         expect(result.toolDisplayNames).toEqual({
             'mcp_workingserver__good_tool': 'good_tool',
@@ -685,7 +685,7 @@ describe('getMcpTools', () => {
             createMockClient({ serverName: 'MalformedServer' }),
         ]);
 
-        expect(result.failedServers).toEqual(['MalformedServer']);
+        expect(result.failedServers).toEqual([{ serverId: 'server-id', serverName: 'MalformedServer' }]);
         expect(result.tools).toEqual({});
         expect(mockLogger.error).toHaveBeenCalledOnce();
         expect(JSON.stringify(mockLogger.error.mock.calls)).not.toContain(remoteReference);

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
@@ -396,7 +396,7 @@ describe('getMcpTools', () => {
             createMockClient({ serverName: 'BrokenServer' }),
         ]);
 
-        expect(result.failedServers).toEqual(['BrokenServer']);
+        expect(result.failedServers).toEqual([{ serverId: 'server-id', serverName: 'BrokenServer' }]);
         expect(Object.keys(result.tools)).toEqual([]);
         expect(mockLogger.error).toHaveBeenCalledWith('Failed to get tools from MCP server.', {
             serverId: 'server-id',
@@ -424,7 +424,7 @@ describe('getMcpTools', () => {
             createMockClient({ serverName: 'Linear' }),
         ]);
 
-        expect(result.failedServers).toEqual(['BrokenServer']);
+        expect(result.failedServers).toEqual([{ serverId: 'server-id', serverName: 'BrokenServer' }]);
         expect(Object.keys(result.tools)).toEqual(['mcp_linear__list_issues']);
     });
 

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.test.ts
@@ -721,6 +721,65 @@ describe('getMcpTools', () => {
         }));
     });
 
+    test('tool execute wrapper replaces a 401 with a safe auth-required error and reports the failure', async () => {
+        const unauthorizedError = Object.assign(
+            new Error('HTTP 401 access_token=access-token'),
+            { statusCode: 401 },
+        );
+        const mockClient = createMockMcpClient([
+            { name: 'list_issues', description: 'List issues', annotations: { readOnlyHint: true } },
+        ]);
+        const toolRecord = mockClient.toolsFromDefinitions();
+        toolRecord['list_issues'].execute.mockRejectedValue(unauthorizedError);
+        mockCreateMCPClient.mockResolvedValue(mockClient);
+
+        const onAuthFailure = vi.fn();
+        const result = await getMcpTools([
+            createMockClient({ serverId: 'server-linear', serverName: 'Linear' }),
+        ], undefined, { onAuthFailure });
+
+        const tool = result.tools['mcp_linear__list_issues'];
+        const thrown = await Promise.resolve(tool.execute({}, { messages: [], toolCallId: 'tool-call-1' }))
+            .then(() => undefined, (error: Error) => error);
+        expect(thrown).toBeInstanceOf(Error);
+        expect(thrown?.message).toContain('Authentication required: the connection to "Linear" is no longer authorized');
+        // The safe error must not carry the external error's contents.
+        expect(thrown?.message).not.toContain('access-token');
+
+        expect(onAuthFailure).toHaveBeenCalledTimes(1);
+        expect(onAuthFailure).toHaveBeenCalledWith({
+            serverId: 'server-linear',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+        });
+        expect(mockCaptureEvent).toHaveBeenCalledWith('ask_mcp_tool_call_completed', expect.objectContaining({
+            success: false,
+            failureReason: 'status_401',
+        }));
+    });
+
+    test('tool execute wrapper does not report non-auth failures as auth failures', async () => {
+        const forbiddenError = Object.assign(new Error('Forbidden'), { statusCode: 403 });
+        const mockClient = createMockMcpClient([
+            { name: 'list_issues', description: 'List issues', annotations: { readOnlyHint: true } },
+        ]);
+        const toolRecord = mockClient.toolsFromDefinitions();
+        toolRecord['list_issues'].execute.mockRejectedValue(forbiddenError);
+        mockCreateMCPClient.mockResolvedValue(mockClient);
+
+        const onAuthFailure = vi.fn();
+        const result = await getMcpTools([
+            createMockClient({ serverId: 'server-linear', serverName: 'Linear' }),
+        ], undefined, { onAuthFailure });
+
+        const tool = result.tools['mcp_linear__list_issues'];
+        await expect(
+            tool.execute({}, { messages: [], toolCallId: 'tool-call-1' })
+        ).rejects.toThrow('Forbidden');
+
+        expect(onAuthFailure).not.toHaveBeenCalled();
+    });
+
     test('tool execute wrapper increments the raw tool call counter after success', async () => {
         const mockClient = createMockMcpClient([
             { name: 'create_issue', description: 'Create issue' },

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
@@ -6,6 +6,7 @@ import { jsonSchema, ToolExecutionOptions } from 'ai';
 import type { JSONSchema7 } from 'json-schema';
 import { createHash } from 'crypto';
 import { getExternalMcpErrorLogFields } from './externalMcpError';
+import { isReconnectRequiredMcpAuthFailure, McpAuthRequiredError, McpToolAuthFailure } from './mcpAuthFailure';
 import { getMcpFaviconUrl } from '@/features/chat/mcp/utils';
 import { __unsafePrisma } from '@/prisma';
 import { McpServerToolPermission } from '@sourcebot/db';
@@ -84,6 +85,12 @@ interface McpToolsAnalyticsContext {
     chatId?: string;
     traceId?: string;
     source: AskMcpAnalyticsSource;
+}
+
+interface McpToolsOptions {
+    // Invoked when a tool call fails with a reconnect-required authentication
+    // failure, before the safe McpAuthRequiredError is thrown in its place.
+    onAuthFailure?: (failure: McpToolAuthFailure) => void;
 }
 
 function getMcpToolFailureReason(error: unknown): string {
@@ -194,7 +201,8 @@ async function getListToolsResult(
  * Creates MCPClients from authenticated transports, retrieves their tools,
  * and returns a namespaced tool record + cleanup function.
  */
-export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpToolsAnalyticsContext): Promise<McpToolsResult> {
+export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpToolsAnalyticsContext, toolsOptions?: McpToolsOptions): Promise<McpToolsResult> {
+    const onAuthFailure = toolsOptions?.onAuthFailure;
     const allTools: McpToolsResult['tools'] = {};
     const failedServers: string[] = [];
     const serverFaviconUrls: Record<string, string> = {};
@@ -321,6 +329,21 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                             throw timeoutError;
                         }
                         failureReason = getMcpToolFailureReason(error);
+                        if (isReconnectRequiredMcpAuthFailure(error)) {
+                            logger.warn(`MCP tool "${qualifiedName}" failed with a reconnect-required authentication error.`, {
+                                serverId,
+                                error: getExternalMcpErrorLogFields(error),
+                            });
+                            onAuthFailure?.({
+                                serverId,
+                                serverName,
+                                toolCallId: options.toolCallId,
+                            });
+                            // Replace the external error with a safe one: the
+                            // original may echo secrets, and the model needs an
+                            // explicit signal that tool use has ended.
+                            throw new McpAuthRequiredError(serverName);
+                        }
                         throw error;
                     } finally {
                         void captureEvent('ask_mcp_tool_call_completed', {

--- a/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
+++ b/packages/web/src/ee/features/chat/mcp/mcpToolSets.ts
@@ -75,7 +75,7 @@ async function incrementMcpToolCallCounter(serverId: string, toolName: string) {
 
 export interface McpToolsResult {
     tools: Record<string, Awaited<ReturnType<MCPClient['tools']>>[string]>;
-    failedServers: string[];
+    failedServers: Array<{ serverId: string; serverName: string }>;
     serverFaviconUrls: Record<string, string>;
     toolDisplayNames: Record<string, string>;
     cleanup: () => Promise<void>;
@@ -204,7 +204,7 @@ async function getListToolsResult(
 export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpToolsAnalyticsContext, toolsOptions?: McpToolsOptions): Promise<McpToolsResult> {
     const onAuthFailure = toolsOptions?.onAuthFailure;
     const allTools: McpToolsResult['tools'] = {};
-    const failedServers: string[] = [];
+    const failedServers: McpToolsResult['failedServers'] = [];
     const serverFaviconUrls: Record<string, string> = {};
     const toolDisplayNames: Record<string, string> = {};
     const mcpClients: MCPClient[] = [];
@@ -389,7 +389,7 @@ export async function getMcpTools(clients: McpToolSet[], analyticsContext?: McpT
                 sanitizedName,
                 error: getExternalMcpErrorLogFields(error),
             });
-            failedServers.push(serverName);
+            failedServers.push({ serverId, serverName });
         }
     }
 

--- a/packages/web/src/ee/features/chat/mcp/prismaOAuthClientProvider.test.ts
+++ b/packages/web/src/ee/features/chat/mcp/prismaOAuthClientProvider.test.ts
@@ -44,7 +44,7 @@ function createPrismaMock() {
 
 function createProvider(
     prisma = createPrismaMock(),
-    options: { allowClientRegistration?: boolean; requestedOAuthScopes?: string[] } = {},
+    options: { allowClientRegistration?: boolean; requestedOAuthScopes?: string[]; forceAuthorization?: boolean } = {},
 ) {
     return new PrismaOAuthClientProvider({
         prisma: prisma as never,
@@ -55,6 +55,7 @@ function createProvider(
         callbackUrl: 'https://sourcebot.example.com/api/ee/askmcp/callback',
         allowClientRegistration: options.allowClientRegistration ?? false,
         requestedOAuthScopes: options.requestedOAuthScopes,
+        forceAuthorization: options.forceAuthorization,
     });
 }
 
@@ -202,6 +203,19 @@ describe('PrismaOAuthClientProvider PKCE verifier storage', () => {
 });
 
 describe('PrismaOAuthClientProvider authorization redirect', () => {
+    test('ignores stored tokens when interactive authorization is forced', async () => {
+        const prisma = createPrismaMock();
+        prisma.userMcpServer.findUnique.mockResolvedValue({
+            tokens: 'encrypted:{"access_token":"stale-token"}',
+            codeVerifier: null,
+            state: null,
+        });
+        const provider = createProvider(prisma, { forceAuthorization: true });
+
+        await expect(provider.tokens()).resolves.toBeUndefined();
+        expect(prisma.userMcpServer.findUnique).not.toHaveBeenCalled();
+    });
+
     test('overwrites existing prompt values with consent', async () => {
         const prisma = createPrismaMock();
         prisma.userMcpServer.update.mockResolvedValue({

--- a/packages/web/src/ee/features/chat/mcp/prismaOAuthClientProvider.ts
+++ b/packages/web/src/ee/features/chat/mcp/prismaOAuthClientProvider.ts
@@ -24,6 +24,7 @@ interface PrismaOAuthClientProviderOptions {
   allowClientRegistration?: boolean;
   requestedOAuthScopes?: string[];
   clientInvalidationPrisma?: McpOAuthPrismaClient;
+  forceAuthorization?: boolean;
 }
 
 export interface ClearMcpServerClientCredentialsOptions {
@@ -86,6 +87,7 @@ export class PrismaOAuthClientProvider implements OAuthClientProvider {
   private readonly callbackUrl: string;
   private readonly callbackReturnTo: string | undefined;
   private readonly requestedOAuthScopes: string[];
+  private readonly forceAuthorization: boolean;
   private observedClientInfo: string | undefined;
   private observedClientInfoSource: McpServerClientInfoSource | undefined;
 
@@ -105,6 +107,7 @@ export class PrismaOAuthClientProvider implements OAuthClientProvider {
     allowClientRegistration = false,
     requestedOAuthScopes = [],
     clientInvalidationPrisma = __unsafePrisma,
+    forceAuthorization = false,
   }: PrismaOAuthClientProviderOptions) {
     this.prisma = prisma;
     this.clientInvalidationPrisma = clientInvalidationPrisma;
@@ -114,6 +117,7 @@ export class PrismaOAuthClientProvider implements OAuthClientProvider {
     this.callbackUrl = callbackUrl;
     this.callbackReturnTo = callbackReturnTo;
     this.requestedOAuthScopes = normalizeMcpRequestedOAuthScopes(requestedOAuthScopes);
+    this.forceAuthorization = forceAuthorization;
 
     if (allowClientRegistration) {
       this.saveClientInformation = async (info: OAuthClientInformation) => {
@@ -177,6 +181,10 @@ export class PrismaOAuthClientProvider implements OAuthClientProvider {
   }
 
   async tokens(): Promise<OAuthTokens | undefined> {
+    if (this.forceAuthorization) {
+      return undefined;
+    }
+
     const userServer = await this.getUserServer();
     if (!userServer?.tokens) {
       return undefined;

--- a/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
+++ b/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export type McpReconnectStatus = 'authentication-required' | 'reconnecting' | 'reconnected';
+
+// Client-only reconnect state for a connector that failed authentication in
+// the current assistant response. `toolCallId` is the first failed tool call,
+// so the inline recovery UI renders on the correct tool result. This state
+// intentionally does not survive an unrelated reload.
+export interface McpReconnectState {
+    serverId: string;
+    serverName: string;
+    toolCallId: string;
+    status: McpReconnectStatus;
+}
+
+export interface McpReconnectContextValue {
+    // Keyed by connector (server) ID.
+    reconnectStates: Record<string, McpReconnectState>;
+    // False until the interrupted assistant response has fully settled
+    // (started tool calls finished, pending approvals denied, the final
+    // tools-disabled step streamed and persisted).
+    isReconnectAllowed: boolean;
+    // True only in the supported case: exactly one failed connector, and it
+    // has been reconnected.
+    isContinueAllowed: boolean;
+    reconnect: (serverId: string) => void;
+    continueAfterReconnect: (serverId: string) => void;
+}
+
+export const McpReconnectContext = createContext<McpReconnectContextValue | undefined>(undefined);
+
+export const useMcpReconnect = () => useContext(McpReconnectContext);
+
+export const getMcpReconnectStateForToolCall = (
+    reconnectStates: Record<string, McpReconnectState>,
+    toolCallId: string,
+): McpReconnectState | undefined => {
+    return Object.values(reconnectStates).find((state) => state.toolCallId === toolCallId);
+};

--- a/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
+++ b/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
@@ -5,9 +5,10 @@ import { createContext, useContext } from 'react';
 export type McpReconnectStatus = 'authentication-required' | 'reconnecting' | 'reconnected';
 
 // Client-only reconnect state for a connector that failed authentication in
-// the current assistant response. `toolCallId` is the first failed tool call,
-// so the inline recovery UI renders on the correct tool result. This state
-// intentionally does not survive an unrelated reload.
+// the current assistant response. `toolCallId` identifies the first failed
+// tool call so its technical status can be decorated while the recovery
+// action remains visible in the thread-level banner. This state intentionally
+// does not survive an unrelated reload.
 export interface McpReconnectState {
     serverId: string;
     serverName: string;

--- a/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
+++ b/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
@@ -1,18 +1,20 @@
 'use client';
 
 import { createContext, useContext } from 'react';
+import type { McpReconnectSource } from '@/features/chat/mcpReconnect';
 
 export type McpReconnectStatus = 'authentication-required' | 'reconnecting' | 'reconnected';
 
 // Client-only reconnect state for a connector that failed authentication in
-// the current assistant response. `toolCallId` identifies the first failed
-// tool call so its technical status can be decorated while the recovery
-// action remains visible in the thread-level banner. This state intentionally
-// does not survive an unrelated reload.
+// the current assistant response. Tool-call failures retain `toolCallId` so
+// their technical status can be decorated. Tool-load failures use the same
+// reconnect machinery but surface their action in the failed-server banner.
+// This state intentionally does not survive an unrelated reload.
 export interface McpReconnectState {
     serverId: string;
     serverName: string;
-    toolCallId: string;
+    toolCallId?: string;
+    source: McpReconnectSource;
     status: McpReconnectStatus;
 }
 

--- a/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
+++ b/packages/web/src/ee/features/chat/mcpReconnectContext.tsx
@@ -25,11 +25,7 @@ export interface McpReconnectContextValue {
     // (started tool calls finished, pending approvals denied, the final
     // tools-disabled step streamed and persisted).
     isReconnectAllowed: boolean;
-    // True only in the supported case: exactly one failed connector, and it
-    // has been reconnected.
-    isContinueAllowed: boolean;
     reconnect: (serverId: string) => void;
-    continueAfterReconnect: (serverId: string) => void;
 }
 
 export const McpReconnectContext = createContext<McpReconnectContextValue | undefined>(undefined);

--- a/packages/web/src/features/chat/components/chatBox/chatBoxPlusButton.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBoxPlusButton.tsx
@@ -9,6 +9,7 @@ interface ChatBoxPlusButtonProps {
     selectedSearchScopes: SearchScope[];
     onSelectedSearchScopesChange: (items: SearchScope[]) => void;
     disabledMcpServerIds: string[];
+    unavailableMcpServerIds?: string[];
     onDisabledMcpServerIdsChange: (ids: string[]) => void;
     isAuthenticated: boolean;
 }

--- a/packages/web/src/features/chat/components/chatBox/chatBoxToolbar.tsx
+++ b/packages/web/src/features/chat/components/chatBox/chatBoxToolbar.tsx
@@ -18,6 +18,7 @@ export interface ChatBoxToolbarProps {
     isContextSelectorOpen: boolean;
     onContextSelectorOpenChanged: (isOpen: boolean) => void;
     disabledMcpServerIds?: string[];
+    unavailableMcpServerIds?: string[];
     onDisabledMcpServerIdsChange?: (ids: string[]) => void;
     isAuthenticated: boolean;
 }
@@ -31,6 +32,7 @@ export const ChatBoxToolbar = ({
     isContextSelectorOpen,
     onContextSelectorOpenChanged,
     disabledMcpServerIds,
+    unavailableMcpServerIds,
     onDisabledMcpServerIdsChange,
     isAuthenticated,
 }: ChatBoxToolbarProps) => {
@@ -44,6 +46,7 @@ export const ChatBoxToolbar = ({
                         selectedSearchScopes={selectedSearchScopes}
                         onSelectedSearchScopesChange={onSelectedSearchScopesChange}
                         disabledMcpServerIds={disabledMcpServerIds}
+                        unavailableMcpServerIds={unavailableMcpServerIds}
                         onDisabledMcpServerIdsChange={onDisabledMcpServerIdsChange}
                         isAuthenticated={isAuthenticated}
                     />

--- a/packages/web/src/features/chat/constants.ts
+++ b/packages/web/src/features/chat/constants.ts
@@ -12,6 +12,7 @@ export const SET_CHAT_STATE_SESSION_STORAGE_KEY = 'setChatState';
 export const PENDING_CHAT_SUBMISSION_SESSION_STORAGE_KEY = 'pendingChatSubmission';
 export const DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY = 'disabledMcpServerIds';
 export const MCP_OAUTH_DRAFT_SESSION_STORAGE_KEY = 'mcpOAuthDraft';
+export const MCP_RECONNECT_SESSION_STORAGE_KEY = 'mcpReconnectPending';
 
 // Single upper bound on the total attachment text submitted per turn (text is
 // inlined and re-emitted every turn). ~256KB ≈ 65-85K tokens: enough for a few

--- a/packages/web/src/features/chat/mcpReconnect.test.ts
+++ b/packages/web/src/features/chat/mcpReconnect.test.ts
@@ -1,0 +1,118 @@
+import { beforeEach, describe, expect, test } from 'vitest';
+import { MCP_RECONNECT_SESSION_STORAGE_KEY } from './constants';
+import {
+    clearMcpPendingReconnect,
+    consumeMcpPendingReconnectForPath,
+    resolveMcpPendingReconnectForPath,
+    saveMcpPendingReconnect,
+} from './mcpReconnect';
+
+const NOW = 1_700_000_000_000;
+
+const createStoredPending = (overrides: Record<string, unknown> = {}) => JSON.stringify({
+    serverId: 'server-1',
+    serverName: 'Linear',
+    toolCallId: 'tool-call-1',
+    returnTo: '/chat/abc123',
+    createdAt: NOW,
+    ...overrides,
+});
+
+describe('resolveMcpPendingReconnectForPath', () => {
+    test('returns the pending reconnect when the current path matches', () => {
+        const result = resolveMcpPendingReconnectForPath(createStoredPending(), '/chat/abc123', NOW + 1000);
+        expect(result.shouldClear).toBe(true);
+        expect(result.pending).toMatchObject({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+        });
+    });
+
+    test('ignores OAuth status query parameters on the current path', () => {
+        const result = resolveMcpPendingReconnectForPath(
+            createStoredPending(),
+            '/chat/abc123?status=connected&server=Linear',
+            NOW + 1000,
+        );
+        expect(result.pending).toBeDefined();
+        expect(result.shouldClear).toBe(true);
+    });
+
+    test('keeps the pending reconnect when the current path is a different thread', () => {
+        const result = resolveMcpPendingReconnectForPath(createStoredPending(), '/chat/other', NOW + 1000);
+        expect(result.pending).toBeUndefined();
+        expect(result.shouldClear).toBe(false);
+    });
+
+    test('clears when the stored value is not valid JSON or has the wrong shape', () => {
+        expect(resolveMcpPendingReconnectForPath('not-json', '/chat/abc123', NOW).shouldClear).toBe(true);
+        expect(resolveMcpPendingReconnectForPath(JSON.stringify({ serverId: 'server-1' }), '/chat/abc123', NOW).shouldClear).toBe(true);
+    });
+
+    test('clears when the pending reconnect has expired', () => {
+        const result = resolveMcpPendingReconnectForPath(
+            createStoredPending(),
+            '/chat/abc123',
+            NOW + 31 * 60 * 1000,
+        );
+        expect(result.pending).toBeUndefined();
+        expect(result.shouldClear).toBe(true);
+    });
+
+    test('clears when the stored return path is not an allowed chat path', () => {
+        const result = resolveMcpPendingReconnectForPath(
+            createStoredPending({ returnTo: '/settings/accountAskAgent' }),
+            '/chat/abc123',
+            NOW,
+        );
+        expect(result.pending).toBeUndefined();
+        expect(result.shouldClear).toBe(true);
+    });
+
+    test('does nothing when no value is stored', () => {
+        expect(resolveMcpPendingReconnectForPath(null, '/chat/abc123', NOW)).toEqual({ shouldClear: false });
+    });
+});
+
+describe('sessionStorage round trip', () => {
+    beforeEach(() => {
+        window.sessionStorage.clear();
+    });
+
+    test('saves, consumes, and clears the pending reconnect', () => {
+        saveMcpPendingReconnect({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+        });
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).not.toBeNull();
+
+        const pending = consumeMcpPendingReconnectForPath('/chat/abc123?status=connected');
+        expect(pending?.serverId).toBe('server-1');
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+    });
+
+    test('does not save a pending reconnect for a disallowed return path', () => {
+        saveMcpPendingReconnect({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: 'https://evil.example.com/chat',
+        });
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+    });
+
+    test('clearMcpPendingReconnect removes the stored value', () => {
+        saveMcpPendingReconnect({
+            serverId: 'server-1',
+            serverName: 'Linear',
+            toolCallId: 'tool-call-1',
+            returnTo: '/chat/abc123',
+        });
+        clearMcpPendingReconnect();
+        expect(window.sessionStorage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY)).toBeNull();
+    });
+});

--- a/packages/web/src/features/chat/mcpReconnect.test.ts
+++ b/packages/web/src/features/chat/mcpReconnect.test.ts
@@ -26,6 +26,7 @@ describe('resolveMcpPendingReconnectForPath', () => {
             serverId: 'server-1',
             serverName: 'Linear',
             toolCallId: 'tool-call-1',
+            source: 'tool-call',
             returnTo: '/chat/abc123',
         });
     });
@@ -73,6 +74,19 @@ describe('resolveMcpPendingReconnectForPath', () => {
 
     test('does nothing when no value is stored', () => {
         expect(resolveMcpPendingReconnectForPath(null, '/chat/abc123', NOW)).toEqual({ shouldClear: false });
+    });
+
+    test('accepts a tool-load reconnect without a tool call ID', () => {
+        const result = resolveMcpPendingReconnectForPath(
+            createStoredPending({ source: 'tool-load', toolCallId: undefined }),
+            '/chat/abc123',
+            NOW,
+        );
+
+        expect(result.pending).toMatchObject({
+            serverId: 'server-1',
+            source: 'tool-load',
+        });
     });
 });
 

--- a/packages/web/src/features/chat/mcpReconnect.ts
+++ b/packages/web/src/features/chat/mcpReconnect.ts
@@ -3,19 +3,27 @@ import { normalizeMcpOAuthDraftPath } from "@/features/chat/mcpOAuthDraft";
 
 const MCP_RECONNECT_MAX_AGE_MS = 30 * 60 * 1000;
 
+export type McpReconnectSource = 'tool-call' | 'tool-load';
+
 // The reconnect metadata preserved across the current-tab OAuth redirect. It
-// re-associates the reconnect flow with the failed tool call when the browser
-// returns to the thread, because the in-memory reconnect state does not
-// survive the navigation.
+// re-associates the reconnect flow with the failed tool call or tool load when
+// the browser returns to the thread, because in-memory state does not survive
+// the navigation.
 export interface McpPendingReconnect {
     serverId: string;
     serverName: string;
-    toolCallId: string;
+    toolCallId?: string;
+    source: McpReconnectSource;
     returnTo: string;
     createdAt: number;
 }
 
-type McpPendingReconnectInput = Omit<McpPendingReconnect, 'createdAt'>;
+type McpPendingReconnectInput = Omit<McpPendingReconnect, 'createdAt' | 'source'> & {
+    source?: McpReconnectSource;
+};
+type StoredMcpPendingReconnect = Omit<McpPendingReconnect, 'source'> & {
+    source?: McpReconnectSource;
+};
 
 interface ResolveMcpPendingReconnectResult {
     pending?: McpPendingReconnect;
@@ -26,14 +34,15 @@ function isRecord(value: unknown): value is Record<string, unknown> {
     return typeof value === 'object' && value !== null;
 }
 
-function isMcpPendingReconnect(value: unknown): value is McpPendingReconnect {
+function isMcpPendingReconnect(value: unknown): value is StoredMcpPendingReconnect {
+    const source = isRecord(value) && value.source === 'tool-load' ? 'tool-load' : 'tool-call';
     return (
         isRecord(value) &&
         typeof value.serverId === 'string' &&
         value.serverId.length > 0 &&
         typeof value.serverName === 'string' &&
-        typeof value.toolCallId === 'string' &&
-        value.toolCallId.length > 0 &&
+        (source === 'tool-load' || (typeof value.toolCallId === 'string' && value.toolCallId.length > 0)) &&
+        (value.source === undefined || value.source === 'tool-call' || value.source === 'tool-load') &&
         typeof value.returnTo === 'string' &&
         typeof value.createdAt === 'number'
     );
@@ -80,6 +89,7 @@ export function resolveMcpPendingReconnectForPath(
     return {
         pending: {
             ...parsed,
+            source: parsed.source ?? 'tool-call',
             returnTo: storedPath,
         },
         shouldClear: true,
@@ -108,6 +118,7 @@ export function saveMcpPendingReconnect(input: McpPendingReconnectInput): void {
     try {
         storage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
             ...input,
+            source: input.source ?? 'tool-call',
             returnTo,
             createdAt: Date.now(),
         } satisfies McpPendingReconnect));

--- a/packages/web/src/features/chat/mcpReconnect.ts
+++ b/packages/web/src/features/chat/mcpReconnect.ts
@@ -1,0 +1,148 @@
+import { MCP_RECONNECT_SESSION_STORAGE_KEY } from "@/features/chat/constants";
+import { normalizeMcpOAuthDraftPath } from "@/features/chat/mcpOAuthDraft";
+
+const MCP_RECONNECT_MAX_AGE_MS = 30 * 60 * 1000;
+
+// The reconnect metadata preserved across the current-tab OAuth redirect. It
+// re-associates the reconnect flow with the failed tool call when the browser
+// returns to the thread, because the in-memory reconnect state does not
+// survive the navigation.
+export interface McpPendingReconnect {
+    serverId: string;
+    serverName: string;
+    toolCallId: string;
+    returnTo: string;
+    createdAt: number;
+}
+
+type McpPendingReconnectInput = Omit<McpPendingReconnect, 'createdAt'>;
+
+interface ResolveMcpPendingReconnectResult {
+    pending?: McpPendingReconnect;
+    shouldClear: boolean;
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+    return typeof value === 'object' && value !== null;
+}
+
+function isMcpPendingReconnect(value: unknown): value is McpPendingReconnect {
+    return (
+        isRecord(value) &&
+        typeof value.serverId === 'string' &&
+        value.serverId.length > 0 &&
+        typeof value.serverName === 'string' &&
+        typeof value.toolCallId === 'string' &&
+        value.toolCallId.length > 0 &&
+        typeof value.returnTo === 'string' &&
+        typeof value.createdAt === 'number'
+    );
+}
+
+export function resolveMcpPendingReconnectForPath(
+    storedValue: string | null,
+    currentPath: string,
+    now = Date.now(),
+): ResolveMcpPendingReconnectResult {
+    if (!storedValue) {
+        return { shouldClear: false };
+    }
+
+    let parsed: unknown;
+    try {
+        parsed = JSON.parse(storedValue);
+    } catch {
+        return { shouldClear: true };
+    }
+
+    if (!isMcpPendingReconnect(parsed)) {
+        return { shouldClear: true };
+    }
+
+    if (now - parsed.createdAt > MCP_RECONNECT_MAX_AGE_MS) {
+        return { shouldClear: true };
+    }
+
+    const storedPath = normalizeMcpOAuthDraftPath(parsed.returnTo);
+    if (!storedPath) {
+        return { shouldClear: true };
+    }
+
+    const normalizedCurrentPath = normalizeMcpOAuthDraftPath(currentPath);
+    if (!normalizedCurrentPath) {
+        return { shouldClear: false };
+    }
+
+    if (storedPath !== normalizedCurrentPath) {
+        return { shouldClear: false };
+    }
+
+    return {
+        pending: {
+            ...parsed,
+            returnTo: storedPath,
+        },
+        shouldClear: true,
+    };
+}
+
+function getSessionStorage(): Storage | undefined {
+    if (typeof window === 'undefined') {
+        return undefined;
+    }
+
+    try {
+        return window.sessionStorage;
+    } catch {
+        return undefined;
+    }
+}
+
+export function saveMcpPendingReconnect(input: McpPendingReconnectInput): void {
+    const storage = getSessionStorage();
+    const returnTo = normalizeMcpOAuthDraftPath(input.returnTo);
+    if (!storage || !returnTo) {
+        return;
+    }
+
+    try {
+        storage.setItem(MCP_RECONNECT_SESSION_STORAGE_KEY, JSON.stringify({
+            ...input,
+            returnTo,
+            createdAt: Date.now(),
+        } satisfies McpPendingReconnect));
+    } catch {
+        // If sessionStorage is unavailable or full, OAuth should still proceed.
+    }
+}
+
+export function clearMcpPendingReconnect(): void {
+    const storage = getSessionStorage();
+    if (!storage) {
+        return;
+    }
+
+    try {
+        storage.removeItem(MCP_RECONNECT_SESSION_STORAGE_KEY);
+    } catch {
+        // Ignore storage cleanup failures.
+    }
+}
+
+export function consumeMcpPendingReconnectForPath(currentPath: string): McpPendingReconnect | undefined {
+    const storage = getSessionStorage();
+    if (!storage) {
+        return undefined;
+    }
+
+    const result = resolveMcpPendingReconnectForPath(
+        storage.getItem(MCP_RECONNECT_SESSION_STORAGE_KEY),
+        currentPath,
+    );
+
+    if (result.shouldClear) {
+        clearMcpPendingReconnect();
+    }
+
+    return result.pending;
+}

--- a/packages/web/src/features/chat/types.ts
+++ b/packages/web/src/features/chat/types.ts
@@ -161,7 +161,7 @@ export type SBChatMessageDataParts = {
     // The `mcp-auth-required` data type signals that a connector's tool call
     // failed with a reconnect-required authentication failure. Always written
     // with `transient: true`: it is consumed live by the client to drive the
-    // inline reconnect UI and is never included in persisted messages.
+    // connector reconnect UI and is never included in persisted messages.
     "mcp-auth-required": { serverId: string; serverName: string; toolCallId: string },
     // A user-provided file attachment included with the message.
     "attachment": AttachmentData,

--- a/packages/web/src/features/chat/types.ts
+++ b/packages/web/src/features/chat/types.ts
@@ -158,6 +158,11 @@ export type SBChatMessageDataParts = {
     "mcp-tool": { modelToolName: string; rawToolName: string },
     // The `mcp-failed-server` data type surfaces MCP servers that failed to load their tools.
     "mcp-failed-server": { serverName: string },
+    // The `mcp-auth-required` data type signals that a connector's tool call
+    // failed with a reconnect-required authentication failure. Always written
+    // with `transient: true`: it is consumed live by the client to drive the
+    // inline reconnect UI and is never included in persisted messages.
+    "mcp-auth-required": { serverId: string; serverName: string; toolCallId: string },
     // A user-provided file attachment included with the message.
     "attachment": AttachmentData,
     // The `command` data type preserves the slash command identity so the server

--- a/packages/web/src/features/chat/types.ts
+++ b/packages/web/src/features/chat/types.ts
@@ -157,7 +157,7 @@ export type SBChatMessageDataParts = {
     // the raw MCP tool name for display.
     "mcp-tool": { modelToolName: string; rawToolName: string },
     // The `mcp-failed-server` data type surfaces MCP servers that failed to load their tools.
-    "mcp-failed-server": { serverName: string },
+    "mcp-failed-server": { serverId: string; serverName: string },
     // The `mcp-auth-required` data type signals that a connector's tool call
     // failed with a reconnect-required authentication failure. Always written
     // with `transient: true`: it is consumed live by the client to drive the


### PR DESCRIPTION
Fixes SOU-1518

## Summary

- detect reconnectable MCP authentication failures during agent turns and safely finish the interrupted response
- let users reconnect failed connectors through OAuth and restore connectors whose tools failed to load
- show reconnect success through the standard Sourcebot toast without automatically continuing the agent turn

## Testing

- yarn workspace @sourcebot/web test run src/ee/features/chat/components/chatThread/useMcpReconnectController.test.tsx src/ee/features/chat/components/chatThread/mcpReconnectBanner.test.tsx src/ee/features/chat/components/chatThread/mcpFailedServersBanner.test.tsx src/ee/features/chat/components/chatThread/tools/mcpToolComponent.test.tsx
- yarn workspace @sourcebot/web exec eslint on the changed reconnect UI and test files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OAuth token handling, agent streaming, and tool approval continuations across server and client; scope is large but bounded with extensive tests and safe error substitution at the MCP boundary.
> 
> **Overview**
> Adds **guided reconnection** when MCP connectors lose authorization during Ask agent turns or fail to load tools.
> 
> **Agent behavior:** Reconnectable auth failures (401, `invalid_grant`, etc.) are classified in `mcpAuthFailure`, surfaced as safe tool errors, and streamed via transient `data-mcp-auth-required`. The agent then **stops further tool calls** (`toolChoice: 'none'`), auto-denies pending approvals, and finishes with a user-facing reconnect prompt. Continuation requests detect the same marker in persisted tool errors and stay in that terminal mode.
> 
> **Reconnect flow:** `connectMcpToAsk` / the connect API accept **`forceAuthorization`** so OAuth ignores stale tokens and always starts interactive reauthorization. Session storage preserves pending reconnect across the redirect; `useMcpReconnectController` gates reconnect until the turn settles, drives OAuth, and confirms via server status (toast on success—**no auto-resend** of the agent turn).
> 
> **UI:** New reconnect banner for mid-turn auth failures; failed-load banner now includes per-connector **Reconnect** actions keyed by `serverId`. Connector menu marks unavailable servers and disables toggles until reconnected; chat thread auto-disables failed connectors and re-enables after successful reconnect.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ffff3c1c5a5c36ad4cc5723033d3b23e0eba6099. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added guided reconnection for MCP connectors when authentication fails during chat.
  * Added reconnect prompts with per-connector actions, loading states, and automatic tool disabling until recovery.
  * Preserved reconnect context across OAuth redirects and restored chat state afterward.
  * Improved connector controls to identify unavailable connections and require reconnection.

* **Bug Fixes**
  * Forced reauthorization now bypasses stale credentials and starts an interactive authorization flow.

* **Documentation**
  * Added an Unreleased changelog entry for guided MCP reconnection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->