### PR TITLE
feat(ask): start chat from selected code range

### DIFF
--- a/packages/web/src/app/(app)/components/editorContextMenu.tsx
+++ b/packages/web/src/app/(app)/components/editorContextMenu.tsx
@@ -2,6 +2,7 @@
 
 import { useToast } from "@/components/hooks/use-toast";
 import { Button } from "@/components/ui/button";
+import { useCreateNewChatThread } from "@/features/chat/useCreateNewChatThread";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { createPathWithQueryParams } from "@/lib/utils";
 import { autoPlacement, computePosition, offset, shift, VirtualElement } from "@floating-ui/react";
@@ -28,6 +29,7 @@ export const EditorContextMenu = ({
     const ref = useRef<HTMLDivElement>(null);
     const { toast } = useToast();
     const captureEvent = useCaptureEvent();
+    const { createChatFromSource } = useCreateNewChatThread();
     useEffect(() => {
         if (selection.empty) {
             ref.current?.classList.add('hidden');
@@ -126,19 +128,47 @@ export const EditorContextMenu = ({
         )
     }, [selection.from, selection.to, repoName, revisionName, path, toast, captureEvent, view]);
 
+    const onAskSourcebot = useCallback(() => {
+        if (selection.empty) {
+            return;
+        }
+
+        const startLine = view.state.doc.lineAt(selection.from).number;
+        const endLine = view.state.doc.lineAt(selection.to - 1).number;
+
+        void createChatFromSource({
+            type: 'file',
+            repo: repoName,
+            path,
+            name: path.split('/').pop() ?? path,
+            revision: revisionName,
+            range: { startLine, endLine },
+        });
+    }, [createChatFromSource, path, repoName, revisionName, selection, view]);
+
     return (
-        <div
-            ref={ref}
-            className="absolute z-10 flex flex-col gap-2 bg-background border border-gray-300 dark:border-gray-700 rounded-md shadow-lg p-2"
-        >
-            <Button
-                variant="ghost"
-                size="sm"
-                onClick={onCopyLinkToSelection}
-            >
-                <Link2Icon className="h-4 w-4 mr-1" />
-                Share selection
-            </Button>
-        </div>
+<div
+  ref={ref}
+  className="absolute z-10 flex items-center gap-1 rounded-lg border border-border bg-popover p-1 shadow-xl"
+>
+  <Button
+    variant="secondary"
+    size="sm"
+    onClick={onCopyLinkToSelection}
+    className="h-8 px-3 hover:bg-black/50"
+  >
+    <Link2Icon className="mr-2 h-4 w-4" />
+    Share selection
+  </Button>
+
+  <Button
+    variant="secondary"
+    size="sm"
+    onClick={onAskSourcebot}
+    className="h-8 px-3 hover:bg-black/50"
+  >
+    Ask SourceBot
+  </Button>
+</div>
     )
 }

--- a/packages/web/src/ee/features/chat/agent.test.ts
+++ b/packages/web/src/ee/features/chat/agent.test.ts
@@ -121,7 +121,7 @@ vi.mock('ai', async (importOriginal) => {
     };
 });
 
-const { createMessageStream } = await import('./agent');
+const { createMessageStream, sliceFileSourceForPrompt } = await import('./agent');
 const { getPromptCacheStrategy } = await import('./promptCaching');
 
 // Strategies reused across the prompt-caching tests below.
@@ -134,6 +134,33 @@ const listReposInput = {
     perPage: 30,
     direction: 'asc',
 } as const;
+
+describe('sliceFileSourceForPrompt', () => {
+    test('slices an inclusive range and preserves its original line offset', () => {
+        expect(sliceFileSourceForPrompt('one\ntwo\nthree\nfour', {
+            startLine: 2,
+            endLine: 3,
+        })).toEqual({
+            source: 'two\nthree',
+            lineOffset: 2,
+        });
+    });
+
+    test('keeps the full file when there is no selected range', () => {
+        expect(sliceFileSourceForPrompt('one\ntwo', undefined)).toEqual({
+            source: 'one\ntwo',
+            lineOffset: 1,
+        });
+    });
+
+    test.each([
+        { startLine: 0, endLine: 1 },
+        { startLine: 3, endLine: 2 },
+        { startLine: 1, endLine: 4 },
+    ])('ignores invalid ranges safely', (range) => {
+        expect(sliceFileSourceForPrompt('one\ntwo\nthree', range)).toBeUndefined();
+    });
+});
 
 const dynamicApprovalRespondedPart = {
     type: 'dynamic-tool',

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -929,6 +929,8 @@ const createPrompt = ({
         repo: string;
         language: string;
         revision: string;
+        range?: FileSource['range'];
+        lineOffset: number;
     }[],
     repos: string[],
     mcpToolRegistry: McpToolRegistryEntry[],

--- a/packages/web/src/ee/features/chat/agent.ts
+++ b/packages/web/src/ee/features/chat/agent.ts
@@ -21,7 +21,7 @@ import {
 import { randomUUID } from "crypto";
 import _dedent from "dedent";
 import { ANSWER_TAG, FILE_REFERENCE_PREFIX } from "@/features/chat/constants";
-import { Source } from "@/features/chat/types";
+import { FileSource, Source } from "@/features/chat/types";
 import { addLineNumbers, fileReferenceToString, formatAttachmentsForPrompt, getAnswerPartFromAssistantMessage, getTurnProgressState, getUserMessageAttachments, getUserMessageText } from "@/features/chat/utils";
 import { createTools } from "./tools";
 import { getConnectedMcpClients } from "@/ee/features/chat/mcp/mcpClientFactory";
@@ -551,6 +551,29 @@ interface AgentOptions {
     orgId?: number;
 }
 
+export const sliceFileSourceForPrompt = (
+    source: string,
+    range: FileSource['range'],
+): { source: string; lineOffset: number } | undefined => {
+    if (!range) {
+        return { source, lineOffset: 1 };
+    }
+
+    const lines = source.split('\n');
+    if (
+        range.startLine < 1 ||
+        range.endLine < range.startLine ||
+        range.endLine > lines.length
+    ) {
+        return undefined;
+    }
+
+    return {
+        source: lines.slice(range.startLine - 1, range.endLine).join('\n'),
+        lineOffset: range.startLine,
+    };
+};
+
 const createAgentStream = async ({
     model,
     promptCacheStrategy,
@@ -591,12 +614,20 @@ const createAgentStream = async ({
                 return undefined;
             }
 
+            const selectedSource = sliceFileSourceForPrompt(fileSource.source, source.range);
+            if (!selectedSource) {
+                logger.warn(`Ignoring invalid selected range for ${source.repo}:${source.path}`);
+                return undefined;
+            }
+
             return {
                 path: fileSource.path,
-                source: fileSource.source,
+                source: selectedSource.source,
                 repo: fileSource.repo,
                 language: fileSource.language,
                 revision: source.revision,
+                lineOffset: selectedSource.lineOffset,
+                range: source.range,
             };
         }))
     ).filter((source) => source !== undefined);
@@ -999,8 +1030,8 @@ const createPrompt = ({
         <files>
         The user has mentioned the following files, which are automatically included for analysis.
 
-        ${files.map(file => `<file path="${file.path}" repository="${file.repo}" language="${file.language}" revision="${file.revision}">
-            ${addLineNumbers(file.source)}
+        ${files.map(file => `<file path="${file.path}" repository="${file.repo}" language="${file.language}" revision="${file.revision}"${file.range ? ` selected_lines="${file.range.startLine}-${file.range.endLine}"` : ''}>
+            ${addLineNumbers(file.source, file.lineOffset)}
             </file>`).join('\n\n')}
         </files>
         `);

--- a/packages/web/src/features/chat/useCreateNewChatThread.test.tsx
+++ b/packages/web/src/features/chat/useCreateNewChatThread.test.tsx
@@ -80,3 +80,35 @@ test("createChatFromSource preserves disabled MCP servers from local storage", a
         disabledMcpServerIds,
     });
 });
+
+test("createChatFromSource ignores duplicate calls while chat creation is pending", async () => {
+    let resolveCreateChat: ((value: { id: string }) => void) | undefined;
+    mocks.createChat.mockImplementation(() => new Promise((resolve) => {
+        resolveCreateChat = resolve;
+    }));
+    mocks.createUIMessage.mockReturnValue({ id: "initial-message" });
+    const { result } = renderHook(() => useCreateNewChatThread());
+    const source: Source = {
+        type: "file",
+        repo: "github.com/sourcebot-dev/sourcebot",
+        path: "packages/web/src/auth.ts",
+        name: "auth.ts",
+        revision: "main",
+    };
+
+    let firstCreate: Promise<void> | undefined;
+    let secondCreate: Promise<void> | undefined;
+    act(() => {
+        firstCreate = result.current.createChatFromSource(source);
+        secondCreate = result.current.createChatFromSource(source);
+    });
+
+    expect(mocks.createChat).toHaveBeenCalledTimes(1);
+
+    resolveCreateChat?.({ id: "chat-1" });
+    await act(async () => {
+        await Promise.all([firstCreate, secondCreate]);
+    });
+
+    expect(mocks.push).toHaveBeenCalledTimes(1);
+});

--- a/packages/web/src/features/chat/useCreateNewChatThread.test.tsx
+++ b/packages/web/src/features/chat/useCreateNewChatThread.test.tsx
@@ -1,0 +1,82 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, expect, test, vi } from "vitest";
+import type { Source } from "./types";
+import { DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY } from "./constants";
+
+const mocks = vi.hoisted(() => ({
+    createChat: vi.fn(),
+    createUIMessage: vi.fn(),
+    push: vi.fn(),
+    setChatState: vi.fn(),
+    toast: vi.fn(),
+}));
+
+vi.mock("next/navigation", () => ({
+    useRouter: () => ({ push: mocks.push }),
+}));
+
+vi.mock("@/components/hooks/use-toast", () => ({
+    useToast: () => ({ toast: mocks.toast }),
+}));
+
+vi.mock("./actions", () => ({
+    createChat: mocks.createChat,
+}));
+
+vi.mock("@/lib/utils", () => ({
+    isServiceError: () => false,
+    createPathWithQueryParams: (path: string) => path,
+}));
+
+vi.mock("./utils", () => ({
+    createUIMessage: mocks.createUIMessage,
+    getAllMentionElements: () => [],
+    slateContentToString: () => "",
+}));
+
+vi.mock("usehooks-ts", () => ({
+    useSessionStorage: () => [null, mocks.setChatState],
+}));
+
+const { useCreateNewChatThread } = await import("./useCreateNewChatThread");
+
+afterEach(() => {
+    window.localStorage.clear();
+    vi.clearAllMocks();
+});
+
+test("createChatFromSource preserves disabled MCP servers from local storage", async () => {
+    const disabledMcpServerIds = ["linear", "github"];
+    window.localStorage.setItem(
+        DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY,
+        JSON.stringify(disabledMcpServerIds),
+    );
+    mocks.createChat.mockResolvedValue({ id: "chat-1" });
+    mocks.createUIMessage.mockReturnValue({ id: "initial-message" });
+    const { result } = renderHook(() => useCreateNewChatThread());
+    const source: Source = {
+        type: "file",
+        repo: "github.com/sourcebot-dev/sourcebot",
+        path: "packages/web/src/auth.ts",
+        name: "auth.ts",
+        revision: "main",
+    };
+
+    await act(async () => {
+        await result.current.createChatFromSource(source);
+    });
+
+    expect(mocks.createUIMessage).toHaveBeenCalledWith(
+        "Explain this selected code.",
+        [],
+        [],
+        disabledMcpServerIds,
+        [],
+        [source],
+    );
+    expect(mocks.setChatState).toHaveBeenCalledWith({
+        inputMessage: { id: "initial-message" },
+        selectedSearchScopes: [],
+        disabledMcpServerIds,
+    });
+});

--- a/packages/web/src/features/chat/useCreateNewChatThread.ts
+++ b/packages/web/src/features/chat/useCreateNewChatThread.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useCallback, useState } from "react";
+import { useCallback, useRef, useState } from "react";
 import { Descendant } from "slate";
 import { createUIMessage, getAllMentionElements } from "./utils";
 import { slateContentToString } from "./utils";
@@ -26,11 +26,17 @@ const getStoredDisabledMcpServerIds = (): string[] => {
 
 export const useCreateNewChatThread = () => {
     const [isLoading, setIsLoading] = useState(false);
+    const createInFlightRef = useRef(false);
     const { toast } = useToast();
     const router = useRouter();
     const [, setChatState] = useSessionStorage<SetChatStatePayload | null>(SET_CHAT_STATE_SESSION_STORAGE_KEY, null);
 
     const createNewChatThread = useCallback(async (children: Descendant[], overrideSearchScopes?: SearchScope[], overrideDisabledMcpServerIds?: string[], attachments: AttachmentData[] = []) => {
+        if (createInFlightRef.current) {
+            return;
+        }
+        createInFlightRef.current = true;
+
         const text = slateContentToString(children);
         const mentions = getAllMentionElements(children);
 
@@ -53,6 +59,7 @@ export const useCreateNewChatThread = () => {
                 description: `❌ Failed to create chat. Reason: ${response.message}`
             });
             setIsLoading(false);
+            createInFlightRef.current = false;
             return;
         }
 
@@ -68,6 +75,11 @@ export const useCreateNewChatThread = () => {
     }, [router, toast, setChatState]);
 
     const createChatFromSource = useCallback(async (source: Source) => {
+        if (createInFlightRef.current) {
+            return;
+        }
+        createInFlightRef.current = true;
+
         const disabledMcpServerIds = getStoredDisabledMcpServerIds();
         const inputMessage = createUIMessage(
             'Explain this selected code.',
@@ -85,6 +97,7 @@ export const useCreateNewChatThread = () => {
                 description: `❌ Failed to create chat. Reason: ${response.message}`,
             });
             setIsLoading(false);
+            createInFlightRef.current = false;
             return;
         }
 

--- a/packages/web/src/features/chat/useCreateNewChatThread.ts
+++ b/packages/web/src/features/chat/useCreateNewChatThread.ts
@@ -9,7 +9,7 @@ import { useRouter } from "next/navigation";
 import { createChat } from "./actions";
 import { isServiceError } from "@/lib/utils";
 import { createPathWithQueryParams } from "@/lib/utils";
-import { AttachmentData, SearchScope, SetChatStatePayload } from "./types";
+import { AttachmentData, SearchScope, SetChatStatePayload, Source } from "./types";
 import { DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY, SELECTED_SEARCH_SCOPES_LOCAL_STORAGE_KEY, SET_CHAT_STATE_SESSION_STORAGE_KEY } from "./constants";
 import { useSessionStorage } from "usehooks-ts";
 
@@ -64,8 +64,38 @@ export const useCreateNewChatThread = () => {
         router.push(url);
     }, [router, toast, setChatState]);
 
+    const createChatFromSource = useCallback(async (source: Source) => {
+        const inputMessage = createUIMessage(
+            'Explain this selected code.',
+            [],
+            [],
+            [],
+            [],
+            [source],
+        );
+
+        setIsLoading(true);
+        const response = await createChat({ source: 'sourcebot-web-client' });
+        if (isServiceError(response)) {
+            toast({
+                description: `❌ Failed to create chat. Reason: ${response.message}`,
+            });
+            setIsLoading(false);
+            return;
+        }
+
+        setChatState({
+            inputMessage,
+            selectedSearchScopes: [],
+            disabledMcpServerIds: [],
+        });
+
+        router.push(`/chat/${response.id}`);
+    }, [router, setChatState, toast]);
+
     return {
         createNewChatThread,
+        createChatFromSource,
         isLoading,
     };
 }

--- a/packages/web/src/features/chat/useCreateNewChatThread.ts
+++ b/packages/web/src/features/chat/useCreateNewChatThread.ts
@@ -13,6 +13,17 @@ import { AttachmentData, SearchScope, SetChatStatePayload, Source } from "./type
 import { DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY, SELECTED_SEARCH_SCOPES_LOCAL_STORAGE_KEY, SET_CHAT_STATE_SESSION_STORAGE_KEY } from "./constants";
 import { useSessionStorage } from "usehooks-ts";
 
+const getStoredDisabledMcpServerIds = (): string[] => {
+    try {
+        const stored = window.localStorage.getItem(DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY);
+        if (stored) {
+            return JSON.parse(stored) as string[];
+        }
+    } catch { /* fall through to [] */ }
+
+    return [];
+}
+
 export const useCreateNewChatThread = () => {
     const [isLoading, setIsLoading] = useState(false);
     const { toast } = useToast();
@@ -31,16 +42,8 @@ export const useCreateNewChatThread = () => {
             }
         } catch { /* fall through to [] */ }
 
-        let storedDisabledMcpServerIds: string[] = [];
-        try {
-            const stored = window.localStorage.getItem(DISABLED_MCP_SERVER_IDS_LOCAL_STORAGE_KEY);
-            if (stored) {
-                storedDisabledMcpServerIds = JSON.parse(stored) as string[];
-            }
-        } catch { /* fall through to [] */ }
-
         const selectedSearchScopes = overrideSearchScopes ?? storedScopes;
-        const disabledMcpServerIds = overrideDisabledMcpServerIds ?? storedDisabledMcpServerIds;
+        const disabledMcpServerIds = overrideDisabledMcpServerIds ?? getStoredDisabledMcpServerIds();
         const inputMessage = createUIMessage(text, mentions.map((mention) => mention.data), selectedSearchScopes, disabledMcpServerIds, attachments);
 
         setIsLoading(true);
@@ -65,11 +68,12 @@ export const useCreateNewChatThread = () => {
     }, [router, toast, setChatState]);
 
     const createChatFromSource = useCallback(async (source: Source) => {
+        const disabledMcpServerIds = getStoredDisabledMcpServerIds();
         const inputMessage = createUIMessage(
             'Explain this selected code.',
             [],
             [],
-            [],
+            disabledMcpServerIds,
             [],
             [source],
         );
@@ -87,7 +91,7 @@ export const useCreateNewChatThread = () => {
         setChatState({
             inputMessage,
             selectedSearchScopes: [],
-            disabledMcpServerIds: [],
+            disabledMcpServerIds,
         });
 
         router.push(`/chat/${response.id}`);

--- a/packages/web/src/features/chat/utils.test.ts
+++ b/packages/web/src/features/chat/utils.test.ts
@@ -769,6 +769,29 @@ test('repairReferences handles malformed inline code blocks', () => {
 });
 
 describe('createUIMessage', () => {
+    test('includes an explicit ranged file source', () => {
+        const result = createUIMessage('Explain this selected code.', [], [], [], [], [{
+            type: 'file',
+            repo: 'github.com/sourcebot-dev/sourcebot',
+            path: 'packages/web/src/auth.ts',
+            name: 'auth.ts',
+            revision: 'main',
+            range: { startLine: 12, endLine: 30 },
+        }]);
+
+        expect(result.parts).toContainEqual({
+            type: 'data-source',
+            data: {
+                type: 'file',
+                repo: 'github.com/sourcebot-dev/sourcebot',
+                path: 'packages/web/src/auth.ts',
+                name: 'auth.ts',
+                revision: 'main',
+                range: { startLine: 12, endLine: 30 },
+            },
+        });
+    });
+
     test('includes disabledMcpServerIds in metadata when provided', () => {
         const result = createUIMessage('hello', [], [], ['server1', 'server2']);
 

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -200,7 +200,7 @@ export const addLineNumbers = (source: string, lineOffset = 1) => {
     return source.split('\n').map((line, index) => `${index + lineOffset}: ${line}`).join('\n');
 }
 
-export const createUIMessage = (text: string, mentions: MentionData[], selectedSearchScopes: SearchScope[], disabledMcpServerIds: string[] = [], attachments: AttachmentData[] = []): CreateUIMessage<SBChatMessage> => {
+export const createUIMessage = (text: string, mentions: MentionData[], selectedSearchScopes: SearchScope[], disabledMcpServerIds: string[] = [], attachments: AttachmentData[] = [], explicitSources: Source[] = []): CreateUIMessage<SBChatMessage> => {
     // Converts applicable mentions into sources.
     const sources: Source[] = mentions
         .map((mention) => {
@@ -218,6 +218,7 @@ export const createUIMessage = (text: string, mentions: MentionData[], selectedS
             return undefined;
         })
         .filter((source) => source !== undefined);
+    sources.push(...explicitSources);
     const commandInvocation = createCommandInvocationData(
         text,
         mentions.filter((mention) => mention.type === 'command'),

--- a/packages/web/src/features/tools/types.ts
+++ b/packages/web/src/features/tools/types.ts
@@ -6,6 +6,10 @@ const fileSourceSchema = z.object({
     path: z.string(),
     name: z.string(),
     revision: z.string(),
+    range: z.object({
+        startLine: z.number().int().positive(),
+        endLine: z.number().int().positive(),
+    }).refine(({ startLine, endLine }) => endLine >= startLine).optional(),
 });
 export type FileSource = z.infer<typeof fileSourceSchema>;
 


### PR DESCRIPTION
## Summary

  Adds an “Ask Sourcebot” action to the existing code-selection popover in Browse and search previews.

  When code is selected, Ask Sourcebot:

  - Creates a new chat.
  - Seeds the prompt with `Explain this selected code.`
  - Attaches the repository, revision, file path, and selected line range.
  - Resolves the file server-side at the selected revision.
  - Sends only the selected lines to the model with original line numbers.
  - Keeps Share selection behavior unchanged.

  This implements issue #1534 Option A only. Side panels and inline conversations are out of scope.

  ## Screenshots

<img width="1512" height="813" alt="Screenshot 2026-08-07 at 2 19 34 PM" src="https://github.com/user-attachments/assets/a4ddbedf-7865-4cb5-9031-633d8c466f87" />


  ## Testing

  - Focused web tests pass: 11 files, 251 tests.
  - Web lint passes.
  - Manual Ask testing is blocked locally because this deployment has no Ask Sourcebot entitlement; the button correctly
  reports that limitation.

  Use the first screenshot for Screenshots. Put the entitlement-error screenshot under Testing or omit it if you want
  the PR to look cleaner.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the Ask agent prompt pipeline and new-chat bootstrap path; behavior is covered by unit tests but incorrect range handling could omit or mislabel code context for the model.
> 
> **Overview**
> Adds **Ask SourceBot** to the code-selection popover in Browse (alongside Share selection). A selection starts a **new chat** seeded with `Explain this selected code.` and a **file source** carrying repo, revision, path, and **line range**.
> 
> **Chat creation:** `useCreateNewChatThread` exposes `createChatFromSource`, merges explicit sources into the initial UI message via `createUIMessage`, and uses an in-flight guard so double-clicks don’t create duplicate chats. Disabled MCP server IDs from local storage are preserved for this path.
> 
> **Model context:** `FileSource` optionally includes a validated `range`. The agent resolves the file at the chosen revision, **slices** content with `sliceFileSourceForPrompt` (invalid ranges are dropped), and injects only those lines into the dynamic prompt with **original line numbers** (`selected_lines` metadata + `addLineNumbers` offset).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2b7bc80e6518fccdf0f0279a225c2aea89c6f0b4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an “Ask SourceBot” option to the file editor context menu.
  * Start chats from a selected file or specific line range for focused code explanations.
  * Preserve selected ranges and original line numbering in chat prompts.
  * Retain selected source attachments when creating chat messages.

* **Bug Fixes**
  * Safely handle invalid or reversed line ranges.
  * Prevent duplicate chat creation while a new chat is being opened.

* **Tests**
  * Added coverage for ranged sources, offsets, full-file prompts, invalid selections, and source-based chat creation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->