### PR TITLE
Vns aditya02 patch 1

### DIFF
--- a/docs/docs/features/permission-syncing.mdx
+++ b/docs/docs/features/permission-syncing.mdx
@@ -43,7 +43,7 @@ We are actively working on supporting more code hosts. If you'd like to see a sp
 | [Bitbucket Data Center](/docs/features/permission-syncing#bitbucket-data-center) | 🟠 Partial |
 | Azure DevOps Cloud | 🛑 |
 | Azure DevOps Server | 🛑 |
-| Gitea | 🛑 |
+| Gitea | ✅ |
 | Gerrit | 🛑 |
 | Generic git host | 🛑 |
 

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -396,7 +396,7 @@ const options = {
         REDIS_TLS_KEY_PASSPHRASE: z.string().optional(),
 
         CONNECTION_MANAGER_UPSERT_TIMEOUT_MS: numberSchema.default(300000),
-        REPO_SYNC_RETRY_BASE_SLEEP_SECONDS: numberSchema.default(60),
+        REPO_SYNC_RETRY_BASE_SLEEP_SECONDS: numberSchema.default(600),
 
         GITLAB_CLIENT_QUERY_TIMEOUT_SECONDS: numberSchema.default(60 * 10),
 


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Low Risk**
> Documentation and a default env value change only; longer default retry spacing may slow recovery from transient sync failures for deployments that relied on the old 60s default.
> 
> **Overview**
> Updates the **permission syncing** platform table so **Gitea** is listed as fully supported (✅) instead of not supported (🛑).
> 
> Raises the default for **`REPO_SYNC_RETRY_BASE_SLEEP_SECONDS`** from **60** to **600** seconds in server env validation, so failed repository sync retries use a longer base delay for exponential backoff when the variable is unset.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe05e17105410cce3efa3ed5986adc54fcd0811c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Gitea permission syncing is now fully supported.

* **Bug Fixes**
  * Improved repository synchronization reliability by increasing the delay before retrying failed sync attempts.
  * This helps reduce repeated retry activity during temporary synchronization issues.

* **Documentation**
  * Updated the platform support documentation to accurately reflect Gitea permission-syncing support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->