### PR TITLE
fix: allow bot-triggered license audits

### DIFF
--- a/.github/workflows/license-audit.yml
+++ b/.github/workflows/license-audit.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Audit licenses with Claude
         uses: anthropics/claude-code-action@v1
         with:
+          allowed_bots: "github-actions"
           anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
           claude_args: '--allowedTools "Bash,Read,Write,Glob,Grep,WebFetch"'
           prompt: ${{ steps.read-prompt.outputs.PROMPT }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Fixed Ask MCP connector tools failing to load when their input schemas use JSON Schema 2019-09 or 2020-12. [#1547](https://github.com/sourcebot-dev/sourcebot/pull/1547)
 - Upgraded `js-yaml` to `^4.3.1`. [#1552](https://github.com/sourcebot-dev/sourcebot/pull/1552)
 - Upgraded `reo-census` to `^1.2.10` in `setup-sourcebot`. [#1554](https://github.com/sourcebot-dev/sourcebot/pull/1554)
-- Allowed license audits to run when triggered by GitHub Actions. [#1559](https://github.com/sourcebot-dev/sourcebot/pull/1559)
 
 ## [5.1.5] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - [EE] Fixed Ask MCP connector tools failing to load when their input schemas use JSON Schema 2019-09 or 2020-12. [#1547](https://github.com/sourcebot-dev/sourcebot/pull/1547)
 - Upgraded `js-yaml` to `^4.3.1`. [#1552](https://github.com/sourcebot-dev/sourcebot/pull/1552)
 - Upgraded `reo-census` to `^1.2.10` in `setup-sourcebot`. [#1554](https://github.com/sourcebot-dev/sourcebot/pull/1554)
+- Allowed license audits to run when triggered by GitHub Actions. [#1559](https://github.com/sourcebot-dev/sourcebot/pull/1559)
 
 ## [5.1.5] - 2026-07-31
 


### PR DESCRIPTION
## Summary

- allow the `github-actions` actor to invoke the Claude license audit
- keep the action allowlist scoped to the repository automation bot

## Testing

- parsed `.github/workflows/license-audit.yml` with Ruby Psych
- ran `git diff --check`

Failure: https://github.com/sourcebot-dev/sourcebot/actions/runs/31248976662/job/93524070990?pr=1557

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow input change scoped to repository automation; no application or security logic changes.
> 
> **Overview**
> The License Audit workflow’s **Audit licenses with Claude** step now passes `allowed_bots: "github-actions"` to `anthropics/claude-code-action@v1`, so runs triggered by the GitHub Actions bot are accepted instead of being blocked by the action’s bot allowlist.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6615fb98a01bc95650de87f09450b7b93e0e162d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * License audits can now run successfully when triggered by GitHub Actions.

* **Documentation**
  * Added an Unreleased changelog entry documenting the license audit improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->