### PR TITLE
fix: use release app for Zoekt sync

### DIFF
--- a/.github/workflows/syncZoekt.yml
+++ b/.github/workflows/syncZoekt.yml
@@ -33,8 +33,8 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v2
         with:
-          app-id: ${{ secrets.SOURCEBOT_SYNC_APP_ID }}
-          private-key: ${{ secrets.SOURCEBOT_SYNC_APP_PRIVATE_KEY }}
+          app-id: ${{ secrets.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
           owner: sourcebot-dev
           repositories: sourcebot
           permission-contents: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `nanoid` to `^3.3.18`. [#1557](https://github.com/sourcebot-dev/sourcebot/pull/1557)
 - Upgraded `dompurify` to `^3.4.13`. [#1556](https://github.com/sourcebot-dev/sourcebot/pull/1556)
 - Upgraded `mermaid` to `^11.16.1`. [#1555](https://github.com/sourcebot-dev/sourcebot/pull/1555)
+- Fixed the automated Zoekt sync workflow to use the existing release GitHub App credentials. [#1561](https://github.com/sourcebot-dev/sourcebot/pull/1561)
 
 ## [5.1.5] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `nanoid` to `^3.3.18`. [#1557](https://github.com/sourcebot-dev/sourcebot/pull/1557)
 - Upgraded `dompurify` to `^3.4.13`. [#1556](https://github.com/sourcebot-dev/sourcebot/pull/1556)
 - Upgraded `mermaid` to `^11.16.1`. [#1555](https://github.com/sourcebot-dev/sourcebot/pull/1555)
-- Fixed the automated Zoekt sync workflow to use the existing release GitHub App credentials. [#1561](https://github.com/sourcebot-dev/sourcebot/pull/1561)
 
 ## [5.1.5] - 2026-07-31
 


### PR DESCRIPTION
## Summary
- use the existing release GitHub App credentials for automated Zoekt submodule PRs
- retain the existing token permissions and repository restriction

## Testing
- bash .github/scripts/testZoektSync.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Workflow-only secret rename with no change to automation logic or permissions; ensure the release App is installed with the same repo access as before.
> 
> **Overview**
> The **Sync Zoekt Submodule** workflow now authenticates with the **release** GitHub App (`RELEASE_APP_ID` / `RELEASE_APP_PRIVATE_KEY`) instead of dedicated `SOURCEBOT_SYNC_APP_*` secrets.
> 
> Repository scope, contents/write and pull-requests/write permissions, and the rest of the automation steps are unchanged—only which App issues the token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dae7c4f24abd7fb5844174fb318e32291b975dc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated workflow authentication to use the release app credentials.
  * No changes to sync behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->