### PR TITLE
fix: scope Zoekt changelog updates to Unreleased

### DIFF
--- a/.github/scripts/addZoektSyncChangelogEntry.sh
+++ b/.github/scripts/addZoektSyncChangelogEntry.sh
@@ -83,12 +83,14 @@ awk -v entry="$entry" '
     next
   }
 
-  in_unreleased && !found_changed && /^## / {
-    print "### Changed"
-    print entry
-    print ""
-    found_changed = 1
-    inserted = 1
+  in_unreleased && /^## / {
+    if (!found_changed) {
+      print "### Changed"
+      print entry
+      print ""
+      found_changed = 1
+      inserted = 1
+    }
     in_unreleased = 0
     print
     next

--- a/.github/scripts/testZoektSync.sh
+++ b/.github/scripts/testZoektSync.sh
@@ -145,6 +145,14 @@ cat > "$changelog_fixture" <<'EOF'
 - Fixed something.
 
 ## [1.0.0]
+
+### Changed
+- Changed something in a released version.
+
+## [0.9.0]
+
+### Changed
+- Changed something in an older released version.
 EOF
 
 chmod 640 "$changelog_fixture"
@@ -155,6 +163,9 @@ assert_contains "$changelog_fixture" \
 assert_contains "$changelog_fixture" \
   "- Updated the bundled Zoekt version. [#42](https://github.com/sourcebot-dev/sourcebot/pull/42)" \
   "the changelog helper should add the generated PR link"
+entry_count=$(grep -Fc "sourcebot/pull/42" "$changelog_fixture")
+assert_equals "$entry_count" 1 \
+  "the changelog helper should add the PR entry only to Unreleased"
 CHANGELOG_PATH="$changelog_fixture" "$changelog_script" 42
 entry_count=$(grep -Fc "sourcebot/pull/42" "$changelog_fixture")
 assert_equals "$entry_count" 1 \

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `nanoid` to `^3.3.18`. [#1557](https://github.com/sourcebot-dev/sourcebot/pull/1557)
 - Upgraded `dompurify` to `^3.4.13`. [#1556](https://github.com/sourcebot-dev/sourcebot/pull/1556)
 - Upgraded `mermaid` to `^11.16.1`. [#1555](https://github.com/sourcebot-dev/sourcebot/pull/1555)
+- Fixed automated Zoekt changelog updates being added to historical releases. [#1563](https://github.com/sourcebot-dev/sourcebot/pull/1563)
 
 ## [5.1.5] - 2026-07-31
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `nanoid` to `^3.3.18`. [#1557](https://github.com/sourcebot-dev/sourcebot/pull/1557)
 - Upgraded `dompurify` to `^3.4.13`. [#1556](https://github.com/sourcebot-dev/sourcebot/pull/1556)
 - Upgraded `mermaid` to `^11.16.1`. [#1555](https://github.com/sourcebot-dev/sourcebot/pull/1555)
-- Fixed automated Zoekt changelog updates being added to historical releases. [#1563](https://github.com/sourcebot-dev/sourcebot/pull/1563)
 
 ## [5.1.5] - 2026-07-31
 


### PR DESCRIPTION
## Summary
- stop changelog insertion state at the first release header after Unreleased
- prevent automated Zoekt entries from being appended to historical Changed sections
- add regression coverage with multiple historical releases

## Testing
- bash .github/scripts/testZoektSync.sh
- git diff --check

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to CI changelog automation and its shell tests; no runtime app or security paths are affected.
> 
> **Overview**
> Fixes the Zoekt changelog helper so automated **Updated the bundled Zoekt version** lines are written only under **## [Unreleased]**, not into **### Changed** sections on older release headers.
> 
> The awk script now always ends the Unreleased scope when it hits a `## ` version header (e.g. `## [1.0.0]`), instead of only doing that when it still needed to create a Changed section. That stops follow-on `### Changed` blocks in historical releases from being treated as Unreleased.
> 
> `testZoektSync.sh` adds a fixture with multiple released versions that already have Changed sections and asserts the PR link appears exactly once after the helper runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e273e60d3431e9eb1776fbb84725b97c26a0abfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed automated changelog updates so new entries are added only to the **Unreleased** section, rather than historical releases.
  * Prevented duplicate entries when the changelog update runs repeatedly.

* **Documentation**
  * Added an Unreleased changelog entry describing the correction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->