### PR TITLE
fix(web): support ports in chat file references

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Upgraded `nanoid` to `^3.3.18`. [#1557](https://github.com/sourcebot-dev/sourcebot/pull/1557)
 - Upgraded `dompurify` to `^3.4.13`. [#1556](https://github.com/sourcebot-dev/sourcebot/pull/1556)
 - Upgraded `mermaid` to `^11.16.1`. [#1555](https://github.com/sourcebot-dev/sourcebot/pull/1555)
+- [EE] Fixed Ask Sourcebot file reference citations for repositories whose code host URL includes a port. [#1565](https://github.com/sourcebot-dev/sourcebot/pull/1565)
 
 ## [5.1.5] - 2026-07-31
 

--- a/packages/web/src/ee/features/chat/components/chatThread/markdownRenderer.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/markdownRenderer.tsx
@@ -49,7 +49,7 @@ function remarkReferencesPlugin() {
     return function (tree: Nodes) {
         findAndReplace(tree, [
             FILE_REFERENCE_REGEX,
-            (_, repo: string, fileName: string, startLine?: string, endLine?: string) => {
+            (_, repo: string, _port: string | undefined, fileName: string, startLine?: string, endLine?: string) => {
                 // Create display text
                 let displayText = fileName.split('/').pop() ?? fileName;
 

--- a/packages/web/src/ee/features/chat/skills/commandResolution.ts
+++ b/packages/web/src/ee/features/chat/skills/commandResolution.ts
@@ -143,7 +143,7 @@ export const getFileSourcesFromText = (text: string): FileSource[] => {
     FILE_REFERENCE_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = FILE_REFERENCE_REGEX.exec(text)) !== null) {
-        const [, repo, path] = match;
+        const [, repo, , path] = match;
         if (!repo || !path) {
             continue;
         }

--- a/packages/web/src/ee/features/chat/skills/components/skillInstructionsEditor.tsx
+++ b/packages/web/src/ee/features/chat/skills/components/skillInstructionsEditor.tsx
@@ -44,7 +44,7 @@ const parseInlineInstructions = (text: string): Descendant[] => {
     FILE_REFERENCE_REGEX.lastIndex = 0;
     let match: RegExpExecArray | null;
     while ((match = FILE_REFERENCE_REGEX.exec(text)) !== null) {
-        const [rawReference, repo, path] = match;
+        const [rawReference, repo, , path] = match;
         if (!repo || !path) {
             continue;
         }

--- a/packages/web/src/ee/features/chat/useExtractPanelItems.ts
+++ b/packages/web/src/ee/features/chat/useExtractPanelItems.ts
@@ -70,7 +70,7 @@ export const useExtractPanelItems = (
         const combined = new RegExp(`${MERMAID_BLOCK_REGEX.source}|${FILE_REFERENCE_REGEX.source}`, 'g');
         let match: RegExpExecArray | null;
         while ((match = combined.exec(text)) !== null) {
-            // match[1]: mermaid body. match[2..5]: file reference repo/path/start/end.
+            // match[1]: mermaid body. match[2..6]: file reference repo/port/path/start/end.
             if (match[1] !== undefined) {
                 const code = match[1].trim();
                 if (!code) {
@@ -85,8 +85,8 @@ export const useExtractPanelItems = (
                 const diagramIndex = diagrams.length;
                 diagrams.push(diagram);
                 orderedItems.push({ kind: 'diagram', diagram, diagramIndex });
-            } else if (match[2] !== undefined && match[3] !== undefined) {
-                const reference = createFileReference({ repo: match[2], path: match[3], startLine: match[4], endLine: match[5] });
+            } else if (match[2] !== undefined && match[4] !== undefined) {
+                const reference = createFileReference({ repo: match[2], path: match[4], startLine: match[5], endLine: match[6] });
                 const source = tryResolveFileReference(reference, referencedFileSources);
                 if (!source) {
                     continue;

--- a/packages/web/src/ee/features/chat/useExtractReferences.ts
+++ b/packages/web/src/ee/features/chat/useExtractReferences.ts
@@ -19,7 +19,7 @@ export const useExtractReferences = (part?: TextUIPart) => {
 
         let match;
         while ((match = FILE_REFERENCE_REGEX.exec(content ?? '')) !== null && match !== null) {
-            const [_, repo, fileName, startLine, endLine] = match;
+            const [, repo, , fileName, startLine, endLine] = match;
 
             const fileReference = createFileReference({
                 repo: repo,

--- a/packages/web/src/features/chat/constants.ts
+++ b/packages/web/src/features/chat/constants.ts
@@ -1,7 +1,7 @@
 export const FILE_REFERENCE_PREFIX = '@file:';
 export const FILE_REFERENCE_REGEX = new RegExp(
     // @file:{repoName::fileName:startLine-endLine}
-    `${FILE_REFERENCE_PREFIX}\\{([^:}]+)::([^:}]+)(?::(\\d+)(?:-(\\d+))?)?\\}`, 
+    `${FILE_REFERENCE_PREFIX}\\{([^:}]+(:\\d+)?[^:}]*)::([^:}]+)(?::(\\d+)(?:-(\\d+))?)?\\}`,
     'g'
 );
 

--- a/packages/web/src/features/chat/utils.test.ts
+++ b/packages/web/src/features/chat/utils.test.ts
@@ -134,6 +134,23 @@ test('fileReferenceToString matches FILE_REFERENCE_REGEX', () => {
     }))).toBe(true);
 });
 
+test('fileReferenceToString matches FILE_REFERENCE_REGEX for repos with ports', () => {
+    const reference = fileReferenceToString({
+        repo: 'git.example.com:8080/org/repo',
+        path: 'auth.ts',
+        range: {
+            startLine: 45,
+            endLine: 60,
+        },
+    });
+
+    FILE_REFERENCE_REGEX.lastIndex = 0;
+    const match = FILE_REFERENCE_REGEX.exec(reference);
+
+    expect(match).not.toBeNull();
+    expect(match?.[1]).toBe('git.example.com:8080/org/repo');
+});
+
 test('slateContentToString serializes command mentions as literal slash commands', () => {
     const children = [{
         type: 'paragraph',

--- a/packages/web/src/features/chat/utils.test.ts
+++ b/packages/web/src/features/chat/utils.test.ts
@@ -149,6 +149,10 @@ test('fileReferenceToString matches FILE_REFERENCE_REGEX for repos with ports', 
 
     expect(match).not.toBeNull();
     expect(match?.[1]).toBe('git.example.com:8080/org/repo');
+    expect(match?.[2]).toBe(':8080');
+    expect(match?.[3]).toBe('auth.ts');
+    expect(match?.[4]).toBe('45');
+    expect(match?.[5]).toBe('60');
 });
 
 test('slateContentToString serializes command mentions as literal slash commands', () => {

--- a/packages/web/src/features/chat/utils.ts
+++ b/packages/web/src/features/chat/utils.ts
@@ -284,7 +284,7 @@ export const createFileReference = ({ repo, path, startLine, endLine }: { repo: 
 export const convertLLMOutputToPortableMarkdown = (text: string, baseUrl: string, sources: FileSource[]): string => {
     return text
         .replace(ANSWER_TAG, '')
-        .replace(FILE_REFERENCE_REGEX, (_, repo, fileName, startLine, endLine) => {
+        .replace(FILE_REFERENCE_REGEX, (_, repo, _port, fileName, startLine, endLine) => {
             const reference = createFileReference({
                 repo,
                 path: fileName,


### PR DESCRIPTION
Fixes SOU-1929

## Summary
- allow numeric ports in repository names parsed from chat file references
- update positional capture consumers, including Mermaid-composed matching
- add a regression test for git.example.com:8080/org/repo

## Testing
- yarn workspace @sourcebot/web test src/features/chat/utils.test.ts --run
- yarn workspace @sourcebot/web test src/features/chat --run
- yarn workspace @sourcebot/web test src/ee/features/chat/useExtractReferences.test.ts src/ee/features/chat/skills/commandResolution.test.ts src/ee/features/chat/skills/components/skillInstructionsEditor.test.ts --run
- targeted ESLint on all changed TypeScript files

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized regex and capture-index updates in chat file-reference handling, with a targeted regression test; no auth or data-layer changes.
> 
> **Overview**
> Fixes **Ask Sourcebot file citations** when the repository identifier includes a **host port** (e.g. `git.example.com:8080/org/repo`). Previously, `FILE_REFERENCE_REGEX` treated the first `:` as the separator between repo and path, so citations were parsed with the wrong repo/path and line ranges.
> 
> The shared **`FILE_REFERENCE_REGEX`** now allows an optional `:digits` segment inside the repo portion before the `::` path delimiter. Every consumer that reads regex capture groups was updated to account for the extra capture (markdown rendering, reference extraction, skill instructions, panel interleaving with Mermaid, portable markdown export). A regression test asserts round-trip parsing for a port-bearing repo.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8d8b900512672ca4cb80c094fe3052e3f703ab25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Ask Sourcebot file-reference citations for repositories hosted on URLs with port numbers.
  - Corrected file paths, repository details, and line ranges when displaying cited code.
  - Preserved existing Mermaid diagram and markdown rendering behavior.
  - Improved citation handling across chat responses and source panels.

- **Tests**
  - Added regression coverage for repository URLs containing ports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->