### PR TITLE
Add internal cloud image release workflow

### DIFF
--- a/.github/workflows/_build-cloud.yml
+++ b/.github/workflows/_build-cloud.yml
@@ -22,6 +22,11 @@ on:
         required: false
         type: string
         default: us-west-1
+      require_sentry:
+        description: "Require complete Sentry build configuration and source-map upload credentials"
+        required: false
+        type: boolean
+        default: true
 
 jobs:
   build:
@@ -58,13 +63,14 @@ jobs:
           SENTRY_ORG: ${{ vars.SENTRY_ORG }}
           SENTRY_WEBAPP_PROJECT: ${{ vars.SENTRY_WEBAPP_PROJECT }}
           SENTRY_BACKEND_PROJECT: ${{ vars.SENTRY_BACKEND_PROJECT }}
+          REQUIRE_SENTRY: ${{ inputs.require_sentry }}
         run: |
           missing=0
-          for name in SENTRY_AUTH_TOKEN AWS_ECR_ROLE_ARN \
-                      NEXT_PUBLIC_SENTRY_ENVIRONMENT \
-                      NEXT_PUBLIC_SENTRY_WEBAPP_DSN \
-                      NEXT_PUBLIC_SENTRY_BACKEND_DSN \
-                      SENTRY_ORG SENTRY_WEBAPP_PROJECT SENTRY_BACKEND_PROJECT; do
+          required_names="AWS_ECR_ROLE_ARN"
+          if [ "$REQUIRE_SENTRY" = "true" ]; then
+            required_names="$required_names SENTRY_AUTH_TOKEN NEXT_PUBLIC_SENTRY_ENVIRONMENT NEXT_PUBLIC_SENTRY_WEBAPP_DSN NEXT_PUBLIC_SENTRY_BACKEND_DSN SENTRY_ORG SENTRY_WEBAPP_PROJECT SENTRY_BACKEND_PROJECT"
+          fi
+          for name in $required_names; do
             if [ -z "${!name}" ]; then
               echo "::error::${name} is not set on the '${ENVIRONMENT}' environment (or the repository)."
               missing=1
@@ -73,8 +79,11 @@ jobs:
             fi
           done
           if [ "$missing" -ne 0 ]; then
-            echo "::error::Refusing to build: the image would ship without Sentry wiring."
+            echo "::error::Refusing to build: required environment configuration is missing."
             exit 1
+          fi
+          if [ "$REQUIRE_SENTRY" != "true" ]; then
+            echo "Sentry wiring is intentionally disabled for the isolated internal demo image."
           fi
 
       - name: Check Prisma migrations
@@ -128,8 +137,7 @@ jobs:
             SENTRY_RELEASE=${{ steps.commit.outputs.sha }}
           # Passed as a secret, not a build-arg: build args are recorded in layer
           # metadata that `mode=max` exports to the cache. @see: Dockerfile
-          secrets: |
-            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
+          secrets: ${{ inputs.require_sentry && format('sentry_auth_token={0}', secrets.SENTRY_AUTH_TOKEN) || '' }}
           # Cache scope is per-environment, and distinct from the OSS build's
           # (which is keyed on platform alone). Sharing a scope would let a build
           # that never sees SENTRY_AUTH_TOKEN restore layers from one that did.
@@ -141,7 +149,12 @@ jobs:
           ENVIRONMENT: ${{ inputs.environment }}
           COMMIT_SHA: ${{ steps.commit.outputs.sha }}
           TAGS: ${{ steps.meta.outputs.tags }}
+          REQUIRE_SENTRY: ${{ inputs.require_sentry }}
         run: |
+          sentry_summary="disabled"
+          if [ "$REQUIRE_SENTRY" = "true" ]; then
+            sentry_summary="$COMMIT_SHA"
+          fi
           {
             echo "### Pushed to ECR"
             echo
@@ -149,7 +162,7 @@ jobs:
             echo "|---|---|"
             echo "| Environment | \`${ENVIRONMENT}\` |"
             echo "| Commit | \`${COMMIT_SHA}\` |"
-            echo "| Sentry release | \`${COMMIT_SHA}\` |"
+            echo "| Sentry | \`${sentry_summary}\` |"
             echo
             echo '```'
             echo "$TAGS"

--- a/.github/workflows/release-cloud-internal.yml
+++ b/.github/workflows/release-cloud-internal.yml
@@ -1,0 +1,30 @@
+name: Release Sourcebot (Cloud - Internal Demo)
+
+permissions:
+  contents: read
+  id-token: write
+
+on:
+  workflow_dispatch:
+    inputs:
+      git_ref:
+        description: Git ref to build for internal.sourcebot.dev
+        required: false
+        default: main
+        type: string
+
+concurrency:
+  group: release-cloud-internal
+  cancel-in-progress: false
+
+jobs:
+  build:
+    uses: ./.github/workflows/_build-cloud.yml
+    with:
+      environment: internal
+      git_ref: ${{ inputs.git_ref || 'main' }}
+      require_sentry: false
+      docker_tags: |
+        type=raw,value=main
+        type=sha,format=long
+    secrets: inherit

--- a/.github/workflows/releaseCloudInternal.yml
+++ b/.github/workflows/releaseCloudInternal.yml
@@ -6,12 +6,6 @@ permissions:
 
 on:
   workflow_dispatch:
-    inputs:
-      git_ref:
-        description: Git ref to build for internal.sourcebot.dev
-        required: false
-        default: main
-        type: string
 
 concurrency:
   group: release-cloud-internal
@@ -22,9 +16,10 @@ jobs:
     uses: ./.github/workflows/_build-cloud.yml
     with:
       environment: internal
-      git_ref: ${{ inputs.git_ref || 'main' }}
+      # Pin the checkout and image tags to the same dispatch commit so metadata
+      # can never identify image contents as a different revision.
+      git_ref: ${{ github.sha }}
       require_sentry: false
       docker_tags: |
         type=raw,value=main
-        type=sha,format=long
-    secrets: inherit
+        type=raw,value=sha-${{ github.sha }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a manually triggered cloud image release workflow for isolated internal deployments. [#1566](https://github.com/sourcebot-dev/sourcebot/pull/1566)
+
 ## [5.1.6] - 2026-08-10
 
 ### Added


### PR DESCRIPTION
## Summary
- add a manually triggered internal cloud image build targeting the isolated internal ECR repository
- make Sentry wiring explicitly optional for non-production builds while preserving the production default and validation

## Verification
- actionlint .github/workflows/_build-cloud.yml .github/workflows/release-cloud-internal.yml

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 1b9f596440d1119aca3df2d847101e1ea20e8012. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a manually triggered cloud release workflow for isolated internal deployments.
  - Cloud image builds can now run without Sentry configuration when Sentry is disabled.
  - Release builds are tagged with both the current commit and the main branch.

- **Documentation**
  - Added an Unreleased changelog entry documenting the new internal cloud release process.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->