### PR TITLE
Verify internal build OIDC identity

### DIFF
--- a/.github/workflows/_build-cloud.yml
+++ b/.github/workflows/_build-cloud.yml
@@ -86,6 +86,30 @@ jobs:
             echo "Sentry wiring is intentionally disabled for the isolated internal demo image."
           fi
 
+      - name: Verify internal GitHub OIDC identity
+        if: inputs.environment == 'internal'
+        env:
+          EXPECTED_OIDC_SUBJECT: repo:sourcebot-dev@135396723/sourcebot@846729675:environment:internal
+        run: |
+          response=$(curl --fail --silent --show-error \
+            -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
+            "$ACTIONS_ID_TOKEN_REQUEST_URL&audience=sts.amazonaws.com")
+          token=$(jq -r '.value' <<<"$response")
+          OIDC_TOKEN="$token" node - <<'NODE'
+          const claims = JSON.parse(Buffer.from(process.env.OIDC_TOKEN.split('.')[1], 'base64url'));
+          console.log(JSON.stringify({
+            sub: claims.sub,
+            aud: claims.aud,
+            repository: claims.repository,
+            repository_id: claims.repository_id,
+            job_workflow_ref: claims.job_workflow_ref,
+          }, null, 2));
+          if (claims.sub !== process.env.EXPECTED_OIDC_SUBJECT) {
+            console.error(`Unexpected OIDC subject: ${claims.sub}`);
+            process.exit(1);
+          }
+          NODE
+
       - name: Check Prisma migrations
         uses: ./.github/actions/check-prisma-migrations
 


### PR DESCRIPTION
Adds a fail-closed OIDC claim guard only for the `internal` cloud build environment. Production behavior is unchanged. The guard prints non-secret claims and pins the expected immutable organization/repository IDs.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches CI identity verification on the AWS OIDC path for internal builds. Risk is limited because the guard is additive, fail-closed, and does not change production behavior.
> 
> **Overview**
> Adds a **fail-closed OIDC subject check** to `_build-cloud.yml` that runs only when `environment == internal`, before AWS credentials are assumed.
> 
> The step fetches the GitHub Actions ID token, logs non-secret claims, and aborts unless `sub` matches the pinned immutable org/repo IDs for the internal environment. Production builds are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4865c3e9c05028b4508e76726b6ea36a9ea218e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->