### PR TITLE
Align internal build OIDC identity

### DIFF
--- a/.github/workflows/_build-cloud.yml
+++ b/.github/workflows/_build-cloud.yml
@@ -89,7 +89,7 @@ jobs:
       - name: Verify internal GitHub OIDC identity
         if: inputs.environment == 'internal'
         env:
-          EXPECTED_OIDC_SUBJECT: repo:sourcebot-dev@135396723/sourcebot@846729675:environment:internal
+          EXPECTED_OIDC_SUBJECT: repo:sourcebot-dev/sourcebot:environment:internal
         run: |
           response=$(curl --fail --silent --show-error \
             -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \


### PR DESCRIPTION
Aligns the internal-only OIDC guard to the exact name-only subject observed in run 31530143690. Production behavior is unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches OIDC identity verification used before assuming AWS ECR roles, but only for the internal environment and only to match the observed subject.
> 
> **Overview**
> Updates the **internal-only** OIDC subject check in `_build-cloud.yml` to the name-only form `repo:sourcebot-dev/sourcebot:environment:internal`, matching the subject GitHub actually issues.
> 
> Production/staging behavior is unchanged; this only affects the guard that runs when `environment == 'internal'`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f369ab1b342f2993781a1ddfa86fe41bde18e077. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->