### PR TITLE
fix(web): scale web heap limit to container memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a manually triggered cloud image release workflow for isolated internal deployments. [#1566](https://github.com/sourcebot-dev/sourcebot/pull/1566)
 
+### Fixed
+- Fixed the web process being capped at a ~4GiB heap regardless of how much memory the container has, which caused multi-second garbage collection pauses on larger deployments. [#1569](https://github.com/sourcebot-dev/sourcebot/pull/1569)
+
 ## [5.1.6] - 2026-08-10
 
 ### Added

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -16,7 +16,7 @@ redirect_stderr=true
 [program:web]
 command=./prefix-output.sh node packages/web/server.js
 # Node's default heap limit caps at ~4GiB regardless of container memory.
-environment=NODE_OPTIONS="--max-old-space-size-percentage=75"
+environment=NODE_OPTIONS="--max-old-space-size-percentage=50"
 priority=20
 autostart=true
 autorestart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,7 +15,6 @@ redirect_stderr=true
 
 [program:web]
 command=./prefix-output.sh node packages/web/server.js
-# Node's default heap limit caps at ~4GiB regardless of container memory.
 environment=NODE_OPTIONS="--max-old-space-size-percentage=50"
 priority=20
 autostart=true

--- a/supervisord.conf
+++ b/supervisord.conf
@@ -15,6 +15,8 @@ redirect_stderr=true
 
 [program:web]
 command=./prefix-output.sh node packages/web/server.js
+# Node's default heap limit caps at ~4GiB regardless of container memory.
+environment=NODE_OPTIONS="--max-old-space-size-percentage=75"
 priority=20
 autostart=true
 autorestart=true


### PR DESCRIPTION
Fixes SOU-1933

## Problem

Node's default old-space limit caps at roughly 4 GiB no matter how much memory the container has. `app.sourcebot.dev` runs with a 16 GiB limit, so the web process was capped at 4288 MiB — about a quarter of what it was allocated.

Once `next-server` reaches that ceiling, V8 stops doing cheap incremental sweeps and runs full stop-the-world mark-compact collections back to back. That blocks the single event loop, so every route slows simultaneously and the health endpoint stops answering.

Evidence from production:

- A 6081 ms `GET /` (the slowest in 7 days; p50 is 58 ms) whose two dominant spans were `prisma:client:operation` at 1398 ms and 1248 ms — with `prisma:engine:query` children of **2.16 ms** and **1.13 ms**. The database did ~2 ms of work; the rest was the event loop being blocked.
- In the same window every other route was slow too: auth 3.2 s, `/api/source` 2.3 s, changelog 2.0 s, commits 1.7 s, repos 1.7 s.
- Postgres was idle throughout — 35 connections all idle, ~100% buffer cache hit rate, zero deadlocks.
- CPU was not the constraint: 171 throttled periods out of 211,223 (0.08%).
- `next-server` was at 4.79 GiB `RssAnon` against the 4.19 GiB V8 ceiling.
- 392 `Liveness probe failed` events in 20 hours, and the pod has restarted 5 times. The container is killed roughly every 6 hours as the heap fills.

## Change

Set `--max-old-space-size-percentage=50` on the `[program:web]` block. Node resolves the percentage against the **cgroup** memory limit rather than host RAM, so it stays proportional at every deployment size.

Measured `heap_size_limit`, in MiB:

| Container limit | Node default | `pct=50` (this PR) | `pct=75` |
|---|---|---|---|
| 16 GiB (prod) | 4288 | **8384** | 12480 |
| 2 GiB | 1120 | **1120** (unchanged) | 1632 |
| 512 MiB | 259 | 259 (unchanged) | — |
| no limit (31.7 GiB host) | 4288 | 8078 | — |

Those numbers imply Node's default is about 50% of the cgroup limit, capped at ~4 GiB. Two consequences:

- **The cap is the actual bug.** It only binds above ~8 GiB, which is why this shows up on `app.sourcebot.dev` and not on typical self-hosted deployments.
- **Deployments at or below 8 GiB are unaffected**, because 50% is exactly what Node already picks below the cap. This change only alters behaviour where the cap was binding, which keeps the blast radius on the one deployment that has the problem.

Scoping it to `[program:web]` via supervisord's `environment=` keeps the backend worker and zoekt on their existing defaults.

## Tradeoffs worth reviewing

**Why 50 and not more.** At a 16 GiB limit, 50% leaves roughly 7.7 GiB for page cache, comfortably above the ~5.8 GiB of file cache zoekt currently uses for its EFS-backed index. 75% would cut that to ~3.6 GiB, and EFS major faults are network round-trips, so search latency would likely suffer. 75% also raises the ceiling for small self-hosted installs (a 2 GiB deployment would go from 1120 to 1632 MiB) for no benefit to them.

**This is a mitigation, not a cure.** The heap grows at roughly 700–800 MiB/hour with no observed plateau, which is what produces the ~6 hour restart cadence. A higher ceiling extends that to ~11 hours; it does not stop it. If the growth is reclaimable garbage, this change genuinely fixes the problem. If it is a leak, the ceiling only delays the wall, and each full GC gets longer because GC cost scales with live heap size. Determining which requires post-GC heap floor data over time — see the follow-ups.

**`NODE_OPTIONS` set at the container level no longer reaches the web process** (the backend and zoekt still see it), and because this flag outranks `--max-old-space-size` regardless of order, an operator's own heap sizing will not take effect for `next-server`. Worth calling out for self-hosters.

## Follow-ups

- The liveness probe uses `timeoutSeconds: 1` with `failureThreshold: 5`. A 1 second timeout on a Next.js health endpoint will trip on any GC pause, which is what converts "briefly slow" into "dead container". Raising it is independent of this change and arguably higher-impact.
- Find what holds the memory. sourcebot-dev/sourcebot#1570 adds heap, GC, and event-loop-lag metrics for the web process, which makes the post-GC floor observable and answers the garbage-vs-leak question without attaching a debugger to production.

## Test plan

- [x] `sh -n` and `busybox sh -n` (the container's actual shell) both clean
- [x] `supervisord.conf` parses; supervisord's own parser yields `{'NODE_OPTIONS': '--max-old-space-size-percentage=50'}`
- [x] Heap ceiling confirmed in the production container: 4288 MiB → 8384 MiB
- [x] Percentage confirmed to resolve against the cgroup limit, not host RAM (16 GiB container on a 31.7 GiB host yields 8192 + 192, not 15852 + 192)
- [x] Confirmed a 2 GiB container is unchanged at 1120 MiB, so smaller deployments are unaffected
- [x] Verified graceful behaviour with no cgroup limit (falls back to a percentage of host RAM, no crash)
- [x] `backend` and `zoekt` confirmed to have no `environment` line
- [ ] Post-deploy: confirm `heap_size_limit` in the running web process and watch restart cadence

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the web process’s available memory capacity based on container resources.
  * Reduced extended garbage-collection pauses that could affect larger deployments.
  * Improved stability and responsiveness under higher workloads.
* **Documentation**
  * Added an Unreleased changelog entry describing the memory-handling improvements and performance impact.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production memory allocation for the web process and overrides container-level `NODE_OPTIONS` for that process only. Incorrect sizing could pressure zoekt page cache or delay OOM/restart behavior if heap growth is a leak.
> 
> **Overview**
> Raises the Next.js web process heap ceiling on large containers by setting `NODE_OPTIONS=--max-old-space-size-percentage=50` in the `[program:web]` supervisord block.
> 
> This removes Node's ~4 GiB default old-space cap so the heap scales with the cgroup memory limit (e.g. ~8 GiB on a 16 GiB deployment), reducing stop-the-world GC pauses. Backend and zoekt keep their existing defaults; smaller deployments at or below ~8 GiB are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b27910ba8dab8f3b0f933cac271f2f57abf9ed3a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->