### PR TITLE
feat(web): expose Prometheus metrics for the web process

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a manually triggered cloud image release workflow for isolated internal deployments. [#1566](https://github.com/sourcebot-dev/sourcebot/pull/1566)
+- Added Prometheus metrics for the web process (heap, garbage collection, and event loop lag), served on `WEB_METRICS_PORT` (default `3070`). [#1570](https://github.com/sourcebot-dev/sourcebot/pull/1570)
 
 ## [5.1.6] - 2026-08-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added a manually triggered cloud image release workflow for isolated internal deployments. [#1566](https://github.com/sourcebot-dev/sourcebot/pull/1566)
-- Added Prometheus metrics for the web process (heap, garbage collection, and event loop lag), served on `WEB_METRICS_PORT` (default `3070`). [#1570](https://github.com/sourcebot-dev/sourcebot/pull/1570)
+- Added Prometheus metrics for the web process, served on `WEB_METRICS_PORT` (default `3070`). [#1570](https://github.com/sourcebot-dev/sourcebot/pull/1570)
 
 ## [5.1.6] - 2026-08-10
 

--- a/packages/shared/src/env.server.ts
+++ b/packages/shared/src/env.server.ts
@@ -174,6 +174,9 @@ const options = {
 
         WORKER_API_URL: z.string().url().default("http://localhost:3060"),
 
+        // Port the web process serves its Prometheus metrics on.
+        WEB_METRICS_PORT: numberSchema.default(3070),
+
         // Auth
         AUTH_SECRET: z.string(),
         AUTH_URL: z.string().url(),

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -173,6 +173,7 @@
     "posthog-js": "^1.369.0",
     "posthog-node": "^5.24.15",
     "pretty-bytes": "^6.1.1",
+    "prom-client": "^15.1.3",
     "psl": "^1.15.0",
     "react": "19.2.4",
     "react-day-picker": "^9.14.0",

--- a/packages/web/src/instrumentation.ts
+++ b/packages/web/src/instrumentation.ts
@@ -10,6 +10,11 @@ export async function register() {
     }
 
     if (process.env.NEXT_RUNTIME === 'nodejs') {
+        const { startMetricsServer } = await import('./metricsServer');
+        startMetricsServer();
+    }
+
+    if (process.env.NEXT_RUNTIME === 'nodejs') {
         const { initialize } = await import('./initialize');
         await initialize();
     }

--- a/packages/web/src/metricsServer.ts
+++ b/packages/web/src/metricsServer.ts
@@ -1,0 +1,50 @@
+import { createLogger, env } from '@sourcebot/shared';
+import { createServer, Server } from 'node:http';
+import { registry } from './promClient';
+
+const logger = createLogger('web-metrics-server');
+
+/**
+ * Serves the web process' Prometheus metrics on its own port, rather than as a
+ * Next.js route, so that scraping doesn't pass through the app's middleware or
+ * get exposed publicly through the ingress.
+ */
+export const startMetricsServer = (): Server | undefined => {
+    // Guard against a missing port: `listen(undefined)` binds a random one, which
+    // would leave the scrape target silently broken instead of loudly absent.
+    const port = Number(env.WEB_METRICS_PORT);
+    if (!Number.isInteger(port) || port <= 0) {
+        logger.error(`Invalid WEB_METRICS_PORT '${env.WEB_METRICS_PORT}'; metrics server not started.`);
+        return undefined;
+    }
+
+    const server = createServer(async (req, res) => {
+        if (req.url !== '/metrics') {
+            res.writeHead(404);
+            res.end();
+            return;
+        }
+
+        try {
+            const metrics = await registry.metrics();
+            res.writeHead(200, { 'Content-Type': registry.contentType });
+            res.end(metrics);
+        } catch (error) {
+            logger.error(`Failed to collect metrics: ${error}`);
+            res.writeHead(500);
+            res.end();
+        }
+    });
+
+    // Metrics must never take down the web server, so swallow listen failures
+    // (a port collision, most likely) instead of letting the 'error' event throw.
+    server.on('error', (error) => {
+        logger.error(`Metrics server error: ${error}`);
+    });
+
+    server.listen(port, () => {
+        logger.info(`Web metrics server listening on port ${port}`);
+    });
+
+    return server;
+};

--- a/packages/web/src/promClient.test.ts
+++ b/packages/web/src/promClient.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { registry } from './promClient';
+
+const metricNames = (output: string): Set<string> => {
+    return new Set(
+        output
+            .split('\n')
+            .filter(line => line.length > 0 && !line.startsWith('#'))
+            .map(line => line.split(/[ {]/)[0])
+    );
+};
+
+describe('web promClient', () => {
+    it('exposes the metrics needed to diagnose heap pressure', async () => {
+        const names = metricNames(await registry.metrics());
+
+        expect(names).toContain('nodejs_heap_size_limit_bytes');
+        expect(names).toContain('nodejs_heap_size_used_bytes');
+        expect(names).toContain('nodejs_eventloop_lag_p99_seconds');
+    });
+
+    it('registers the gc duration histogram', () => {
+        // Asserted via the registry rather than the rendered output: the histogram
+        // emits no series until a garbage collection has actually been observed.
+        expect(registry.getSingleMetric('nodejs_gc_duration_seconds')).toBeDefined();
+    });
+
+    it('reports a plausible heap size limit', async () => {
+        const output = await registry.metrics();
+        const line = output.split('\n').find(l => l.startsWith('nodejs_heap_size_limit_bytes '));
+
+        expect(line).toBeDefined();
+
+        const limit = Number(line!.split(' ')[1]);
+        expect(Number.isFinite(limit)).toBe(true);
+        // Any real V8 heap limit is well above 100MB and well below 100GB.
+        expect(limit).toBeGreaterThan(100 * 1024 * 1024);
+        expect(limit).toBeLessThan(100 * 1024 * 1024 * 1024);
+    });
+
+    it('can be collected repeatedly', async () => {
+        const first = await registry.metrics();
+        const second = await registry.metrics();
+
+        expect(metricNames(first)).toEqual(metricNames(second));
+    });
+});

--- a/packages/web/src/promClient.ts
+++ b/packages/web/src/promClient.ts
@@ -1,0 +1,21 @@
+import client, { Gauge, Registry } from 'prom-client';
+import { getHeapStatistics } from 'node:v8';
+
+export const registry = new Registry();
+
+// `collectDefaultMetrics` reports heap usage but not the ceiling it's measured
+// against, and usage alone can't distinguish "busy" from "out of room". Without
+// the limit there's no way to tell whether V8 is doing cheap incremental
+// collections or is pinned at its ceiling running full mark-compacts.
+const heapSizeLimit = new Gauge({
+    name: 'nodejs_heap_size_limit_bytes',
+    help: 'V8 heap size limit in bytes',
+    collect() {
+        this.set(getHeapStatistics().heap_size_limit);
+    },
+});
+registry.registerMetric(heapSizeLimit);
+
+client.collectDefaultMetrics({
+    register: registry,
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -9291,6 +9291,7 @@ __metadata:
     posthog-js: "npm:^1.369.0"
     posthog-node: "npm:^5.24.15"
     pretty-bytes: "npm:^6.1.1"
+    prom-client: "npm:^15.1.3"
     psl: "npm:^1.15.0"
     raw-loader: "npm:^4.0.2"
     react: "npm:19.2.4"


### PR DESCRIPTION
## Problem

The web process has no instrumentation of any kind. Heap usage, GC duration, and event loop lag are invisible for the process that serves every application request.

`:3060` is the backend worker and `:6070` is zoekt; both report `nodejs_*` / `go_*` runtime metrics. The Next.js process reports nothing. Diagnosing a recent incident — a 6 s homepage render caused by V8 running back-to-back full mark-compacts at its heap ceiling — required reading `/sys/fs/cgroup` files inside the container and inferring the rest from trace span arithmetic, because the relevant numbers simply were not collected.

## Change

Mirror the backend's `prom-client` setup for the web process:

| File | Purpose |
|---|---|
| `packages/web/src/promClient.ts` | Registry + `collectDefaultMetrics` + a custom heap-limit gauge |
| `packages/web/src/metricsServer.ts` | Serves `/metrics` on its own port |
| `packages/web/src/instrumentation.ts` | Starts it in the `nodejs` runtime |
| `packages/shared/src/env.server.ts` | `WEB_METRICS_PORT`, default `3070` |

This yields `nodejs_heap_size_used_bytes`, `nodejs_gc_duration_seconds`, `nodejs_eventloop_lag_p99_seconds`, `process_resident_memory_bytes`, and the per-heap-space gauges.

Two deliberate decisions:

**A separate port, not a Next.js route.** A `/api/metrics` route would pass through app middleware and be reachable through the ingress. A dedicated port keeps scraping off the request path and unexposed publicly, matching how the backend and zoekt already work.

**`nodejs_heap_size_limit_bytes` is added by hand**, because `collectDefaultMetrics` omits it. This is the metric the recent investigation actually needed: without the ceiling, heap usage alone cannot distinguish a merely busy process from one pinned at its limit and thrashing. `nodejs_heap_space_size_*` can approximate it, but not legibly in an alert threshold.

The metrics server is designed never to take down the web process — the `error` event is handled rather than left to throw, and an unusable port is logged and skipped rather than passed to `listen(undefined)`, which would silently bind a random port and leave the scrape target quietly broken.

## Note for reviewers

`prom-client` does not appear in `.next/standalone/node_modules`, which would normally mean a `MODULE_NOT_FOUND` at startup. It is fully bundled instead: its own internal metric names are inlined into the server chunk and no external `require("prom-client")` survives the build. Verified, but worth knowing if the bundling behaviour ever changes.

## Test plan

- [x] `yarn workspace @sourcebot/web build` — exit 0
- [x] `packages/web/src/promClient.test.ts` — 4/4 pass
- [x] `eslint` clean on all new/changed files
- [x] `tsc --noEmit` reports no errors in the new files (the 30 pre-existing errors are all in `.test.ts` files and unrelated)
- [x] End-to-end via a throwaway integration test: `/metrics` returns 200 with `text/plain`, contains `nodejs_heap_size_limit_bytes` and `nodejs_heap_size_used_bytes`, and other paths 404
- [x] Port guard verified: with `WEB_METRICS_PORT` unset it logs `Invalid WEB_METRICS_PORT 'undefined'; metrics server not started.` and returns without binding
- [x] Confirmed `prom-client` is bundled into the standalone output rather than externalised
- [ ] Post-deploy: confirm `:3070/metrics` responds in the cluster and the scrape lands in Better Stack

## Requires

sourcebot-dev/sourcebot-infra#24 exposes port 3070 and adds the scrape. That PR also repairs the existing backend and zoekt scrapes, which turned out to have been failing silently since prod moved namespaces — no app metric has reached Better Stack in that window. Without it, these metrics are collected but never read.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive observability only: a separate metrics server that is designed not to crash the web process, with no changes to auth, request handling, or data paths.
> 
> **Overview**
> Adds **Prometheus runtime metrics** for the Next.js web process (heap, GC, event-loop lag), previously only available for the worker and Zoekt.
> 
> Metrics are served on a **dedicated port** (`WEB_METRICS_PORT`, default `3070`) via a standalone HTTP server started from `instrumentation.ts`, so scrapes bypass app middleware and stay off the public ingress. Includes a custom `nodejs_heap_size_limit_bytes` gauge (omitted by `collectDefaultMetrics`) so heap usage can be compared against V8's ceiling. Failures (bad port, listen errors) are logged without taking down the web process.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cf8db222642c2dcdfc29d912dc448e5ee0d26a46. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for the web process, including memory usage, garbage collection, event-loop lag, and V8 heap limits.
  * Metrics are available at the `/metrics` endpoint on a configurable port, defaulting to `3070`.
  * Added clear handling for unavailable metrics ports, unsupported paths, and collection failures.

* **Documentation**
  * Documented the new metrics availability and configuration under Unreleased changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->