### PR TITLE
fix(web): prevent stalled code search result navigation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed the web process being capped at a ~4GiB heap regardless of how much memory the container has, which caused multi-second garbage collection pauses on larger deployments. [#1569](https://github.com/sourcebot-dev/sourcebot/pull/1569)
 - Upgraded `@sentry/*` to `^10.70.0`, fixing memory leaks where spans retained request data indefinitely. [#1572](https://github.com/sourcebot-dev/sourcebot/pull/1572)
+- Fixed code search result links occasionally getting stuck during navigation and restored Cmd/Ctrl-click to open matches in preview. [#1574](https://github.com/sourcebot-dev/sourcebot/pull/1574)
 
 ## [5.1.6] - 2026-08-10
 

--- a/packages/web/src/app/(app)/components/pathHeader.tsx
+++ b/packages/web/src/app/(app)/components/pathHeader.tsx
@@ -230,6 +230,7 @@ export const PathHeader = ({
 
             <Link
                 className={cn("font-medium cursor-pointer hover:underline", repoNameClassName)}
+                prefetch={false}
                 href={getBrowsePath({
                     repoName: repo.name,
                     path: '/',
@@ -249,6 +250,7 @@ export const PathHeader = ({
                 >
                     <span className="mr-0.5">@</span>
                     <Link
+                        prefetch={false}
                         href={getBrowsePath({
                             repoName: repo.name,
                             path: '',
@@ -286,6 +288,7 @@ export const PathHeader = ({
                                 <DropdownMenuContent align="start" className="min-w-[200px]">
                                     {hiddenSegments.map((segment) => (
                                         <Link
+                                            prefetch={false}
                                             href={getBrowsePath({
                                                 repoName: repo.name,
                                                 path: segment.fullPath,
@@ -317,6 +320,7 @@ export const PathHeader = ({
                                 <VscodeFileIcon fileName={segment.name} className="h-4 w-4 mr-1 flex-shrink-0" />
                             )}
                             <Link
+                                prefetch={false}
                                 className={cn(
                                     "font-mono text-sm min-w-0 truncate cursor-pointer hover:underline",
                                 )}

--- a/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatch.test.tsx
+++ b/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatch.test.tsx
@@ -1,0 +1,93 @@
+import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { FileMatch } from './fileMatch';
+
+vi.mock('next/link', () => ({
+    default: ({ children, href, prefetch, ...props }: React.AnchorHTMLAttributes<HTMLAnchorElement> & { prefetch?: boolean }) => (
+        <a {...props} href="#test-target" data-href={href} data-prefetch={String(prefetch)}>
+            {children}
+        </a>
+    ),
+}));
+
+vi.mock('@/app/(app)/components/lightweightCodeHighlighter', () => ({
+    LightweightCodeHighlighter: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const file = {
+    fileName: {
+        text: 'src/index.ts',
+        matchRanges: [],
+    },
+    webUrl: '',
+    repository: 'github.com/sourcebot-dev/sourcebot',
+    repositoryId: 1,
+    language: 'TypeScript',
+    branches: ['main'],
+    chunks: [],
+};
+
+const match = {
+    content: 'const result = true;',
+    contentStart: {
+        byteOffset: 0,
+        lineNumber: 10,
+        column: 1,
+    },
+    matchRanges: [{
+        start: {
+            byteOffset: 6,
+            lineNumber: 10,
+            column: 7,
+        },
+        end: {
+            byteOffset: 12,
+            lineNumber: 10,
+            column: 13,
+        },
+    }],
+};
+
+afterEach(() => {
+    cleanup();
+});
+
+describe('FileMatch', () => {
+    it('disables prefetching and preserves ordinary link clicks', () => {
+        const onOpenPreview = vi.fn();
+        render(<FileMatch file={file} match={match} onOpenPreview={onOpenPreview} />);
+
+        const link = screen.getByRole('link');
+        expect(link.getAttribute('data-prefetch')).toBe('false');
+
+        fireEvent.click(link);
+        expect(onOpenPreview).not.toHaveBeenCalled();
+    });
+
+    it.each([
+        ['Cmd', { metaKey: true }],
+        ['Ctrl', { ctrlKey: true }],
+    ])('opens the preview and cancels navigation for %s-click', (_modifier, eventInit) => {
+        const onOpenPreview = vi.fn();
+        render(<FileMatch file={file} match={match} onOpenPreview={onOpenPreview} />);
+
+        const link = screen.getByRole('link');
+        const clickEvent = createEvent.click(link, eventInit);
+        fireEvent(link, clickEvent);
+
+        expect(clickEvent.defaultPrevented).toBe(true);
+        expect(onOpenPreview).toHaveBeenCalledOnce();
+    });
+
+    it('supports modifier-plus-Enter for keyboard users', () => {
+        const onOpenPreview = vi.fn();
+        render(<FileMatch file={file} match={match} onOpenPreview={onOpenPreview} />);
+
+        const link = screen.getByRole('link');
+        const keyDownEvent = createEvent.keyDown(link, { key: 'Enter', metaKey: true });
+        fireEvent(link, keyDownEvent);
+
+        expect(keyDownEvent.defaultPrevented).toBe(true);
+        expect(onOpenPreview).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatch.tsx
+++ b/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatch.tsx
@@ -9,11 +9,13 @@ import { getBrowsePath } from "@/app/(app)/browse/hooks/utils";
 interface FileMatchProps {
     match: SearchResultChunk;
     file: SearchResultFile;
+    onOpenPreview: () => void;
 }
 
 export const FileMatch = ({
     match,
     file,
+    onOpenPreview,
 }: FileMatchProps) => {
     // If it's just the title, don't show a code preview
     if (match.matchRanges.length === 0) {
@@ -24,6 +26,7 @@ export const FileMatch = ({
         <Link
             tabIndex={0}
             className="cursor-pointer focus:ring-inset focus:ring-4 bg-background hover:bg-editor-lineHighlight"
+            prefetch={false}
             href={getBrowsePath({
                 repoName: file.repository,
                 revisionName: file.branches?.[0] ?? 'HEAD',
@@ -38,6 +41,22 @@ export const FileMatch = ({
                     }
                 }
             })}
+            onClick={(event) => {
+                if (!event.metaKey && !event.ctrlKey) {
+                    return;
+                }
+
+                event.preventDefault();
+                onOpenPreview();
+            }}
+            onKeyDown={(event) => {
+                if (event.key !== 'Enter' || (!event.metaKey && !event.ctrlKey)) {
+                    return;
+                }
+
+                event.preventDefault();
+                onOpenPreview();
+            }}
             title="open file: click, open file preview: cmd/ctrl + click"
         >
             <LightweightCodeHighlighter

--- a/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatchContainer.tsx
+++ b/packages/web/src/app/(app)/search/components/searchResultsPanel/fileMatchContainer.tsx
@@ -123,6 +123,12 @@ export const FileMatchContainer = ({
                     <FileMatch
                         match={match}
                         file={file}
+                        onOpenPreview={() => {
+                            const matchIndex = matches.slice(0, index).reduce((acc, previousMatch) => {
+                                return acc + previousMatch.matchRanges.length;
+                            }, 0);
+                            onOpenFilePreview(matchIndex);
+                        }}
                     />
                     {(index !== matches.length - 1 || isMoreContentButtonVisible) && (
                         <Separator className="bg-accent" />


### PR DESCRIPTION
## Summary

- disable Next.js prefetching for code search matches and `PathHeader` links
- restore Cmd/Ctrl-click behavior so a code match opens in the preview panel at the correct match
- add focused interaction coverage for ordinary, modified, and keyboard activation

## Test plan

- `yarn workspace @sourcebot/web test src/app/\(app\)/search/components/searchResultsPanel/fileMatch.test.tsx`
- `yarn workspace @sourcebot/web eslint src/app/\(app\)/search/components/searchResultsPanel/fileMatch.tsx src/app/\(app\)/search/components/searchResultsPanel/fileMatch.test.tsx src/app/\(app\)/search/components/searchResultsPanel/fileMatchContainer.tsx src/app/\(app\)/components/pathHeader.tsx`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 74f3951c3d86c7463ee85ecb558577810f7e6e28. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Cmd/Ctrl-clicking or pressing Cmd/Ctrl+Enter on a code search result now opens its preview without navigating away.
* **Bug Fixes**
  * Improved code search result navigation behavior.
  * Disabled unnecessary link prefetching for repository, branch, breadcrumb, and search result links.
* **Documentation**
  * Added an Unreleased changelog entry describing these improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->