### PR TITLE
fix(web): create the QueryClient per-request on the server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the web process being capped at a ~4GiB heap regardless of how much memory the container has, which caused multi-second garbage collection pauses on larger deployments. [#1569](https://github.com/sourcebot-dev/sourcebot/pull/1569)
 - Upgraded `@sentry/*` to `^10.70.0`, fixing memory leaks where spans retained request data indefinitely. [#1572](https://github.com/sourcebot-dev/sourcebot/pull/1572)
 - Fixed code search result links occasionally getting stuck during navigation and restored Cmd/Ctrl-click to open matches in preview. [#1574](https://github.com/sourcebot-dev/sourcebot/pull/1574)
+- Fixed a server-side memory leak where a single shared react-query cache retained state from every server render; the cache is now created per-request. [#1575](https://github.com/sourcebot-dev/sourcebot/pull/1575)
 
 ## [5.1.6] - 2026-08-10
 

--- a/packages/web/src/app/queryClientProvider.tsx
+++ b/packages/web/src/app/queryClientProvider.tsx
@@ -1,14 +1,47 @@
 'use client';
 
 import * as React from "react"
-import { QueryClient, QueryClientProvider as QueryClientProviderBase, QueryClientProviderProps } from "@tanstack/react-query"
+import { isServer, QueryClient, QueryClientProvider as QueryClientProviderBase, QueryClientProviderProps } from "@tanstack/react-query"
 
-const queryClient = new QueryClient();
- 
+const makeQueryClient = () => {
+    return new QueryClient();
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+/**
+ * On the server, always create a fresh QueryClient so it lives and dies with
+ * the request. A module-scoped client is rooted for the process lifetime and
+ * every SSR render deposits query state into it — with request-derived query
+ * keys (repos, file paths, searches) that cache only ever grows, and queries
+ * never become inactive server-side (unmount/unsubscribe don't run during
+ * SSR), so nothing is ever evicted. In production this retained whole render
+ * graphs at ~400 MiB/h until the container was OOM-adjacent and liveness
+ * probes killed it.
+ *
+ * In the browser a singleton is correct (one user, unmounts run, gcTime
+ * evicts) and deliberately NOT stored in React state, so the client survives
+ * React suspending during the initial render.
+ *
+ * @see https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr
+ */
+const getQueryClient = () => {
+    if (isServer) {
+        return makeQueryClient();
+    }
+
+    if (!browserQueryClient) {
+        browserQueryClient = makeQueryClient();
+    }
+    return browserQueryClient;
+}
+
 export const QueryClientProvider = ({ children, ...props }: Omit<QueryClientProviderProps, 'client'>) => {
-  return (
-    <QueryClientProviderBase client={queryClient} {...props}>
-        {children}
-    </QueryClientProviderBase>
-  )
+    const queryClient = getQueryClient();
+
+    return (
+        <QueryClientProviderBase client={queryClient} {...props}>
+            {children}
+        </QueryClientProviderBase>
+    )
 }


### PR DESCRIPTION
## Problem

After #1572 fixed the Sentry span-retention leak, the web process still retained **~400 MiB/h** of heap. This was proven to be genuine retention (not lazy GC) by forcing a full GC on the production process via the inspector: at a 2073 MiB heap it freed only 247 MiB.

A sampling heap profile taken across that forced GC — so it contains only allocations that *survived* a real collection — shows the retained memory is **server-side render graphs**, dominated by @tanstack/react-query query/observer construction, with CodeMirror `EditorState` and browse-page component state hanging off it.

The anchor is `packages/web/src/app/queryClientProvider.tsx`:

```tsx
const queryClient = new QueryClient();   // module scope
```

On the server this is one client, rooted for the process lifetime, shared by every SSR render:

- every `useQuery` during SSR deposits a `Query` entry into its cache, keyed by request-derived keys (repos, file paths, revisions, search strings) — an unbounded, traffic-shaped key space that only ever gains entries;
- react-query's own eviction (`gcTime`) never fires server-side, because eviction requires the query to become inactive, and unmount/unsubscribe never run during SSR — the render is serialized and abandoned, but everything wired into the cache stays reachable from the module root.

Net: the shared cache transitively pins whole SSR render graphs, growing until GC stalls trip the liveness probe.

TanStack Query's docs call this exact pattern out, verbatim and in caps: ["**NEVER DO THIS** ... Creating the queryClient at the file root level makes the cache shared between all requests and means _all_ data gets passed to _all_ users."](https://tanstack.com/query/latest/docs/framework/react/guides/ssr)

## Fix

The [Advanced Server Rendering guide's](https://tanstack.com/query/latest/docs/framework/react/guides/advanced-ssr) `getQueryClient` pattern:

```tsx
const getQueryClient = () => {
    if (isServer) {
        return makeQueryClient();      // fresh per server render — dies with the request
    }
    if (!browserQueryClient) {
        browserQueryClient = makeQueryClient();
    }
    return browserQueryClient;         // browser keeps a stable singleton
};
```

- **Server:** a per-request client releases its cache — and everything anchored to it — when the render completes.
- **Browser:** the module-scope singleton is unchanged behavior and is what the docs recommend client-side (one user, unmounts run, `gcTime` evicts). It is deliberately **not** stored in `useState`: if React suspends during the initial render, state would be discarded and a new client would lose the cache mid-hydration.

## Behavioral note for reviewers

Besides memory, this removes a cross-request defect: previously, query data cached by one request's SSR could be rendered into a *different* request's HTML (the "all data gets passed to all users" warning above). With a per-request client those renders now produce the loading state — which the client-side fetch always replaced anyway.

## Test plan

- [x] eslint + tsc clean on the file
- [x] Full web suite: 1216/1216 across 105 files (the provider wraps the root layout, so broad coverage matters)
- [x] Production build exit 0
- [ ] Post-deploy: re-measure the forced-GC heap floor a few hours into a container's life; the react-query cohort should be gone from the surviving-GC profile and the floor should plateau (dashboard: "Sourcebot app latency & stalls" → Heap used / Process uptime)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c0f96849f15645c8936e1b42b932f60b94b5c43e. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a server-side memory leak by isolating the React Query cache for each request.
  * Improved server rendering reliability by preventing cache data from being shared between requests.
  * Preserved efficient client-side caching by reusing the browser cache where appropriate.

* **Documentation**
  * Added an Unreleased changelog entry describing the memory leak fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->