### PR TITLE
docs: clarify scoped access token entitlement

### DIFF
--- a/docs/api-reference/sourcebot-public.openapi.json
+++ b/docs/api-reference/sourcebot-public.openapi.json
@@ -2423,7 +2423,7 @@
           "Scoped Access Tokens"
         ],
         "summary": "Create a scoped access token",
-        "description": "Creates an opaque bearer token that expires exactly one hour after issuance and is restricted to the requested repositories. Repository IDs are validated atomically against the API-key owner's current access; the request fails if any ID is missing or inaccessible. Repository IDs are returned by GET /api/repos.\n\nThis endpoint requires a Sourcebot API key. Scoped access tokens, OAuth tokens, and browser sessions cannot mint another scoped access token. The returned token is independent of the API key after issuance and cannot be refreshed.",
+        "description": "Creates an opaque bearer token that expires exactly one hour after issuance and is restricted to the requested repositories.",
         "security": [
           {
             "bearerToken": []
@@ -2432,6 +2432,9 @@
             "apiKeyHeader": []
           }
         ],
+        "x-mint": {
+          "content": "<Info>\nThe scoped access token APIs require a custom entitlement. To request access, contact [team@sourcebot.dev](mailto:team@sourcebot.dev).\n</Info>"
+        },
         "requestBody": {
           "required": true,
           "content": {
@@ -2503,7 +2506,7 @@
           "Scoped Access Tokens"
         ],
         "summary": "Revoke a scoped access token",
-        "description": "Immediately revokes a scoped access token created by the authenticated API-key owner. This endpoint requires a Sourcebot API key.",
+        "description": "Immediately revokes a scoped access token created by the authenticated API-key owner.",
         "security": [
           {
             "bearerToken": []
@@ -2512,6 +2515,9 @@
             "apiKeyHeader": []
           }
         ],
+        "x-mint": {
+          "content": "<Info>\nThe scoped access token APIs require a custom entitlement. To request access, contact [team@sourcebot.dev](mailto:team@sourcebot.dev).\n</Info>"
+        },
         "parameters": [
           {
             "schema": {

--- a/docs/docs/api-reference/authentication.mdx
+++ b/docs/docs/api-reference/authentication.mdx
@@ -35,6 +35,10 @@ curl -X POST https://your-sourcebot-instance.com/api/search \
 
 ## Using a scoped access token
 
+<Info>
+The scoped access token APIs require a custom entitlement. To request access, contact [team@sourcebot.dev](mailto:team@sourcebot.dev).
+</Info>
+
 Scoped access tokens are short-lived bearer credentials intended for clients that should only access a specific set of repositories. Create one with a Sourcebot API key by calling `POST /api/ee/scoped_access_token` with repository names:
 
 ```bash

--- a/packages/web/src/openapi/publicApiDocument.ts
+++ b/packages/web/src/openapi/publicApiDocument.ts
@@ -50,6 +50,12 @@ This API is only available with an active Sourcebot license. [More information](
 </Note>
 `;
 
+const SCOPED_ACCESS_TOKEN_ENTITLEMENT_INFO = dedent`
+<Info>
+The scoped access token APIs require a custom entitlement. To request access, contact [team@sourcebot.dev](mailto:team@sourcebot.dev).
+</Info>
+`;
+
 const publicFileTreeNodeSchema: SchemaObject = {
     type: 'object',
     properties: {
@@ -456,9 +462,7 @@ export function createPublicOpenApiDocument(version: string) {
         tags: [scopedAccessTokensTag.name],
         summary: 'Create a scoped access token',
         description: dedent`
-            Creates an opaque bearer token that expires exactly one hour after issuance and is restricted to the requested repositories. Repository IDs are validated atomically against the API-key owner's current access; the request fails if any ID is missing or inaccessible. Repository IDs are returned by GET /api/repos.
-
-            This endpoint requires a Sourcebot API key. Scoped access tokens, OAuth tokens, and browser sessions cannot mint another scoped access token. The returned token is independent of the API key after issuance and cannot be refreshed.
+            Creates an opaque bearer token that expires exactly one hour after issuance and is restricted to the requested repositories.
         `,
         security: [
             { [securitySchemeNames.bearerToken]: [] },
@@ -480,6 +484,9 @@ export function createPublicOpenApiDocument(version: string) {
             403: errorJson('The current authentication method is not an API key, or the API-key owner is not permitted to perform this operation.'),
             500: errorJson('Unexpected token creation failure.'),
         },
+        'x-mint': {
+            content: SCOPED_ACCESS_TOKEN_ENTITLEMENT_INFO,
+        },
     });
 
     registry.registerPath({
@@ -488,7 +495,7 @@ export function createPublicOpenApiDocument(version: string) {
         operationId: 'revokeScopedAccessToken',
         tags: [scopedAccessTokensTag.name],
         summary: 'Revoke a scoped access token',
-        description: 'Immediately revokes a scoped access token created by the authenticated API-key owner. This endpoint requires a Sourcebot API key.',
+        description: 'Immediately revokes a scoped access token created by the authenticated API-key owner.',
         security: [
             { [securitySchemeNames.bearerToken]: [] },
             { [securitySchemeNames.apiKeyHeader]: [] },
@@ -506,6 +513,9 @@ export function createPublicOpenApiDocument(version: string) {
             403: errorJson('The current authentication method is not an API key, or the API-key owner is not permitted to perform this operation.'),
             404: errorJson('Scoped access token not found.'),
             500: errorJson('Unexpected token revocation failure.'),
+        },
+        'x-mint': {
+            content: SCOPED_ACCESS_TOKEN_ENTITLEMENT_INFO,
         },
     });
 


### PR DESCRIPTION
## Summary

- add an info callout to the scoped access token create and revoke API pages
- add the same entitlement and contact guidance to the authentication reference
- shorten the create and revoke endpoint descriptions
- regenerate the checked-in OpenAPI specification

## Validation

- OpenAPI JSON parses successfully
- `yarn workspace @sourcebot/web exec eslint src/openapi/publicApiDocument.ts`
- `git diff --check`

No changelog entry because this is a documentation-only change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation and OpenAPI description changes only; no runtime or auth behavior changes.
> 
> **Overview**
> This PR updates **scoped access token** docs so readers know the feature needs a **custom entitlement** and how to request it (`team@sourcebot.dev`).
> 
> It adds a shared Mint **Info** callout via `SCOPED_ACCESS_TOKEN_ENTITLEMENT_INFO` on **create** and **revoke** in `publicApiDocument.ts` (`x-mint`), mirrors the same callout in `authentication.mdx`, and **shortens** the OpenAPI endpoint descriptions (dropping long auth/repo-validation detail from the spec text). The checked-in **`sourcebot-public.openapi.json`** is regenerated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8928f4511ad04ebd45b118c354215066dddfa6a3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated scoped access token API documentation with clearer entitlement requirements.
  * Added guidance to contact `team@sourcebot.dev` for access.
  * Simplified descriptions of token creation and revocation endpoints by removing detailed authentication requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->