### PR TITLE
fix(web): reuse CodeMirror search language

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Fixed memory leak attributed to CodeMirror allocating objects on heap that were never freed. [#1580](https://github.com/sourcebot-dev/sourcebot/pull/1580)
+
 ## [5.1.7] - 2026-08-13
 
 ### Added

--- a/packages/web/src/app/(app)/components/searchBar/zoektLanguageExtension.test.ts
+++ b/packages/web/src/app/(app)/components/searchBar/zoektLanguageExtension.test.ts
@@ -1,0 +1,6 @@
+import { expect, test } from 'vitest';
+import { zoekt } from './zoektLanguageExtension';
+
+test('reuses the same language support across calls', () => {
+    expect(zoekt()).toBe(zoekt());
+});

--- a/packages/web/src/app/(app)/components/searchBar/zoektLanguageExtension.ts
+++ b/packages/web/src/app/(app)/components/searchBar/zoektLanguageExtension.ts
@@ -1,7 +1,9 @@
 import { LanguageSupport, StreamLanguage } from "@codemirror/language";
 import { tags as t } from "@lezer/highlight";
 
-export const zoekt = () => {
+// StreamLanguage permanently registers a document NodeType, so this must be a
+// module singleton rather than one instance per SearchBar render.
+const zoektLanguageSupport = (() => {
     const zoektLanguage = StreamLanguage.define({
         startState() {
             return {
@@ -75,4 +77,6 @@ export const zoekt = () => {
     });
 
     return new LanguageSupport(zoektLanguage);
-};
+})();
+
+export const zoekt = () => zoektLanguageSupport;


### PR DESCRIPTION
## Summary

- create the Zoekt CodeMirror `StreamLanguage` and `LanguageSupport` once per module
- keep the existing `zoekt()` API while returning the shared instance
- add a regression test that verifies repeated calls return the same object

## Root cause

Every server render of the browse SearchBar called `StreamLanguage.define()`. CodeMirror permanently registers each language document `NodeType` in a module-global array, retaining the per-render language and closures after GC. The singleton prevents one permanently rooted language instance from being created per browse request.

Linear: [SOU-1978](https://linear.app/sourcebot/issue/SOU-1978/fix-per-request-codemirror-streamlanguage-heap-leak-in-browse-ssr)

## Validation

- `yarn workspace @sourcebot/web test --run "src/app/(app)/components/searchBar/zoektLanguageExtension.test.ts"`
- ESLint on both changed files
- `git diff --check`

The repository-wide web TypeScript check currently reports unrelated pre-existing errors in review-agent, MCP Prisma-scope, file-source, and auth test fixtures; neither changed file reports an error.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 2a019d5595bc045d68a034753c0b42e89db98296. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved search editor responsiveness and reduced memory usage by reusing language support.
* **Bug Fixes**
  * Fixed a CodeMirror memory leak caused by unreleased allocations.
* **Tests**
  * Added coverage verifying consistent language-support reuse across repeated calls.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->