### PR TITLE
fix(web): block disallowed Meta crawler before SSR

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed memory leak attributed to CodeMirror allocating objects on heap that were never freed. [#1580](https://github.com/sourcebot-dev/sourcebot/pull/1580)
 - Kept Git provider credentials out of subprocess arguments and on-disk configuration by using isolated in-memory credential caches. [#1584](https://github.com/sourcebot-dev/sourcebot/pull/1584)
+- Blocked `meta-externalagent` before server rendering when it ignores Sourcebot's crawler policy. [#1592](https://github.com/sourcebot-dev/sourcebot/pull/1592)
 
 ## [5.1.7] - 2026-08-13
 

--- a/packages/web/src/proxy.test.ts
+++ b/packages/web/src/proxy.test.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { describe, expect, test } from 'vitest';
+import { proxy } from './proxy';
+
+describe('proxy', () => {
+    test.each([
+        'meta-externalagent/1.1 (+https://developers.facebook.com/docs/sharing/webmasters/crawler)',
+        'Mozilla/5.0 (compatible; META-EXTERNALAGENT/1.1)',
+    ])('blocks the disallowed Meta crawler before rendering', async (userAgent) => {
+        const response = await proxy(new NextRequest('https://sourcebot.example/browse/github.com/sourcebot-dev/sourcebot', {
+            headers: {
+                'user-agent': userAgent,
+            },
+        }));
+
+        expect(response.status).toBe(403);
+        await expect(response.text()).resolves.toBe('Crawler access is disallowed.');
+    });
+
+    test('allows ordinary browser requests through', async () => {
+        const response = await proxy(new NextRequest('https://sourcebot.example/browse/github.com/sourcebot-dev/sourcebot', {
+            headers: {
+                'user-agent': 'Mozilla/5.0 Chrome/145.0.0.0',
+            },
+        }));
+
+        expect(response.status).toBe(200);
+        expect(response.headers.get('x-middleware-next')).toBe('1');
+    });
+
+    test('preserves the legacy organization-prefix redirect', async () => {
+        const response = await proxy(new NextRequest('https://sourcebot.example/~/search'));
+
+        expect(response.status).toBe(301);
+        expect(response.headers.get('location')).toBe('https://sourcebot.example/search');
+    });
+});

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -2,6 +2,14 @@ import { StatusCodes } from 'http-status-codes';
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
 
+// robots.txt disallows search and AI-training crawlers, but robots directives
+// are advisory. meta-externalagent has been observed ignoring that policy and
+// exhaustively walking the unbounded /browse URL space, so enforce the same
+// restriction before the request reaches server-side rendering.
+const BLOCKED_CRAWLER_USER_AGENTS = [
+    'meta-externalagent',
+] as const;
+
 /**
  * As part of our original SaaS effort in April 2025, we introduced
  * multi-tenancy into Sourcebot as part of v3.0.0. Organizations
@@ -24,6 +32,16 @@ import type { NextRequest } from 'next/server'
  * See: https://github.com/sourcebot-dev/sourcebot/pull/1076
  */
 export async function proxy(request: NextRequest) {
+    const userAgent = request.headers.get('user-agent')?.toLowerCase();
+    if (
+        userAgent
+        && BLOCKED_CRAWLER_USER_AGENTS.some(blockedCrawler => userAgent.includes(blockedCrawler))
+    ) {
+        return new NextResponse('Crawler access is disallowed.', {
+            status: StatusCodes.FORBIDDEN,
+        });
+    }
+
     const url = request.nextUrl.clone();
 
     if (url.pathname.startsWith('/~/')) {


### PR DESCRIPTION
## Summary

- Enforce the existing robots.txt policy for meta-externalagent in the Next.js proxy.
- Return 403 before the request reaches authentication, database work, or React server rendering.
- Preserve normal browser traffic and the existing legacy URL redirect behavior.

## Finding

Production ALB logs for the 2026-08-14 traffic surge contain 700,083 requests from 16:00-21:00 UTC. Of those, 563,237 were successful /browse requests spanning 198,239 distinct pathnames. User-agent attribution shows meta-externalagent generated 562,846 of them: 99.93% of browse traffic and about 80% of all web traffic in the window.

The application robots.txt already explicitly disallows meta-externalagent because Sourcebot exposes an effectively unbounded file/revision/commit URL space, but robots directives are advisory and the crawler is ignoring them. During the same window, post-major-GC old-space continued to rise with cumulative requests. Blocking this crawler does not replace the underlying retention fixes, but it removes the verified production load amplifier that is driving the current heap growth rate and liveness pressure.

## Remediation

The proxy now recognizes meta-externalagent case-insensitively and returns 403 before SSR. This makes the documented crawler policy enforceable even when the crawler does not honor robots.txt, while leaving link-preview fetchers and ordinary browsers unchanged.

## Test plan

- yarn workspace @sourcebot/web test --run src/proxy.test.ts (4 tests passed)
- yarn workspace @sourcebot/web exec eslint src/proxy.ts src/proxy.test.ts
- Regression cases cover the observed Meta user-agent forms, case-insensitive matching, ordinary browser passthrough, and the existing legacy organization-prefix redirect.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 54012b147df53308ff092c5a1aa77a2542a2740b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added protection against requests from crawlers that do not follow the site’s crawler policy.
  - Blocked requests receive a clear HTTP 403 response before page rendering.
- **Bug Fixes**
  - Preserved existing redirects for legacy organization-prefixed URLs.
- **Documentation**
  - Added an unreleased changelog entry describing the crawler filtering update.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->