### PR TITLE
fix(web): disable leaking production Sentry performance telemetry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed memory leak attributed to CodeMirror allocating objects on heap that were never freed. [#1580](https://github.com/sourcebot-dev/sourcebot/pull/1580)
 - Kept Git provider credentials out of subprocess arguments and on-disk configuration by using isolated in-memory credential caches. [#1584](https://github.com/sourcebot-dev/sourcebot/pull/1584)
+- Disabled Sentry server performance tracing and profiling in production to prevent completed request contexts from being retained, while keeping error reporting enabled. [#1593](https://github.com/sourcebot-dev/sourcebot/pull/1593)
 
 ## [5.1.7] - 2026-08-13
 

--- a/packages/web/src/sentry.server.config.test.ts
+++ b/packages/web/src/sentry.server.config.test.ts
@@ -1,0 +1,67 @@
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest';
+
+const mocks = vi.hoisted(() => ({
+    init: vi.fn(),
+    nodeProfilingIntegration: vi.fn(() => ({ name: 'ProfilingIntegration' })),
+}));
+
+vi.mock('@sentry/nextjs', () => ({
+    init: mocks.init,
+}));
+
+vi.mock('@sentry/profiling-node', () => ({
+    nodeProfilingIntegration: mocks.nodeProfilingIntegration,
+}));
+
+vi.mock('@sourcebot/shared', () => ({
+    createLogger: () => ({
+        debug: vi.fn(),
+    }),
+}));
+
+const importConfig = async (environment: string) => {
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_WEBAPP_DSN', 'https://public@example.com/1');
+    vi.stubEnv('NEXT_PUBLIC_SENTRY_ENVIRONMENT', environment);
+    await import('./sentry.server.config');
+};
+
+describe('Sentry server configuration', () => {
+    beforeEach(() => {
+        vi.resetModules();
+        vi.clearAllMocks();
+    });
+
+    afterEach(() => {
+        vi.unstubAllEnvs();
+    });
+
+    test('keeps production error reporting without request tracing or profiling', async () => {
+        await importConfig('production');
+
+        expect(mocks.init).toHaveBeenCalledOnce();
+        const options = mocks.init.mock.calls[0][0];
+        expect(options).toMatchObject({
+            dsn: 'https://public@example.com/1',
+            environment: 'production',
+        });
+        expect(options).not.toHaveProperty('tracesSampleRate');
+        expect(options).not.toHaveProperty('profileSessionSampleRate');
+        expect(options).not.toHaveProperty('profileLifecycle');
+        expect(options).not.toHaveProperty('integrations');
+        expect(mocks.nodeProfilingIntegration).not.toHaveBeenCalled();
+    });
+
+    test('keeps tracing and profiling available in development', async () => {
+        await importConfig('development');
+
+        expect(mocks.init).toHaveBeenCalledWith({
+            dsn: 'https://public@example.com/1',
+            environment: 'development',
+            integrations: [{ name: 'ProfilingIntegration' }],
+            tracesSampleRate: 1.0,
+            profileSessionSampleRate: 1.0,
+            profileLifecycle: 'trace',
+        });
+        expect(mocks.nodeProfilingIntegration).toHaveBeenCalledOnce();
+    });
+});

--- a/packages/web/src/sentry.server.config.ts
+++ b/packages/web/src/sentry.server.config.ts
@@ -9,17 +9,24 @@ import { createLogger } from "@sourcebot/shared";
 const logger = createLogger('sentry-server-config');
 
 if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT) {
+    const enablePerformanceMonitoring = process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development';
+
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        integrations: [
-            nodeProfilingIntegration(),
-        ],
-        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
-        // Evaluated once per `Sentry.init()`, i.e. once per server process.
-        profileSessionSampleRate: 1.0,
-        // Profile only while a sampled root span is active, rather than continuously.
-        profileLifecycle: 'trace',
+        // Sentry's server tracing and profiling retain completed Next.js request
+        // async contexts under sustained SSR traffic. Keep production error
+        // reporting enabled without those per-request telemetry paths.
+        ...(enablePerformanceMonitoring ? {
+            integrations: [
+                nodeProfilingIntegration(),
+            ],
+            tracesSampleRate: 1.0,
+            // Evaluated once per `Sentry.init()`, i.e. once per server process.
+            profileSessionSampleRate: 1.0,
+            // Profile only while a sampled root span is active, rather than continuously.
+            profileLifecycle: 'trace' as const,
+        } : {}),
     });
 } else {
     logger.debug("[server] Sentry was not initialized");


### PR DESCRIPTION
## Summary

Disable Sentry server performance tracing and profiling outside development while preserving production error reporting.

## Finding

The Better Stack dashboard showed the post-major-GC web heap floor rising in near lockstep with completed requests. On the current production revision, the combined interval covered 1,666,915 requests; the 15-minute heap-floor regression was 1,328 bytes/request with a 0.996 correlation. The increase was overwhelmingly old-space and continued through frequent major GCs.

I reproduced the retention against the exact deployed web revision with full `/browse` SSR, a live Sentry envelope sink, unique request URLs, and repeated forced full GCs:

- With the production Sentry server configuration active, 1,000 completed requests retained 156.0 MiB of heap (160.0 MiB old-space). The retained floor was unchanged after 193 seconds, beyond multiple 60-second profile rotations.
- A heap-snapshot differential contained 648 additional complete `ServerResponse`, `IncomingMessage`, `NodeNextRequest`, and `IncrementalCache` graphs, plus 9,783 destroyed `Immediate` objects and 4,508 `AsyncContextFrame` objects.
- Native global handles dominated 108.35 MiB of the differential. The retention path runs through async-local context tables containing OpenTelemetry, Next request/work, and React RSC stores, then into completed response graphs. Native profiling greatly amplifies the cross-request chains.
- The exact same workload with Sentry initialized for errors only (DSN and environment, but no tracing or profiling configuration) was flat after forced GC: heap moved from 223.97 MiB to 212.46 MiB after 1,000 requests.
- The no-Sentry control was also flat. This exonerates the current Next/React Query/CodeMirror browse path for this workload.

The production crawler burst was the immediate load amplifier, but the retained objects are completed request graphs rather than in-flight requests. A separate PR blocks that crawler before SSR.

Dashboard: https://telemetry.betterstack.com/team/t306397/dashboards/1096933

## Remediation

- Keep `Sentry.init` enabled in production with its DSN and environment, so server exceptions continue to be reported.
- Omit `tracesSampleRate` entirely in production. A value of zero would still configure span recording in the SDK; omitting tracing options disables the per-request span path.
- Do not install `nodeProfilingIntegration` or configure trace-lifecycle profiling in production.
- Preserve the existing 100% tracing and trace-lifecycle profiling behavior in development.
- Add regression tests for both production errors-only and development performance configurations.

This intentionally trades production server performance traces/profiles for stable memory use while retaining error visibility. Better Stack continues to provide the production HTTP, GC, event-loop, and heap metrics used in this investigation.

## Verification

- `yarn workspace @sourcebot/web test --run src/sentry.server.config.test.ts` (2 tests passed)
- `yarn workspace @sourcebot/web exec eslint src/sentry.server.config.ts src/sentry.server.config.test.ts`
- Exact-current SSR forced-GC control described above

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production observability (no server traces/profiles) but reduces a documented memory-retention risk; error reporting path is preserved.
> 
> **Overview**
> Production server Sentry init now stays **errors-only**: `tracesSampleRate`, profiling integration, and related options are omitted unless `NEXT_PUBLIC_SENTRY_ENVIRONMENT` is `development`. That replaces always-on profiling and a **0.1** trace sample rate in production, which was retaining completed Next.js request async context under SSR load.
> 
> **Development** still gets full tracing (100% sample) and trace-lifecycle profiling via `nodeProfilingIntegration`, unchanged in intent from before.
> 
> New Vitest coverage in `sentry.server.config.test.ts` asserts production init has DSN/environment only and development init includes the performance options.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1ad965c8e796451fe61b74d606b51aee486abefe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->