### PR TITLE
fix(web): bound Next route cache memory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- Upgraded Next.js to 16.3.1 to bound memory retained by high-cardinality dynamic route cache entries. [#1594](https://github.com/sourcebot-dev/sourcebot/pull/1594)
 - Fixed memory leak attributed to CodeMirror allocating objects on heap that were never freed. [#1580](https://github.com/sourcebot-dev/sourcebot/pull/1580)
 - Kept Git provider credentials out of subprocess arguments and on-disk configuration by using isolated in-memory credential caches. [#1584](https://github.com/sourcebot-dev/sourcebot/pull/1584)
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -162,7 +162,7 @@
     "micromatch": "^4.0.8",
     "minidenticons": "^4.2.1",
     "motion": "^12.42.0",
-    "next": "^16.2.11",
+    "next": "^16.3.1",
     "next-auth": "^5.0.0-beta.32",
     "next-navigation-guard": "^0.2.0",
     "next-themes": "^0.3.0",

--- a/packages/web/src/ee/features/chat/useUnsavedChangesGuard.test.tsx
+++ b/packages/web/src/ee/features/chat/useUnsavedChangesGuard.test.tsx
@@ -20,6 +20,7 @@ afterEach(() => {
 // A minimal underlying App Router for the guard library to wrap. Without an
 // outer router there is nothing to intercept, so the guard never engages.
 const makeMockRouter = (): AppRouterInstance => ({
+    bfcacheId: "test",
     push: vi.fn(),
     replace: vi.fn(),
     refresh: vi.fn(),

--- a/packages/web/src/features/agents/review-agent/nodes/githubPushPrReviews.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/githubPushPrReviews.test.ts
@@ -68,7 +68,7 @@ describe('githubPushPrReviews', () => {
 
         await githubPushPrReviews(octokit, MOCK_PAYLOAD, SINGLE_REVIEW);
 
-        const call = octokit.rest.pulls.createReviewComment.mock.calls[0][0];
+        const call = vi.mocked(octokit.rest.pulls.createReviewComment).mock.calls[0][0];
         expect(call).toHaveProperty('line', 10);
         expect(call).not.toHaveProperty('start_line');
     });
@@ -84,7 +84,7 @@ describe('githubPushPrReviews', () => {
 
         await githubPushPrReviews(octokit, MOCK_PAYLOAD, multiLineReviews);
 
-        const call = octokit.rest.pulls.createReviewComment.mock.calls[0][0];
+        const call = vi.mocked(octokit.rest.pulls.createReviewComment).mock.calls[0][0];
         expect(call).toHaveProperty('start_line', 5);
         expect(call).toHaveProperty('line', 15);
         expect(call).toHaveProperty('start_side', 'RIGHT');

--- a/packages/web/src/features/agents/review-agent/nodes/gitlabMrParser.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/gitlabMrParser.test.ts
@@ -48,7 +48,11 @@ const MOCK_MR_API_RESPONSE = {
     },
 };
 
-function makeMockGitlabClient(allDiffsResult: unknown, mrOverrides: Partial<typeof MOCK_MR_API_RESPONSE> = {}) {
+type MockMrApiResponseOverrides = Omit<Partial<typeof MOCK_MR_API_RESPONSE>, 'description'> & {
+    description?: string | null;
+};
+
+function makeMockGitlabClient(allDiffsResult: unknown, mrOverrides: MockMrApiResponseOverrides = {}) {
     return {
         MergeRequests: {
             show: vi.fn().mockResolvedValue({ ...MOCK_MR_API_RESPONSE, ...mrOverrides }),

--- a/packages/web/src/features/agents/review-agent/nodes/gitlabPushMrReviews.test.ts
+++ b/packages/web/src/features/agents/review-agent/nodes/gitlabPushMrReviews.test.ts
@@ -101,7 +101,7 @@ describe('gitlabPushMrReviews', () => {
 
         await gitlabPushMrReviews(client, 101, MOCK_PAYLOAD, SINGLE_REVIEW);
 
-        const noteBody = client.MergeRequestNotes.create.mock.calls[0][2] as string;
+        const noteBody = vi.mocked(client.MergeRequestNotes.create).mock.calls[0][2] as string;
         expect(noteBody).toContain('src/foo.ts');
     });
 
@@ -116,7 +116,7 @@ describe('gitlabPushMrReviews', () => {
 
         await gitlabPushMrReviews(client, 101, MOCK_PAYLOAD, multiLineReviews);
 
-        const noteBody = client.MergeRequestNotes.create.mock.calls[0][2] as string;
+        const noteBody = vi.mocked(client.MergeRequestNotes.create).mock.calls[0][2] as string;
         expect(noteBody).toContain('10');
         expect(noteBody).toContain('20');
         expect(noteBody).toContain('Refactor this block');
@@ -272,9 +272,9 @@ describe('gitlabPushMrReviews', () => {
 
         await gitlabPushMrReviews(client, 101, payloadWithDiffs, addedLineReview);
 
-        const call = client.MergeRequestDiscussions.create.mock.calls[0][3];
-        expect(call.position).not.toHaveProperty('oldLine');
-        expect(call.position.newLine).toBe('2');
+        const position = vi.mocked(client.MergeRequestDiscussions.create).mock.calls[0]![3]!.position!;
+        expect(position).not.toHaveProperty('oldLine');
+        expect(position.newLine).toBe('2');
     });
 
     test('uses new path for both oldPath and newPath when old path is /dev/null (added file)', async () => {

--- a/packages/web/src/features/git/getFileSourceApi.test.ts
+++ b/packages/web/src/features/git/getFileSourceApi.test.ts
@@ -83,7 +83,7 @@ describe('getFileSourceForRepo', () => {
 
     const mockPrisma = {
         repo: { findFirst: mockFindFirst },
-    } as Parameters<typeof getFileSourceForRepo>[1]['prisma'];
+    } as unknown as Parameters<typeof getFileSourceForRepo>[1]['prisma'];
 
     beforeEach(() => {
         vi.clearAllMocks();

--- a/packages/web/src/features/mcp/prismaScope.test.ts
+++ b/packages/web/src/features/mcp/prismaScope.test.ts
@@ -10,6 +10,7 @@ const user = {
     emailVerified: null,
     image: null,
     sessionVersion: 0,
+    lastActiveAt: null,
     createdAt: new Date('2026-01-01T00:00:00Z'),
     updatedAt: new Date('2026-01-01T00:00:00Z'),
     accounts: [],

--- a/packages/web/src/middleware/withAuth.test.ts
+++ b/packages/web/src/middleware/withAuth.test.ts
@@ -1053,6 +1053,9 @@ describe('getAuthContext', () => {
                 userId,
                 orgId: MOCK_ORG.id,
                 role: OrgRole.MEMBER,
+                suspendedAt: null,
+                scimExternalId: null,
+                lastActiveAt: null,
             });
             setMockHeaders(new Headers({ 'Authorization': 'Bearer sboa_oauthtoken' }));
 
@@ -1080,6 +1083,9 @@ describe('getAuthContext', () => {
                 userId,
                 orgId: MOCK_ORG.id,
                 role: OrgRole.MEMBER,
+                suspendedAt: null,
+                scimExternalId: null,
+                lastActiveAt: null,
             });
             setMockHeaders(new Headers({ 'Authorization': 'Bearer sboa_oauthtoken' }));
 
@@ -1101,6 +1107,9 @@ describe('getAuthContext', () => {
                 userId,
                 orgId: MOCK_ORG.id,
                 role: OrgRole.MEMBER,
+                suspendedAt: null,
+                scimExternalId: null,
+                lastActiveAt: null,
             });
             prisma.apiKey.findUnique.mockResolvedValue({ ...MOCK_API_KEY, hash: 'apikey', createdById: userId });
             setMockHeaders(new Headers({ 'X-Sourcebot-Api-Key': 'sourcebot-apikey' }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -3714,10 +3714,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/env@npm:16.2.11"
-  checksum: 10c0/fdb5ff54037f5e554c7452a31f745e40a02ea55416b80c9abf5ebb3b6fba54beaa15e080fc8470f9a59b3a0506c7ce775764134256d413f17e17e4f92802cee3
+"@next/env@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/env@npm:16.3.1"
+  checksum: 10c0/c2c61e12c31a8d3be6738fc18b4d7c1e6a151336fb386b4eff8961ee0c72cabb33867febe903a2aacf26aed75be9aa77d4947b15c45162fc0279c0f612884f5a
   languageName: node
   linkType: hard
 
@@ -3730,58 +3730,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-darwin-arm64@npm:16.2.11"
+"@next/swc-darwin-arm64@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-darwin-arm64@npm:16.3.1"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-darwin-x64@npm:16.2.11"
+"@next/swc-darwin-x64@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-darwin-x64@npm:16.3.1"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.11"
+"@next/swc-linux-arm64-gnu@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.3.1"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.11"
+"@next/swc-linux-arm64-musl@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-linux-arm64-musl@npm:16.3.1"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.11"
+"@next/swc-linux-x64-gnu@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-linux-x64-gnu@npm:16.3.1"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.11"
+"@next/swc-linux-x64-musl@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-linux-x64-musl@npm:16.3.1"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.11"
+"@next/swc-win32-arm64-msvc@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.3.1"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.11":
-  version: 16.2.11
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.11"
+"@next/swc-win32-x64-msvc@npm:16.3.1":
+  version: 16.3.1
+  resolution: "@next/swc-win32-x64-msvc@npm:16.3.1"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -9069,7 +9069,7 @@ __metadata:
     micromatch: "npm:^4.0.8"
     minidenticons: "npm:^4.2.1"
     motion: "npm:^12.42.0"
-    next: "npm:^16.2.11"
+    next: "npm:^16.3.1"
     next-auth: "npm:^5.0.0-beta.32"
     next-navigation-guard: "npm:^0.2.0"
     next-themes: "npm:^0.3.0"
@@ -9156,12 +9156,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@swc/helpers@npm:0.5.15":
-  version: 0.5.15
-  resolution: "@swc/helpers@npm:0.5.15"
+"@swc/helpers@npm:0.5.23":
+  version: 0.5.23
+  resolution: "@swc/helpers@npm:0.5.23"
   dependencies:
     tslib: "npm:^2.8.0"
-  checksum: 10c0/33002f74f6f885f04c132960835fdfc474186983ea567606db62e86acd0680ca82f34647e8e610f4e1e422d1c16fce729dde22cd3b797ab1fd9061a825dabca4
+  checksum: 10c0/02da7b4df465693933ecd4851cc193ec729c309939c8a84eccae5ec0010aafc3894e713b8ef8d13a6ba401759f0e900c88e2dcfef5872c27bb91e70f73275cce
   languageName: node
   linkType: hard
 
@@ -18302,24 +18302,24 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:^16.2.11":
-  version: 16.2.11
-  resolution: "next@npm:16.2.11"
+"next@npm:^16.2.11, next@npm:^16.3.1":
+  version: 16.3.1
+  resolution: "next@npm:16.3.1"
   dependencies:
-    "@next/env": "npm:16.2.11"
-    "@next/swc-darwin-arm64": "npm:16.2.11"
-    "@next/swc-darwin-x64": "npm:16.2.11"
-    "@next/swc-linux-arm64-gnu": "npm:16.2.11"
-    "@next/swc-linux-arm64-musl": "npm:16.2.11"
-    "@next/swc-linux-x64-gnu": "npm:16.2.11"
-    "@next/swc-linux-x64-musl": "npm:16.2.11"
-    "@next/swc-win32-arm64-msvc": "npm:16.2.11"
-    "@next/swc-win32-x64-msvc": "npm:16.2.11"
-    "@swc/helpers": "npm:0.5.15"
+    "@next/env": "npm:16.3.1"
+    "@next/swc-darwin-arm64": "npm:16.3.1"
+    "@next/swc-darwin-x64": "npm:16.3.1"
+    "@next/swc-linux-arm64-gnu": "npm:16.3.1"
+    "@next/swc-linux-arm64-musl": "npm:16.3.1"
+    "@next/swc-linux-x64-gnu": "npm:16.3.1"
+    "@next/swc-linux-x64-musl": "npm:16.3.1"
+    "@next/swc-win32-arm64-msvc": "npm:16.3.1"
+    "@next/swc-win32-x64-msvc": "npm:16.3.1"
+    "@swc/helpers": "npm:0.5.23"
     baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
-    postcss: "npm:8.4.31"
-    sharp: "npm:^0.34.5"
+    postcss: "npm:8.5.23"
+    sharp: "npm:^0.35.3"
     styled-jsx: "npm:5.1.6"
   peerDependencies:
     "@opentelemetry/api": ^1.1.0
@@ -18358,7 +18358,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/81f85262cf01ad6b4fd4a8be369925dfe206806a33e967733033d7adcf367aa0ba1f911272de6169a3d09315821eddf6b57594337a456ad134ba5aa8870a80b1
+  checksum: 10c0/a071c6fdb9d02fc97b520d2c94aacfce693cf1847287129e0eaec42e8715433d925d165b8c800aff102f40820c8cf4a2e0306905d4d9912b5864a16e4f223bf0
   languageName: node
   linkType: hard
 
@@ -19392,6 +19392,17 @@ __metadata:
   version: 4.2.0
   resolution: "postcss-value-parser@npm:4.2.0"
   checksum: 10c0/f4142a4f56565f77c1831168e04e3effd9ffcc5aebaf0f538eee4b2d465adfd4b85a44257bb48418202a63806a7da7fe9f56c330aebb3cac898e46b4cbf49161
+  languageName: node
+  linkType: hard
+
+"postcss@npm:8.5.23":
+  version: 8.5.23
+  resolution: "postcss@npm:8.5.23"
+  dependencies:
+    nanoid: "npm:^3.3.16"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/ed714e635b330bb42666ecdd0c0b4f30224ded15b0b0052d6bc2b92832f2cf17d1c1141359453f96f0a84f8fbf4c405a74df187f559163b8f31131b2535455aa
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary

- upgrade Next.js from 16.2.11 to 16.3.1, which contains the upstream fix for the production filesystem-route cache retaining high-cardinality dynamic request paths
- update affected test mocks and fixtures for the type contracts exercised by the Next.js 16.3 build

## Finding

Better Stack showed the post-major-GC heap floor tracking request volume with a 0.996 correlation and an observed slope of about 1.30 KiB/request. ALB logs showed that 198,239 distinct `/browse` pathnames were requested during the inspected window; 99.93% of `/browse` requests came from `meta-externalagent`.

The deployed Next.js 16.2.11 build checks a concrete pathname against its filesystem manifests before matching a dynamic route. Each distinct `/browse/...` pathname is therefore inserted as a negative entry in `fsChecker.getItemsLru`. That cache has a nominal size of 1,048,576, but a cached miss has a value of `null` and was charged as only one unit. Its key was also a V8 sliced string that retained the full request URL.

I reproduced this with the exact production image and runtime under Linux. After forced full GC, 1,000 requests that varied only the query string were flat, while 1,579 distinct valid blob pathnames retained 1.631 MiB (1.058 KiB/path). The heap snapshot contained 1,581 route-cache entries versus two in the repeated-path control, with the retained paths rooted through `Symbol(@next/router-server-methods) -> fsChecker -> getItemsLru`.

This is the same defect described in vercel/next.js#94890 and fixed by vercel/next.js#96229. The upstream fix charges the cache for the key plus per-entry overhead, copies sliced keys, and bounds the cache at 8 MiB. Next.js 16.3.0 was the first stable release containing it; this PR upgrades to the latest stable 16.3.1.

## Verification

- `yarn workspace @sourcebot/web test --run` — 115 files and 1,261 tests passed
- `yarn workspace @sourcebot/web vitest run src/ee/features/chat/useUnsavedChangesGuard.test.tsx` — 6 tests passed
- targeted tests for the six updated SDK/Prisma fixture files — 148 tests passed
- standalone web `tsc --noEmit --pretty false` — passed
- `yarn workspace @sourcebot/web lint` — passed
- verified the installed 16.3.1 implementation uses key-aware sizing, flattened keys, the 8 MiB budget, and a cached-miss sentinel

Upstream references:

- https://github.com/vercel/next.js/issues/94890
- https://github.com/vercel/next.js/pull/96229
- https://github.com/vercel/next.js/commit/9a31a17600d361cdb05b0e901b6093441ec081a5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the web application framework to improve memory management for dynamic routes with many unique entries.
  * Improved reliability of unsaved-changes navigation behavior in supported browser navigation scenarios.
  * Improved consistency of authentication and integration behavior across supported data scenarios.

* **Documentation**
  * Added an Unreleased changelog entry describing the framework upgrade and memory-management improvement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->