### PR TITLE
fix(api/offers): return Content-Type: application/json

### DIFF
--- a/packages/web/src/app/api/(server)/offers/route.test.ts
+++ b/packages/web/src/app/api/(server)/offers/route.test.ts
@@ -1,0 +1,72 @@
+import { NextRequest } from "next/server";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    env: {
+        SOURCEBOT_INSTALL_ID: "test-install-id",
+    },
+    offers: [
+        { id: "team-monthly", name: "Team", price: { monthly: 100, yearly: 1000 } },
+        { id: "enterprise-monthly", name: "Enterprise", price: { monthly: 500, yearly: 5000 } },
+    ] as unknown,
+}));
+
+vi.mock("@sourcebot/shared", () => ({
+    env: mocks.env,
+    createLogger: () => ({
+        info: vi.fn(),
+        warn: vi.fn(),
+        error: vi.fn(),
+        debug: vi.fn(),
+    }),
+}));
+
+vi.mock("@/features/billing/client", () => ({
+    client: {
+        offers: vi.fn().mockResolvedValue(mocks.offers),
+    },
+}));
+
+vi.mock("@opentelemetry/sdk-trace-base", () => ({
+    getEnv: () => ({}),
+    TraceIdRatioBasedSampler: vi.fn(),
+    ParentBasedSampler: vi.fn(),
+    AlwaysOnSampler: vi.fn(),
+    AlwaysOffSampler: vi.fn(),
+}));
+
+vi.mock("@/lib/posthog", () => ({
+    captureEvent: vi.fn(),
+}));
+
+import { GET } from "./route";
+
+const makeRequest = () => new NextRequest("https://example.com/api/offers");
+
+describe("GET /api/offers", () => {
+    afterEach(() => {
+        vi.clearAllMocks();
+    });
+
+    it("returns a 200 with the offers as JSON", async () => {
+        const response = await GET(makeRequest(), {});
+        expect(response.status).toBe(200);
+
+        const body = await response.json();
+        expect(body).toEqual(mocks.offers);
+    });
+
+    it("sets Content-Type: application/json", async () => {
+        const response = await GET(makeRequest(), {});
+        // Next.js / Web Headers are case-insensitive, but be defensive
+        const contentType = response.headers.get("Content-Type") ?? response.headers.get("content-type") ?? "";
+        expect(contentType).toContain("application/json");
+    });
+
+    it("preserves the public cache-control header", async () => {
+        const response = await GET(makeRequest(), {});
+        const cacheControl = response.headers.get("Cache-Control") ?? "";
+        expect(cacheControl).toContain("public");
+        expect(cacheControl).toContain("max-age=300");
+    });
+});

--- a/packages/web/src/app/api/(server)/offers/route.ts
+++ b/packages/web/src/app/api/(server)/offers/route.ts
@@ -10,6 +10,7 @@ export const GET = apiHandler(async () => {
 
     return new Response(JSON.stringify(offers), {
         headers: {
+            'Content-Type': 'application/json',
             'Cache-Control': 'public, max-age=300'
         }
     });


### PR DESCRIPTION
Fixes #1595

## Summary

`GET /api/offers` was returning a JSON body with `Content-Type: text/plain;charset=UTF-8` because `new Response(JSON.stringify(offers))` does not set a content type. This is the only public API route in `packages/web/src/app/api/(server)/` that uses `new Response(JSON.stringify(...))` without setting `Content-Type`; every other public JSON route uses `Response.json(...)` or sets the header explicitly. The OpenAPI spec for this endpoint already declares the response as `application/json`, so the actual response was violating the documented contract.

## Why this matters

Strict API clients (CLI tools, OpenAPI-generated SDKs, third-party integrations) inspect `Content-Type` before parsing. A client that sees `text/plain;charset=UTF-8` will refuse to parse the body even though it is valid JSON. The in-app `getOffers` client happens to parse regardless of `Content-Type` because `response.json()` ignores it, but that is a coincidence of the Web `fetch` API, not because the response is correct.

## Changes

- `packages/web/src/app/api/(server)/offers/route.ts` — add `'Content-Type': 'application/json'` to the response headers. One-line change, body unchanged.
- `packages/web/src/app/api/(server)/offers/route.test.ts` — new file, 3 vitest cases that pin down the three observable invariants of this route: status 200 with the mocked body, `Content-Type: application/json`, and the existing `Cache-Control: public, max-age=300` header preserved. The OTel suite-load error and the `posthog` import are mocked the same way other tests in this repo handle them.

## Validation

- New tests: 3/3 pass on the new file alone.
- `yarn workspace @sourcebot/web test --run` returns 1157/1157 tests pass (3 more than the prior baseline of 1154 — the 3 new tests in this PR). The 7 pre-existing `@opentelemetry/sdk-trace-base` suite-load failures in `ee/askmcp/...` and `ee/permissionSyncStatus/...` are unchanged and not introduced by this PR.
- `git diff --check` clean.
- Manually verified in Node.js: `new Response(JSON.stringify({a:1}))` returns `Content-Type: text/plain;charset=UTF-8`; `Response.json({a:1})` returns `Content-Type: application/json`. Same engines, same behavior at the route layer.
- No OpenAPI, no docs change needed. The spec already declares `application/json`; this change makes the actual response match it.

## Test plan

- `yarn workspace @sourcebot/web test --run src/app/api/(server)/offers/route.test.ts` (3 cases, all pass).
- `yarn workspace @sourcebot/web test --run` (full suite, 1157/1157 pass with the same 7 pre-existing OTel suite-load failures as before this PR).

## Risks

None. The body is unchanged; only the response header is corrected. Clients that were already parsing by sniffing or by `response.json()` are unaffected. Strict clients that were rejecting the response start working.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 110f6889f2fa7def6c2815538a5bea01ce7eefd6. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Offers API responses now explicitly identify their content as JSON, improving compatibility with clients.

* **Tests**
  * Added coverage verifying offer responses, content type, and five-minute caching behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->