### PR TITLE
fix(web/ee): load identity provider config once in getLinkedAccounts

### DIFF
--- a/packages/web/src/ee/features/sso/actions.test.ts
+++ b/packages/web/src/ee/features/sso/actions.test.ts
@@ -2,6 +2,7 @@ import { beforeEach, describe, expect, test, vi } from 'vitest';
 
 const mocks = vi.hoisted(() => ({
     authContext: undefined as unknown,
+    getIdentityProviderConfigs: vi.fn(),
     hasEntitlement: vi.fn(),
     removeAccountPermissionSyncScheduler: vi.fn(),
     scheduleAndTriggerAccountPermissionSync: vi.fn(),
@@ -38,13 +39,14 @@ vi.mock('@sourcebot/shared', () => ({
     doesIdpSupportPermissionSyncing: () => true,
     env: { PERMISSION_SYNC_ENABLED: 'true' },
     getIdentityProviderConfig: vi.fn(),
-    getIdentityProviderConfigs: vi.fn(),
+    getIdentityProviderConfigs: mocks.getIdentityProviderConfigs,
 }));
 vi.mock('next/headers', () => ({
     cookies: vi.fn(),
 }));
 
 const {
+    getLinkedAccounts,
     triggerAccountPermissionSync,
     unlinkLinkedAccountProvider,
 } = await import('./actions');
@@ -56,6 +58,8 @@ beforeEach(() => {
     mocks.scheduleAndTriggerAccountPermissionSync.mockResolvedValue({
         jobId: 'job-1',
     });
+    // Default: empty identity provider config; specific tests override.
+    mocks.getIdentityProviderConfigs.mockResolvedValue({});
 });
 
 describe('triggerAccountPermissionSync', () => {
@@ -152,5 +156,98 @@ describe('unlinkLinkedAccountProvider', () => {
             unlinkLinkedAccountProvider('github'),
         ).rejects.toThrow('Redis unavailable');
         expect(deleteMany).not.toHaveBeenCalled();
+    });
+});
+
+describe('getLinkedAccounts', () => {
+    test('merges linked accounts with unlinked account_linking providers from config', async () => {
+        const findMany = vi.fn().mockResolvedValue([
+            {
+                id: 'account-1',
+                providerType: 'github',
+                providerId: 'github',
+                providerAccountId: 'gh-1',
+                permissionSyncIssue: null,
+            },
+        ]);
+        mocks.authContext = {
+            prisma: { account: { findMany } },
+            role: 'MEMBER',
+            user: { id: 'user-1' },
+        };
+        mocks.getIdentityProviderConfigs.mockResolvedValue({
+            github: {
+                provider: 'github',
+                displayName: 'GitHub',
+                purpose: 'account_linking',
+                accountLinkingRequired: false,
+            },
+            'gitlab-corp': {
+                provider: 'gitlab',
+                displayName: 'GitLab Corp',
+                purpose: 'account_linking',
+                accountLinkingRequired: true,
+            },
+        });
+
+        const result = await getLinkedAccounts();
+
+        // The single linked account (from the DB) is included.
+        expect(result).toContainEqual(
+            expect.objectContaining({
+                providerId: 'github',
+                providerType: 'github',
+                displayName: 'GitHub',
+                isLinked: true,
+                accountId: 'account-1',
+                providerAccountId: 'gh-1',
+                isAccountLinkingProvider: true,
+                required: false,
+                supportsPermissionSync: true,
+            }),
+        );
+        // The unlinked account_linking provider from config is also surfaced.
+        expect(result).toContainEqual(
+            expect.objectContaining({
+                providerId: 'gitlab-corp',
+                providerType: 'gitlab',
+                displayName: 'GitLab Corp',
+                isLinked: false,
+                isAccountLinkingProvider: true,
+                required: true,
+            }),
+        );
+        // Linked accounts come before unlinked entries (preserves existing order).
+        expect(result.map((r) => r.providerId)).toEqual([
+            'github',
+            'gitlab-corp',
+        ]);
+    });
+
+    test('loads the identity provider config exactly once regardless of account count', async () => {
+        // Regression test for the N+1 in getIdentityProviderConfig -> getIdentityProviderConfigs
+        // -> loadConfig. With five linked accounts, the config should be loaded
+        // once, not five times.
+        const findMany = vi.fn().mockResolvedValue(
+            ['github', 'gitlab', 'google', 'azure-ad', 'okta'].map(
+                (providerId, index) => ({
+                    id: `account-${index + 1}`,
+                    providerType: providerId,
+                    providerId,
+                    providerAccountId: `${providerId}-1`,
+                    permissionSyncIssue: null,
+                }),
+            ),
+        );
+        mocks.authContext = {
+            prisma: { account: { findMany } },
+            role: 'MEMBER',
+            user: { id: 'user-1' },
+        };
+        mocks.getIdentityProviderConfigs.mockResolvedValue({});
+
+        await getLinkedAccounts();
+
+        expect(mocks.getIdentityProviderConfigs).toHaveBeenCalledTimes(1);
     });
 });

--- a/packages/web/src/ee/features/sso/actions.ts
+++ b/packages/web/src/ee/features/sso/actions.ts
@@ -6,7 +6,7 @@ import { withAuth } from "@/middleware/withAuth";
 import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
 import { OrgRole, type AccountPermissionSyncIssue } from "@sourcebot/db";
 import { hasEntitlement } from "@/lib/entitlements";
-import { createLogger, doesIdpSupportPermissionSyncing, env, getIdentityProviderConfig, getIdentityProviderConfigs } from "@sourcebot/shared";
+import { createLogger, doesIdpSupportPermissionSyncing, env, getIdentityProviderConfigs } from "@sourcebot/shared";
 import { cookies } from "next/headers";
 import { removeAccountPermissionSyncScheduler, scheduleAndTriggerAccountPermissionSync } from "@/ee/features/permissionSync/accountPermissionSyncQueue.server";
 import { unexpectedError } from "@/lib/serviceError";
@@ -50,11 +50,18 @@ export const getLinkedAccounts = async () => sew(() =>
                 env.PERMISSION_SYNC_ENABLED === 'true' &&
                 await hasEntitlement('permission-syncing');
 
+            // getIdentityProviderConfig re-invokes getIdentityProviderConfigs
+            // (and therefore loadConfig) on every call, so calling it inside the
+            // loop below would re-read the config file once per linked account.
+            // Hoist the lookup to a single call before the loop, mirroring the
+            // pattern already used by the second loop in this function.
+            const identityProviders = await getIdentityProviderConfigs();
+
             const result: LinkedAccount[] = [];
 
             // All connected accounts (from DB), enriched with config data where available
             for (const account of accounts) {
-                const providerConfig = await getIdentityProviderConfig(account.providerId);
+                const providerConfig = identityProviders[account.providerId];
                 const isAccountLinking = providerConfig?.purpose === 'account_linking';
 
                 result.push({
@@ -71,8 +78,8 @@ export const getLinkedAccounts = async () => sew(() =>
                 });
             }
 
-            // Unlinked account_linking providers from config (not yet connected)
-            const identityProviders = await getIdentityProviderConfigs();
+            // Unlinked account_linking providers from config (not yet connected).
+            // Reuses the `identityProviders` map loaded once above.
             for (const [id, providerConfig] of Object.entries(identityProviders)) {
                 const account = accounts.find((account) => account.providerId === id);
                 if (!account) {


### PR DESCRIPTION
## Summary

`getLinkedAccounts` called `getIdentityProviderConfig(account.providerId)` inside a for-loop over the user's linked accounts. Each call internally re-invokes `getIdentityProviderConfigs` (in `packages/shared/src/env.server.ts`), which re-reads the config file from disk (or re-fetches the remote config URL) and re-validates it with ajv on every iteration.

A user with N linked accounts triggered N full config reads on every call to `getLinkedAccounts`, plus one more read from the second loop in the same function. With a 50 KB config file and 5 linked accounts, that is 5 × 50 KB of disk reads + 5 × `JSON.parse` + 5 × ajv schema validation per settings-page load. The retry-on-`ENOENT` logic in `loadConfig` (5 attempts × 2 s delay) also amplified the worst-case latency when the config file was being mounted.

Hoist the `getIdentityProviderConfigs()` call to once before the first loop, mirror the pattern already used by the second loop, and use a synchronous object lookup per account. The second loop now reuses the same map.

## Validation

- `yarn workspace @sourcebot/web test --run src/ee/features/sso/actions.test.ts` → 6 passed (4 pre-existing + 2 new)
- `yarn workspace @sourcebot/web test --run` → 1168 passed (same 7 pre-existing `@opentelemetry/sdk-trace-base` suite-load failures as `upstream/main`)
- `yarn workspace @sourcebot/web lint` → clean
- `yarn workspace @sourcebot/web exec tsc --noEmit` → 0 new errors introduced (the existing `withAuth.ts` `SCOPED_ACCESS_TOKEN_PREFIX` / `scopedAccessToken` errors are pre-existing on `upstream/main@39b5953b` and unrelated to this PR)

## Test plan

- [x] `yarn workspace @sourcebot/web test --run src/ee/features/sso/actions.test.ts` (6 passed: 4 pre-existing + 2 new)
- [x] `yarn workspace @sourcebot/web test --run` (1168 passed; same 7 pre-existing suite-load failures as `upstream/main`)
- [x] `yarn workspace @sourcebot/web lint` (0 errors)
- [x] `npx tsc --noEmit -p packages/web/tsconfig.json` (0 new errors)

Fixes #1601

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c5cf7a2d62bbacd7bbbb686f0d38393c8286ce2b. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the display and handling of linked sign-in accounts.
  - Ensured available account-linking providers are included alongside existing linked accounts.
  - Preserved account ordering and provider details for a consistent experience.
  - Improved consistency when multiple linked accounts use identity-provider configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->