### PR TITLE
fix(worker): schedule experimental GitHub repos

### DIFF
--- a/packages/backend/src/api.ts
+++ b/packages/backend/src/api.ts
@@ -18,7 +18,7 @@ import { SINGLE_TENANT_ORG_ID } from './constants.js';
 import { isGitHubRateLimitError, isNotFound } from './errors.js';
 import { PromClient } from './promClient.js';
 import { createGitHubRepoRecord } from './repoCompileUtils.js';
-import type { JobManager } from './types.js';
+import type { JobManager, Settings } from './types.js';
 
 const logger = createLogger('api');
 
@@ -35,6 +35,7 @@ export class Api {
         private prisma: PrismaClient,
         private jobManager: JobManager,
         redis: Redis,
+        private settings: Settings,
     ) {
         const app = express();
         app.use(express.json());
@@ -138,14 +139,11 @@ export class Api {
             create: record,
         });
 
-        const jobId = await this.jobManager.trigger(
-            'repo-index',
-            {
-                repoId: repo.id,
-                type: RepoIndexingJobType.INDEX,
-            },
-            { priority: JOB_PRIORITIES.INTERACTIVE },
-        );
+        const jobId = await scheduleAndTriggerRepoIndexing({
+            jobManager: this.jobManager,
+            repoId: repo.id,
+            reindexIntervalMs: this.settings.reindexIntervalMs,
+        });
 
         res.status(200).json({ jobId, repoId: repo.id });
     }
@@ -162,3 +160,33 @@ export class Api {
         });
     }
 }
+
+const scheduleAndTriggerRepoIndexing = async ({
+    jobManager,
+    repoId,
+    reindexIntervalMs,
+}: {
+    jobManager: JobManager;
+    repoId: number;
+    reindexIntervalMs: number;
+}): Promise<string> => {
+    await jobManager.upsertJobScheduler(
+        "repo-index",
+        `repo-index-v1-${repoId}`,
+        reindexIntervalMs,
+        {
+            repoId,
+            type: RepoIndexingJobType.INDEX,
+        },
+        { priority: JOB_PRIORITIES.SCHEDULED },
+    );
+
+    return jobManager.trigger(
+        "repo-index",
+        {
+            repoId,
+            type: RepoIndexingJobType.INDEX,
+        },
+        { priority: JOB_PRIORITIES.INTERACTIVE },
+    );
+};

--- a/packages/backend/src/index.ts
+++ b/packages/backend/src/index.ts
@@ -84,7 +84,7 @@ jobManager.register(repoPermissionSyncWorkload);
 jobManager.register(attachmentPruneWorkload);
 jobManager.register(auditLogPruneWorkload);
 
-const api = new Api(promClient, prisma, jobManager, redis);
+const api = new Api(promClient, prisma, jobManager, redis, settings);
 
 await cleanupOrphanedRepoResources(prisma);
 

--- a/packages/backend/src/reconcileJobSchedulers.test.ts
+++ b/packages/backend/src/reconcileJobSchedulers.test.ts
@@ -71,9 +71,16 @@ describe("reconcileJobSchedulers", () => {
         });
         expect(mocks.repoFindMany).toHaveBeenCalledWith({
             where: {
-                connections: {
-                    some: {},
-                },
+                OR: [
+                    {
+                        connections: {
+                            some: {},
+                        },
+                    },
+                    {
+                        isAutoCleanupDisabled: true,
+                    },
+                ],
             },
             select: { id: true },
         });
@@ -203,6 +210,44 @@ describe("reconcileJobSchedulers", () => {
         expect(
             mocks.removeJobScheduler.mock.invocationCallOrder[0],
         ).toBeLessThan(mocks.trigger.mock.invocationCallOrder[0]);
+    });
+
+    test("keeps index schedulers for repos with automatic cleanup disabled", async () => {
+        mocks.repoFindMany.mockImplementation(async ({ where }) => {
+            if (where?.isAutoCleanupDisabled === false) {
+                return [];
+            }
+            if (where?.isPublic === false) {
+                return [];
+            }
+            return [{ id: 42 }, { id: 84 }];
+        });
+        mocks.getJobSchedulerIds.mockImplementation(async (workloadName) =>
+            workloadName === "repo-index" ? ["repo-index-v1-84"] : [],
+        );
+
+        await reconcileJobSchedulers({
+            db,
+            jobManager,
+            settings: {
+                resyncConnectionIntervalMs: 86_400_000,
+                reindexIntervalMs: 3_600_000,
+                userDrivenPermissionSyncIntervalMs: 43_200_000,
+                repoDrivenPermissionSyncIntervalMs: 21_600_000,
+            },
+        });
+
+        expect(mocks.upsertJobScheduler).toHaveBeenCalledWith(
+            "repo-index",
+            "repo-index-v1-84",
+            3_600_000,
+            { repoId: 84, type: "INDEX" },
+            { priority: 10 },
+        );
+        expect(mocks.removeJobScheduler).not.toHaveBeenCalledWith(
+            "repo-index",
+            "repo-index-v1-84",
+        );
     });
 
     test("removes permission schedulers when permission syncing is disabled", async () => {

--- a/packages/backend/src/reconcileJobSchedulers.ts
+++ b/packages/backend/src/reconcileJobSchedulers.ts
@@ -56,9 +56,16 @@ export const reconcileJobSchedulers = async ({
         }),
         db.repo.findMany({
             where: {
-                connections: {
-                    some: {},
-                },
+                OR: [
+                    {
+                        connections: {
+                            some: {},
+                        },
+                    },
+                    {
+                        isAutoCleanupDisabled: true,
+                    },
+                ],
             },
             select: {
                 id: true,


### PR DESCRIPTION
## Summary
- create a recurring repo indexing scheduler when adding a repository through the experimental GitHub endpoint
- retain and rebuild schedulers for connectionless repositories with automatic cleanup disabled
- pass worker settings into the API for the configured reindex interval

## Testing
- `yarn workspace @sourcebot/backend test --run`
- `yarn workspace @sourcebot/backend build`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit 7a7167dada7fc78bd3cf56bc5f00a18a44458739. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Repository indexing now supports recurring schedules based on the configured reindex interval.
  - Indexing requests can run immediately while also maintaining their recurring schedule.

- **Bug Fixes**
  - Index schedules are now preserved for repositories where automatic cleanup is disabled.
  - Repositories with active connections continue to receive the appropriate indexing schedules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->