### PR TITLE
fix(backend): decode percent-encoded characters in generic git URL config

### DIFF
--- a/packages/backend/src/repoCompileUtils.test.ts
+++ b/packages/backend/src/repoCompileUtils.test.ts
@@ -255,8 +255,35 @@ describe('compileGenericGitHostConfig_url', () => {
 
         expect(result.repoData).toHaveLength(1);
         expect(result.repoData[0].name).toBe('github.com/test/repo');
-        
+
         const metadata = result.repoData[0].metadata as { gitConfig?: Record<string, string> };
         expect(metadata.gitConfig!['zoekt.name']).toBe('github.com/test/repo');
+    });
+
+    test('should decode URL-encoded characters in the direct url pathname', async () => {
+        // Regression for #1384: the file-origin path already calls
+        // decodeURIComponent on the origin URL pathname, but the direct-URL
+        // path did not. The same remote configured two different ways
+        // produced different `name`/`displayName` values, which broke
+        // search-index metadata and gave the same repo inconsistent
+        // identifiers depending on how it was configured.
+        mockedIsUrlAValidGitRepo.mockResolvedValue(true);
+
+        const config = {
+            type: 'git' as const,
+            url: 'https://github.com/test/Project%20Name%20With%20Spaces.git',
+        };
+
+        const result = await compileGenericGitHostConfig_url(config, 1);
+
+        expect(result.repoData).toHaveLength(1);
+        expect(result.warnings).toHaveLength(0);
+        // The repo name should have decoded spaces, not %20
+        expect(result.repoData[0].name).toBe('github.com/test/Project Name With Spaces');
+        expect(result.repoData[0].displayName).toBe('github.com/test/Project Name With Spaces');
+
+        const metadata = result.repoData[0].metadata as { gitConfig?: Record<string, string> };
+        expect(metadata.gitConfig!['zoekt.name']).toBe('github.com/test/Project Name With Spaces');
+        expect(metadata.gitConfig!['zoekt.display-name']).toBe('github.com/test/Project Name With Spaces');
     });
 });

--- a/packages/backend/src/repoCompileUtils.ts
+++ b/packages/backend/src/repoCompileUtils.ts
@@ -726,7 +726,13 @@ export const compileGenericGitHostConfig_url = async (
 
     // @note: matches the naming here:
     // https://github.com/sourcebot-dev/zoekt/blob/main/gitindex/index.go#L293
-    const repoName = path.join(remoteUrl.host, remoteUrl.pathname.replace(/\.git$/, ''));
+    // Decode URL-encoded characters (e.g., %20 -> space) so that a direct URL
+    // config derives the same repo name as a file-origin config whose origin
+    // URL gets decoded by the same call below. Without this, a URL like
+    // `https://github.com/test/Project%20Name.git` and a file config pointing
+    // at the same remote end up with different `name`/`displayName` values.
+    const decodedPathname = decodeURIComponent(remoteUrl.pathname);
+    const repoName = path.join(remoteUrl.host, decodedPathname.replace(/\.git$/, ''));
 
     const repo: RepoData = {
         external_codeHostType: 'genericGitHost',


### PR DESCRIPTION
## Summary

`compileGenericGitHostConfig_url` in `packages/backend/src/repoCompileUtils.ts` derived the repo `name` / `displayName` / zoekt metadata from `remoteUrl.pathname` without decoding percent-encoded characters. The file-origin counterpart (`compileGenericGitHostConfig_file`) already calls `decodeURIComponent` on the origin URL pathname, so the same remote configured as a direct URL vs. discovered from a local repository origin ended up with two different identifiers.

Concretely, a URL like `https://github.com/test/Project%20Name%20With%20Spaces.git` and a file config pointing at the same remote would derive:

- direct URL:    `github.com/test/Project%20Name%20With%20Spaces`
- file origin:   `github.com/test/Project Name With Spaces`

That breaks search-index metadata (the value is written into `zoekt.name` / `zoekt.display-name` / `name` / `displayName`) and makes the same repository look like two different repos depending on how it was configured.

The fix mirrors the existing file-origin pattern: pull `decodeURIComponent` on `remoteUrl.pathname` before stripping the `.git` suffix and joining with the host. One production-line change.

## Validation

- `yarn workspace @sourcebot/backend test --run src/repoCompileUtils.test.ts` → 12 passed (11 pre-existing + 1 new)
- `yarn workspace @sourcebot/backend test --run` → 262 passed (261 baseline + 1 new), 15 pre-existing failures unchanged
- `yarn workspace @sourcebot/backend exec tsc --noEmit` → 0 new errors introduced (all 11 pre-existing tsc errors are in the new BullMQ JobManager files added in #1427 and are unrelated to this PR)

## Test plan

- [x] `yarn workspace @sourcebot/backend test --run src/repoCompileUtils.test.ts` (12 passed)
- [x] `yarn workspace @sourcebot/backend test --run` (262 passed; same 15 pre-existing failures as `upstream/main`)
- [x] `yarn workspace @sourcebot/backend exec tsc --noEmit` (0 new errors)

## Out of scope

Malformed percent escapes like `Project%GGName`. The file-origin path also throws on these via the raw `decodeURIComponent` call, so this PR preserves the same behavior. A separate change could wrap the decode with a malformed-escape fallback if the maintainer wants to relax that.

Fixes #1384

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-path naming change in repo compile utilities with a focused unit test; no auth, security, or data migration impact.
> 
> **Overview**
> **Direct HTTPS generic git connections** now decode percent-encoded path segments (e.g. `%20` → space) when building repo `name`, `displayName`, and zoekt metadata, matching the existing **file-origin** compile path.
> 
> That removes a mismatch where the same remote configured as a URL vs. discovered from a local clone could get two identifiers (encoded vs. decoded), which broke search-index consistency.
> 
> A regression test covers URL configs with spaces in the repo path and asserts `zoekt.name` / `zoekt.display-name` align with the decoded name.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 91ffdbc8efa16e2779fc26e940c5f8de4e831dfa. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository names and display names from direct Git URLs now correctly preserve URL-encoded characters.
  * Repository metadata now consistently reflects the decoded names used elsewhere in the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->