### PR TITLE
chore: mirror main and tags to sourcebot-private

### DIFF
--- a/.github/workflows/mirror-sourcebot-private.yml
+++ b/.github/workflows/mirror-sourcebot-private.yml
@@ -1,0 +1,56 @@
+name: Mirror to sourcebot-private
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - "v*"
+      - "setup-sourcebot-v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: mirror-sourcebot-private
+  cancel-in-progress: false
+
+jobs:
+  mirror:
+    if: github.repository == 'sourcebot-dev/sourcebot'
+    runs-on: ubuntu-latest
+    environment: sourcebot-private-mirror
+
+    steps:
+      - name: Check out complete repository history
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          fetch-tags: true
+          persist-credentials: false
+
+      - name: Create mirror installation token
+        id: app-token
+        uses: actions/create-github-app-token@v3
+        with:
+          client-id: ${{ vars.MIRROR_APP_CLIENT_ID }}
+          private-key: ${{ secrets.MIRROR_APP_PRIVATE_KEY }}
+          owner: sourcebot-dev
+          repositories: sourcebot-private
+          permission-contents: write
+          permission-workflows: write
+
+      - name: Mirror main and tags
+        env:
+          MIRROR_TOKEN: ${{ steps.app-token.outputs.token }}
+        shell: bash
+        run: |
+          git remote add private \
+            "https://x-access-token:${MIRROR_TOKEN}@github.com/sourcebot-dev/sourcebot-private.git"
+
+          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
+            git push --atomic private HEAD:refs/heads/main --tags
+          else
+            git push --atomic private --tags
+          fi

--- a/.github/workflows/mirror-sourcebot-private.yml
+++ b/.github/workflows/mirror-sourcebot-private.yml
@@ -7,6 +7,13 @@ on:
     tags:
       - "v*"
       - "setup-sourcebot-v*"
+  # Release commits use `[skip ci]`, which suppresses push-triggered workflows.
+  workflow_run:
+    workflows:
+      - Release Sourcebot (Production)
+      - Release setup-sourcebot
+    types:
+      - completed
   workflow_dispatch:
 
 permissions:
@@ -26,6 +33,7 @@ jobs:
       - name: Check out complete repository history
         uses: actions/checkout@v7
         with:
+          ref: main
           fetch-depth: 0
           fetch-tags: true
           persist-credentials: false
@@ -49,8 +57,4 @@ jobs:
           git remote add private \
             "https://x-access-token:${MIRROR_TOKEN}@github.com/sourcebot-dev/sourcebot-private.git"
 
-          if [[ "${GITHUB_REF}" == "refs/heads/main" ]]; then
-            git push --atomic private HEAD:refs/heads/main --tags
-          else
-            git push --atomic private --tags
-          fi
+          git push --atomic private HEAD:refs/heads/main --tags

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Added an automated one-way mirror of `main` and release tags to `sourcebot-private`. [#1611](https://github.com/sourcebot-dev/sourcebot/pull/1611)
-
 ## [5.1.8] - 2026-08-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added an automated one-way mirror of `main` and release tags to `sourcebot-private`. [#1611](https://github.com/sourcebot-dev/sourcebot/pull/1611)
+
 ## [5.1.8] - 2026-08-19
 
 ### Added


### PR DESCRIPTION
Fixes SOU-2019

Adds a one-way workflow that mirrors `main` and release tags to `sourcebot-private`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/bugbot) is generating a summary for commit c8d06a472aa853752f2836cd6f45d1732f0f8df3. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated synchronization following successful releases.
  * Ensured the primary code branch and version tags are mirrored consistently.
  * Enhanced reliability by using atomic synchronization.
* **User Impact**
  * No changes to application functionality or user-facing behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->