### PR TITLE
fix(web): auto-hide error banner when chat error is cleared

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed unary Zoekt searches retaining a gRPC channel after every request by closing each client on completion. [#1591](https://github.com/sourcebot-dev/sourcebot/pull/1591)
+- Fixed Ask error banner persisting after transient network errors were cleared, causing stale "Network error" messages to appear after every question. [#1614](https://github.com/sourcebot-dev/sourcebot/pull/1614)
 
 ## [5.1.8] - 2026-08-19
 

--- a/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/chatThread.tsx
@@ -420,11 +420,11 @@ export const ChatThread = ({
     }, [scrollRef]);
 
 
-    // Keep the error state & banner visibility in sync.
+    // Keep the error state & banner visibility in sync. The banner should
+    // automatically hide when the error is cleared (e.g. when a new request
+    // starts successfully), preventing stale error banners from lingering.
     useEffect(() => {
-        if (error) {
-            setIsErrorBannerVisible(true);
-        }
+        setIsErrorBannerVisible(!!error);
     }, [error]);
 
     const onSubmit = useCallback(async (children: Descendant[], editor: CustomEditor, attachments: AttachmentData[]) => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes SOU-2018

## Problem

Users were seeing a "Network error" message displayed at the top of the Ask page after every question, even though the question would continue and succeed. The error appeared benign but was confusing and degraded the user experience.

## Root Cause

The error banner visibility was only set to `true` when an error occurred, but was never automatically hidden when the error state was cleared by the AI SDK. This caused stale error banners to persist even after:
- A new request started successfully (the AI SDK explicitly clears errors when starting a new request)
- A transient error was resolved

The problematic code:
```javascript
useEffect(() => {
    if (error) {
        setIsErrorBannerVisible(true);
    }
}, [error]);
```

This effect only ran when `error` changed to a truthy value, but did nothing when `error` became `undefined` (cleared).

## Solution

Changed the effect to properly synchronize banner visibility with the error state:
```javascript
useEffect(() => {
    setIsErrorBannerVisible(!!error);
}, [error]);
```

Now:
- When `error` is truthy → banner is visible
- When `error` is falsy (undefined/null) → banner is hidden

This ensures that transient errors that get cleared by the AI SDK (e.g., when a new request starts) no longer leave lingering error banners.

## Testing

- Ran linter: `yarn workspace @sourcebot/web lint` ✅
- Ran web package tests: `yarn workspace @sourcebot/web test` ✅ (1424 tests passed)
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [SOU-2018](https://linear.app/sourcebot/issue/SOU-2018/network-error-showing-after-every-ask-question-but-it-still-works)

<div><a href="https://cursor.com/agents/bc-6b4a1954-dc40-4820-a6ad-a9293969884f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6b4a1954-dc40-4820-a6ad-a9293969884f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Ask network-error banners remaining visible after a temporary error is cleared.
  - Error banners now automatically hide when a new request starts successfully.

- **Documentation**
  - Added an unreleased changelog entry describing the fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->