### PR TITLE
fix(web): show repository first-sync banner to everyone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 - Fixed unary Zoekt searches retaining a gRPC channel after every request by closing each client on completion. [#1591](https://github.com/sourcebot-dev/sourcebot/pull/1591)
+- Fixed the repository first-sync banner not appearing for members and anonymous viewers. [#1615](https://github.com/sourcebot-dev/sourcebot/pull/1615)
 
 ## [5.1.8] - 2026-08-19
 

--- a/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
+++ b/packages/web/src/app/(app)/components/banners/bannerResolver.test.ts
@@ -291,10 +291,10 @@ describe('resolveActiveBanner', () => {
 
             expect(result?.id).toBe('repositoryFirstSync');
             expect(result?.dismissible).toBe(true);
-            expect(result?.audience).toBe('owner');
+            expect(result?.audience).toBe('everyone');
         });
 
-        test('hides first-time syncing repositories from members', () => {
+        test('shows first-time syncing repositories to members', () => {
             const result = resolveActiveBanner(makeContext({
                 role: OrgRole.MEMBER,
                 repositorySyncCounts: {
@@ -304,7 +304,20 @@ describe('resolveActiveBanner', () => {
                 },
             }));
 
-            expect(result).toBeNull();
+            expect(result?.id).toBe('repositoryFirstSync');
+        });
+
+        test('shows first-time syncing repositories to anonymous viewers', () => {
+            const result = resolveActiveBanner(makeContext({
+                role: null,
+                repositorySyncCounts: {
+                    firstTimeSyncingCount: 3,
+                    failedCount: 0,
+                    warningCount: 0,
+                },
+            }));
+
+            expect(result?.id).toBe('repositoryFirstSync');
         });
 
         test('repository warnings take priority over first-time syncing', () => {

--- a/packages/web/src/app/(app)/components/banners/bannerResolver.tsx
+++ b/packages/web/src/app/(app)/components/banners/bannerResolver.tsx
@@ -276,7 +276,7 @@ function buildCandidates(ctx: BannerContext): BannerDescriptor[] {
             id: 'repositoryFirstSync',
             priority: BannerPriority.REPOSITORY_FIRST_SYNC,
             dismissible: true,
-            audience: 'owner',
+            audience: 'everyone',
             render: (props) => (
                 <RepositoryFirstSyncBanner
                     {...props}

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -171,16 +171,14 @@ export default async function Layout(props: LayoutProps) {
         permissionSyncStatus !== null && !isServiceError(permissionSyncStatus)
             ? permissionSyncStatus.issues
             : [];
-    const repositorySyncCountsResult = role === OrgRole.OWNER
-        ? await getRepositorySyncCounts().catch((error) => {
-              console.error("Failed to load repository sync counts", error);
-              return {
-                  firstTimeSyncingCount: 0,
-                  failedCount: 0,
-                  warningCount: 0,
-              };
-          })
-        : { firstTimeSyncingCount: 0, failedCount: 0, warningCount: 0 };
+    const repositorySyncCountsResult = await getRepositorySyncCounts().catch((error) => {
+        console.error("Failed to load repository sync counts", error);
+        return {
+            firstTimeSyncingCount: 0,
+            failedCount: 0,
+            warningCount: 0,
+        };
+    });
     if (isServiceError(repositorySyncCountsResult)) {
         throw new ServiceErrorException(repositorySyncCountsResult);
     }

--- a/packages/web/src/app/api/(server)/repository-sync-counts/route.ts
+++ b/packages/web/src/app/api/(server)/repository-sync-counts/route.ts
@@ -5,7 +5,7 @@ import { sew } from "@/middleware/sew";
 import { getRepositorySyncCounts } from "@/features/repos/repositorySyncCounts.server";
 import { StatusCodes } from "http-status-codes";
 
-// eslint-disable-next-line authz/require-auth-wrapper -- Authentication and owner authorization are enforced by getRepositorySyncCounts.
+// eslint-disable-next-line authz/require-auth-wrapper -- Optional authentication and repository visibility are enforced by getRepositorySyncCounts.
 export const GET = apiHandler(async () => {
     const result = await sew(() => getRepositorySyncCounts());
 

--- a/packages/web/src/features/repos/repositorySyncCounts.server.test.ts
+++ b/packages/web/src/features/repos/repositorySyncCounts.server.test.ts
@@ -1,0 +1,80 @@
+import { OrgRole } from "@sourcebot/db";
+import { beforeEach, describe, expect, test, vi } from "vitest";
+
+const mocks = vi.hoisted(() => ({
+    authContext: undefined as unknown,
+    count: vi.fn(),
+    getFailedJobIds: vi.fn(),
+}));
+
+vi.mock("server-only", () => ({}));
+vi.mock("react", () => ({
+    cache: (fn: unknown) => fn,
+}));
+vi.mock("@/middleware/withAuth", () => ({
+    withOptionalAuth: (fn: (context: unknown) => unknown) =>
+        fn(mocks.authContext),
+}));
+vi.mock("@/lib/bullmqClient", () => ({
+    getBullMQClient: () => ({
+        getFailedJobIds: mocks.getFailedJobIds,
+    }),
+}));
+
+const { getRepositorySyncCounts } = await import(
+    "./repositorySyncCounts.server"
+);
+
+const setAuthContext = (role?: OrgRole) => {
+    mocks.authContext = {
+        org: { id: 42 },
+        prisma: { repo: { count: mocks.count } },
+        role,
+    };
+};
+
+beforeEach(() => {
+    vi.clearAllMocks();
+});
+
+describe("getRepositorySyncCounts", () => {
+    test.each([
+        ["members", OrgRole.MEMBER],
+        ["anonymous viewers", undefined],
+    ])("returns first-sync counts to %s", async (_audience, role) => {
+        setAuthContext(role);
+        mocks.count.mockResolvedValueOnce(3);
+
+        await expect(getRepositorySyncCounts()).resolves.toEqual({
+            firstTimeSyncingCount: 3,
+            failedCount: 0,
+            warningCount: 0,
+        });
+        expect(mocks.count).toHaveBeenCalledOnce();
+        expect(mocks.count).toHaveBeenCalledWith({
+            where: {
+                orgId: 42,
+                indexedAt: null,
+                firstIndexingJobFinishedAt: null,
+            },
+        });
+        expect(mocks.getFailedJobIds).not.toHaveBeenCalled();
+    });
+
+    test("includes failure and warning counts for owners", async () => {
+        setAuthContext(OrgRole.OWNER);
+        mocks.count
+            .mockResolvedValueOnce(3)
+            .mockResolvedValueOnce(1)
+            .mockResolvedValueOnce(2);
+        mocks.getFailedJobIds.mockResolvedValue(["failed-job"]);
+
+        await expect(getRepositorySyncCounts()).resolves.toEqual({
+            firstTimeSyncingCount: 3,
+            failedCount: 1,
+            warningCount: 2,
+        });
+        expect(mocks.getFailedJobIds).toHaveBeenCalledOnce();
+        expect(mocks.count).toHaveBeenCalledTimes(3);
+    });
+});

--- a/packages/web/src/features/repos/repositorySyncCounts.server.ts
+++ b/packages/web/src/features/repos/repositorySyncCounts.server.ts
@@ -1,8 +1,7 @@
 import "server-only";
 
 import { getBullMQClient } from "@/lib/bullmqClient";
-import { withAuth } from "@/middleware/withAuth";
-import { withMinimumOrgRole } from "@/middleware/withMinimumOrgRole";
+import { withOptionalAuth } from "@/middleware/withAuth";
 import { OrgRole } from "@sourcebot/db";
 import { REPO_INDEX_QUEUE } from "@sourcebot/shared";
 import { cache } from "react";
@@ -14,44 +13,46 @@ export interface RepositorySyncCounts {
 }
 
 export const getRepositorySyncCounts = cache(async () =>
-    withAuth(({ org, prisma, role }) =>
-        withMinimumOrgRole(role, OrgRole.OWNER, async () => {
-            const failedJobIds = await getBullMQClient().getFailedJobIds(
-                REPO_INDEX_QUEUE,
-            );
+    withOptionalAuth(async ({ org, prisma, role }) => {
+        const firstTimeSyncingCount = await prisma.repo.count({
+            where: {
+                orgId: org.id,
+                indexedAt: null,
+                firstIndexingJobFinishedAt: null,
+            },
+        });
 
-            const [
-                firstTimeSyncingCount,
-                failedCount,
-                warningCount,
-            ] = await Promise.all([
-                prisma.repo.count({
-                    where: {
-                        orgId: org.id,
-                        indexedAt: null,
-                        firstIndexingJobFinishedAt: null,
-                    },
-                }),
-                prisma.repo.count({
-                    where: {
-                        orgId: org.id,
-                        latestIndexingJobId: { in: failedJobIds },
-                        indexedAt: null,
-                    },
-                }),
-                prisma.repo.count({
-                    where: {
-                        orgId: org.id,
-                        latestIndexingJobId: { in: failedJobIds },
-                        indexedAt: { not: null },
-                    },
-                }),
-            ]);
-
+        if (role !== OrgRole.OWNER) {
             return {
                 firstTimeSyncingCount,
-                failedCount,
-                warningCount,
+                failedCount: 0,
+                warningCount: 0,
             };
-        })
-    ));
+        }
+
+        const failedJobIds = await getBullMQClient().getFailedJobIds(
+            REPO_INDEX_QUEUE,
+        );
+        const [failedCount, warningCount] = await Promise.all([
+            prisma.repo.count({
+                where: {
+                    orgId: org.id,
+                    latestIndexingJobId: { in: failedJobIds },
+                    indexedAt: null,
+                },
+            }),
+            prisma.repo.count({
+                where: {
+                    orgId: org.id,
+                    latestIndexingJobId: { in: failedJobIds },
+                    indexedAt: { not: null },
+                },
+            }),
+        ]);
+
+        return {
+            firstTimeSyncingCount,
+            failedCount,
+            warningCount,
+        };
+    }));


### PR DESCRIPTION
## Summary

- show the repository first-sync banner to owners, members, and anonymous viewers
- load repository first-sync counts through optional authentication while keeping failure and warning counts owner-only
- add coverage for banner audiences and count visibility

## Test plan

- yarn workspace @sourcebot/web test --run src/app/(app)/components/banners/bannerResolver.test.ts src/app/(app)/components/banners/repositoryFirstSyncBanner.test.tsx src/features/repos/repositorySyncCounts.server.test.ts
- yarn workspace @sourcebot/web lint

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Widens a previously owner-only API to optional auth so first-sync repo counts are visible to members and anonymous users. Failure/warning details remain owner-gated.
> 
> **Overview**
> The repository first-sync banner now shows to **members and anonymous viewers**, not just owners, so people waiting on initial indexing can see progress.
> 
> `getRepositorySyncCounts` uses optional auth and always returns first-sync counts. Failure and warning counts stay owner-only (zeros for everyone else). Layout loads those counts for all roles instead of skipping the fetch for non-owners.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d2bb5f5aa33616096dcdede4077806b91e23d46d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Repository first-sync notifications now appear for members and anonymous viewers when applicable.
  * Improved visibility of repository synchronization progress during initial setup.
  * Owners continue to receive failure and warning information for repository sync issues.

* **Documentation**
  * Added an Unreleased changelog entry describing the first-sync notification fix.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->