### PR TITLE
feat(web): make Sentry tracing and profiling opt-in

### DIFF
--- a/.env.development
+++ b/.env.development
@@ -30,6 +30,8 @@ CONFIG_PATH=${PWD}/config.json # Path to the sourcebot config file (if one exist
 # NEXT_PUBLIC_SENTRY_WEBAPP_DSN=""
 # SENTRY_ENVIRONMENT="dev"
 # NEXT_PUBLIC_SENTRY_ENVIRONMENT="dev"
+# SENTRY_TRACING_ENABLED="false" # Set to "true" to enable server and edge tracing.
+# SENTRY_PROFILING_ENABLED="false" # Set to "true" to enable server-side profiling. Requires tracing.
 # SENTRY_AUTH_TOKEN=
 
 # Logtail

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Made Sentry tracing and profiling opt-in through environment variables. [#1616](https://github.com/sourcebot-dev/sourcebot/pull/1616)
+
 ## [5.1.9] - 2026-08-22
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-- Made Sentry tracing and profiling opt-in through environment variables. [#1616](https://github.com/sourcebot-dev/sourcebot/pull/1616)
-
 ## [5.1.9] - 2026-08-22
 
 ### Fixed

--- a/packages/web/src/sentry.edge.config.ts
+++ b/packages/web/src/sentry.edge.config.ts
@@ -5,12 +5,16 @@
 
 import * as Sentry from "@sentry/nextjs";
 
+const isTracingEnabled = process.env.SENTRY_TRACING_ENABLED === 'true';
+
 if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT) {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
 
-        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
+        ...(isTracingEnabled ? {
+            tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
+        } : {}),
 
         // Setting this option to true will print useful information to the console while you're setting up Sentry.
         debug: false,

--- a/packages/web/src/sentry.server.config.ts
+++ b/packages/web/src/sentry.server.config.ts
@@ -7,19 +7,25 @@ import { nodeProfilingIntegration } from "@sentry/profiling-node";
 import { createLogger } from "@sourcebot/shared";
 
 const logger = createLogger('sentry-server-config');
+const isTracingEnabled = process.env.SENTRY_TRACING_ENABLED === 'true';
+const isProfilingEnabled = isTracingEnabled && process.env.SENTRY_PROFILING_ENABLED === 'true';
 
 if (!!process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN && !!process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT) {
     Sentry.init({
         dsn: process.env.NEXT_PUBLIC_SENTRY_WEBAPP_DSN,
         environment: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT,
-        integrations: [
-            nodeProfilingIntegration(),
-        ],
-        tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
-        // Evaluated once per `Sentry.init()`, i.e. once per server process.
-        profileSessionSampleRate: 1.0,
-        // Profile only while a sampled root span is active, rather than continuously.
-        profileLifecycle: 'trace',
+        ...(isTracingEnabled ? {
+            tracesSampleRate: process.env.NEXT_PUBLIC_SENTRY_ENVIRONMENT === 'development' ? 1.0 : 0.1,
+        } : {}),
+        ...(isProfilingEnabled ? {
+            integrations: [
+                nodeProfilingIntegration(),
+            ],
+            // Evaluated once per `Sentry.init()`, i.e. once per server process.
+            profileSessionSampleRate: 1.0,
+            // Profile only while a sampled root span is active, rather than continuously.
+            profileLifecycle: 'trace' as const,
+        } : {}),
     });
 } else {
     logger.debug("[server] Sentry was not initialized");


### PR DESCRIPTION
Fixes SOU-2011

## Summary
- make Sentry tracing opt-in for the Node and edge runtimes with `SENTRY_TRACING_ENABLED=true`
- make Node profiling opt-in with `SENTRY_PROFILING_ENABLED=true` and require tracing to be enabled
- document both environment variables in the development environment template

## Testing
- `yarn workspace @sourcebot/web eslint src/sentry.server.config.ts src/sentry.edge.config.ts`
- `yarn workspace @sourcebot/web build`
- `git diff --check`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Observability toggles only; default behavior reduces tracing/profiling overhead with no change to error reporting when Sentry is configured.
> 
> **Overview**
> Sentry **performance tracing** on the **Node server** and **edge** runtimes is now off unless `SENTRY_TRACING_ENABLED=true`. When tracing is disabled, `tracesSampleRate` is no longer passed to `Sentry.init` (previously it was always set with dev vs prod sampling).
> 
> **Server-side profiling** (`nodeProfilingIntegration`, session sampling, trace-linked lifecycle) is only registered when both tracing is enabled and `SENTRY_PROFILING_ENABLED=true`. Without those flags, Sentry still initializes for errors when DSN/env are set, but without trace or profile overhead.
> 
> `.env.development` documents the two new optional variables with defaults of `"false"`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3f6bd63d52781be09a6062f9553d5ba012271fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Improvements**
  - Improved error monitoring configuration with separate controls for tracing and performance profiling.
  - Performance profiling now activates only when tracing is enabled, helping prevent unnecessary monitoring overhead.
  - Monitoring sampling can now be adjusted by environment, supporting more targeted diagnostics across development and production.
- **Configuration**
  - Added optional development settings for enabling tracing and profiling when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->