### PR TITLE
chore: add agent notes column to CVE remediation run summary

### DIFF
--- a/.github/scripts/render-cve-remediation-summary.sh
+++ b/.github/scripts/render-cve-remediation-summary.sh
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Renders the CVE remediation results table for the workflow run summary.
+# Combines the issue metadata produced by the discovery job with the optional
+# per-issue notes written by the remediation agent. A note is looked up by the
+# issue's Linear identifier (SOU-123.md) or, as a fallback, its Linear UUID.
+#
+# Usage: render-cve-remediation-summary.sh <issues-json-file> <notes-directory>
+
+ISSUES_FILE="${1:?issues JSON file is required}"
+NOTES_DIR="${2:?notes directory is required}"
+
+MAX_NOTE_LENGTH=500
+
+escape_table_cell() {
+  printf '%s' "${1//|/\\|}"
+}
+
+echo '| Linear issue | Priority | Status | Title | Notes |'
+echo '| --- | ---: | --- | --- | --- |'
+
+while IFS= read -r issue; do
+  identifier=$(jq -r '.identifier' <<<"$issue")
+  id=$(jq -r '.id' <<<"$issue")
+  url=$(jq -r '.url' <<<"$issue")
+  priority=$(jq -r '.priority' <<<"$issue")
+  status=$(jq -r '.status' <<<"$issue")
+  title=$(jq -r '.title' <<<"$issue")
+
+  note=""
+  for note_key in "$identifier" "$id"; do
+    if [[ -z "$note_key" || "$note_key" == */* || "$note_key" == .* ]]; then
+      continue
+    fi
+    note_file="$NOTES_DIR/$note_key.md"
+    if [[ -f "$note_file" ]]; then
+      note=$(tr -s '[:space:]' ' ' < "$note_file")
+      note="${note# }"
+      note="${note% }"
+      break
+    fi
+  done
+  if (( ${#note} > MAX_NOTE_LENGTH )); then
+    note="${note:0:MAX_NOTE_LENGTH}…"
+  fi
+
+  printf '| [%s](%s) | %s | %s | %s | %s |\n' \
+    "$identifier" "$url" "$priority" "$status" \
+    "$(escape_table_cell "$title")" \
+    "$(escape_table_cell "$note")"
+done < <(jq -c '.[]' "$ISSUES_FILE")

--- a/.github/scripts/render-cve-remediation-summary.sh
+++ b/.github/scripts/render-cve-remediation-summary.sh
@@ -13,8 +13,14 @@ NOTES_DIR="${2:?notes directory is required}"
 
 MAX_NOTE_LENGTH=500
 
+if ! jq -e 'type == "array"' "$ISSUES_FILE" >/dev/null 2>&1; then
+  echo "issues file '$ISSUES_FILE' is missing or is not a JSON array" >&2
+  exit 1
+fi
+
 escape_table_cell() {
-  printf '%s' "${1//|/\\|}"
+  local escaped="${1//\\/\\\\}"
+  printf '%s' "${escaped//|/\\|}"
 }
 
 echo '| Linear issue | Priority | Status | Title | Notes |'

--- a/.github/scripts/test-cve-remediation.sh
+++ b/.github/scripts/test-cve-remediation.sh
@@ -4,6 +4,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 FILTER="$SCRIPT_DIR/filter-unlinked-cve-issues.jq"
 DISCOVERY_SCRIPT="$SCRIPT_DIR/find-unlinked-cve-issues.sh"
+RENDER_SCRIPT="$SCRIPT_DIR/render-cve-remediation-summary.sh"
 WORKFLOW_FILE="$SCRIPT_DIR/../workflows/_cve-remediation.yml"
 CALLER_WORKFLOW_FILE="$SCRIPT_DIR/../workflows/cve-remediation.yml"
 SYSTEM_PROMPT_FILE="$SCRIPT_DIR/../prompts/cve-remediation-system.md"
@@ -15,6 +16,19 @@ assert_json() {
   local expected="$3"
 
   if ! jq -e --argjson expected "$expected" '. == $expected' <<<"$actual" >/dev/null; then
+    echo "FAIL: $description"
+    echo "Expected: $expected"
+    echo "Actual:   $actual"
+    exit 1
+  fi
+}
+
+assert_equals() {
+  local description="$1"
+  local actual="$2"
+  local expected="$3"
+
+  if [[ "$actual" != "$expected" ]]; then
     echo "FAIL: $description"
     echo "Expected: $expected"
     echo "Actual:   $actual"
@@ -138,7 +152,9 @@ FAKE_CURL_DIR=$(mktemp -d)
 FAKE_CURL_COUNT=$(mktemp)
 FAKE_CURL_PAYLOAD_DIR=$(mktemp -d)
 FAKE_GH_LOG=$(mktemp)
-trap 'rm -rf "$FAKE_CURL_DIR" "$FAKE_CURL_PAYLOAD_DIR"; rm -f "$FAKE_CURL_COUNT" "$FAKE_GH_LOG"' EXIT
+RENDER_NOTES_DIR=$(mktemp -d)
+RENDER_ISSUES_FILE=$(mktemp)
+trap 'rm -rf "$FAKE_CURL_DIR" "$FAKE_CURL_PAYLOAD_DIR" "$RENDER_NOTES_DIR"; rm -f "$FAKE_CURL_COUNT" "$FAKE_GH_LOG" "$RENDER_ISSUES_FILE"' EXIT
 printf '0\n' > "$FAKE_CURL_COUNT"
 
 cat > "$FAKE_CURL_DIR/curl" <<'EOF'
@@ -325,6 +341,62 @@ assert_json \
   "$(jq -c '.variables.after' "$FAKE_CURL_PAYLOAD_DIR/3.json")" \
   '"next-page"'
 
+cat > "$RENDER_ISSUES_FILE" <<'EOF'
+[
+  {
+    "id": "issue-31",
+    "identifier": "SOU-31",
+    "title": "[sourcebot-dev/example] CVE-31: note keyed by identifier",
+    "url": "https://linear.app/sourcebot/issue/SOU-31/test",
+    "priority": 1,
+    "status": "Todo",
+    "statusType": "unstarted"
+  },
+  {
+    "id": "issue-32",
+    "identifier": "SOU-32",
+    "title": "[sourcebot-dev/example] CVE-32: pipe | in title",
+    "url": "https://linear.app/sourcebot/issue/SOU-32/test",
+    "priority": 2,
+    "status": "Backlog",
+    "statusType": "backlog"
+  },
+  {
+    "id": "issue-33",
+    "identifier": "SOU-33",
+    "title": "[sourcebot-dev/example] CVE-33: no note",
+    "url": "https://linear.app/sourcebot/issue/SOU-33/test",
+    "priority": 3,
+    "status": "Backlog",
+    "statusType": "backlog"
+  },
+  {
+    "id": "issue-34",
+    "identifier": "SOU-34",
+    "title": "[sourcebot-dev/example] CVE-34: note keyed by UUID",
+    "url": "https://linear.app/sourcebot/issue/SOU-34/test",
+    "priority": 4,
+    "status": "Backlog",
+    "statusType": "backlog"
+  }
+]
+EOF
+printf 'Opened PR #99 upgrading foo to 1.2.3.\n' > "$RENDER_NOTES_DIR/SOU-31.md"
+printf 'No patched | release exists yet;\nre-check tomorrow.\n' > "$RENDER_NOTES_DIR/SOU-32.md"
+printf 'Skipped: dependency already patched on main.\n' > "$RENDER_NOTES_DIR/issue-34.md"
+
+EXPECTED_SUMMARY='| Linear issue | Priority | Status | Title | Notes |
+| --- | ---: | --- | --- | --- |
+| [SOU-31](https://linear.app/sourcebot/issue/SOU-31/test) | 1 | Todo | [sourcebot-dev/example] CVE-31: note keyed by identifier | Opened PR #99 upgrading foo to 1.2.3. |
+| [SOU-32](https://linear.app/sourcebot/issue/SOU-32/test) | 2 | Backlog | [sourcebot-dev/example] CVE-32: pipe \| in title | No patched \| release exists yet; re-check tomorrow. |
+| [SOU-33](https://linear.app/sourcebot/issue/SOU-33/test) | 3 | Backlog | [sourcebot-dev/example] CVE-33: no note |  |
+| [SOU-34](https://linear.app/sourcebot/issue/SOU-34/test) | 4 | Backlog | [sourcebot-dev/example] CVE-34: note keyed by UUID | Skipped: dependency already patched on main. |'
+
+assert_equals \
+  "renders the results table with flattened, escaped agent notes" \
+  "$("$RENDER_SCRIPT" "$RENDER_ISSUES_FILE" "$RENDER_NOTES_DIR")" \
+  "$EXPECTED_SUMMARY"
+
 assert_json \
   "maps Linear on-call assignees to GitHub reviewers" \
   "$(jq -c . "$REVIEWER_MAP_FILE")" \
@@ -403,5 +475,21 @@ assert_workflow_not_contains \
   "does not use the unavailable inputs context in a reusable workflow call" \
   '${{ inputs.max_issues' \
   "$CALLER_WORKFLOW_FILE"
+assert_workflow_contains \
+  "hands issue metadata to the remediation job through an artifact" \
+  'name: cve-remediation-issues'
+assert_workflow_contains \
+  "prompts Claude with the notes location for the run summary" \
+  'cve-remediation-notes/<LINEAR-IDENTIFIER>.md'
+assert_workflow_contains \
+  "renders the remediation results table after the agent runs" \
+  '.cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh'
+assert_workflow_contains \
+  "reports remediation results even when the agent step fails" \
+  'if: always()'
+assert_workflow_contains \
+  "includes the agent notes column in the results table" \
+  '| Linear issue | Priority | Status | Title | Notes |' \
+  "$RENDER_SCRIPT"
 
 echo "All CVE remediation tests passed."

--- a/.github/scripts/test-cve-remediation.sh
+++ b/.github/scripts/test-cve-remediation.sh
@@ -509,8 +509,11 @@ assert_workflow_contains \
   "prompts Claude with the notes location for the run summary" \
   'cve-remediation-notes/<LINEAR-IDENTIFIER>.md'
 assert_workflow_contains \
-  "renders the remediation results table after the agent runs" \
-  '.cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh'
+  "snapshots the renderer before the agent can touch the checkout" \
+  'cp .cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh "$RUNNER_TEMP/render-cve-remediation-summary.sh"'
+assert_workflow_contains \
+  "renders the remediation results table from the pre-agent snapshot" \
+  '"$RUNNER_TEMP/render-cve-remediation-summary.sh" "$ISSUES_FILE" "$NOTES_DIR"'
 if ! grep -A1 -- '- name: Report remediation results' "$WORKFLOW_FILE" | grep -Fq 'if: always()'; then
   echo "FAIL: reports remediation results even when the agent step fails"
   echo "Expected the 'Report remediation results' step to run with 'if: always()'"

--- a/.github/scripts/test-cve-remediation.sh
+++ b/.github/scripts/test-cve-remediation.sh
@@ -514,6 +514,13 @@ assert_workflow_contains \
 assert_workflow_contains \
   "renders the remediation results table from the pre-agent snapshot" \
   '"$RUNNER_TEMP/render-cve-remediation-summary.sh" "$ISSUES_FILE" "$NOTES_DIR"'
+snapshot_line=$(grep -nF -- 'cp .cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh' "$WORKFLOW_FILE" | head -1 | cut -d: -f1)
+agent_line=$(grep -nF -- 'name: Run Claude CVE remediation agent' "$WORKFLOW_FILE" | head -1 | cut -d: -f1)
+if [[ -z "$snapshot_line" || -z "$agent_line" ]] || ((snapshot_line >= agent_line)); then
+  echo "FAIL: snapshots the renderer before the Claude agent step runs"
+  echo "Expected the renderer copy (line ${snapshot_line:-missing}) to precede the agent step (line ${agent_line:-missing})"
+  exit 1
+fi
 if ! grep -A1 -- '- name: Report remediation results' "$WORKFLOW_FILE" | grep -Fq 'if: always()'; then
   echo "FAIL: reports remediation results even when the agent step fails"
   echo "Expected the 'Report remediation results' step to run with 'if: always()'"

--- a/.github/scripts/test-cve-remediation.sh
+++ b/.github/scripts/test-cve-remediation.sh
@@ -378,24 +378,45 @@ cat > "$RENDER_ISSUES_FILE" <<'EOF'
     "priority": 4,
     "status": "Backlog",
     "statusType": "backlog"
+  },
+  {
+    "id": "issue-35",
+    "identifier": "SOU-35",
+    "title": "[sourcebot-dev/example] CVE-35: truncated long note",
+    "url": "https://linear.app/sourcebot/issue/SOU-35/test",
+    "priority": 5,
+    "status": "Backlog",
+    "statusType": "backlog"
   }
 ]
 EOF
 printf 'Opened PR #99 upgrading foo to 1.2.3.\n' > "$RENDER_NOTES_DIR/SOU-31.md"
-printf 'No patched | release exists yet;\nre-check tomorrow.\n' > "$RENDER_NOTES_DIR/SOU-32.md"
+cat > "$RENDER_NOTES_DIR/SOU-32.md" <<'EOF'
+No patched | release \| exists yet;
+re-check tomorrow.
+EOF
 printf 'Skipped: dependency already patched on main.\n' > "$RENDER_NOTES_DIR/issue-34.md"
+LONG_NOTE=$(printf 'a%.0s' $(seq 1 600))
+printf '%s\n' "$LONG_NOTE" > "$RENDER_NOTES_DIR/SOU-35.md"
 
 EXPECTED_SUMMARY='| Linear issue | Priority | Status | Title | Notes |
 | --- | ---: | --- | --- | --- |
 | [SOU-31](https://linear.app/sourcebot/issue/SOU-31/test) | 1 | Todo | [sourcebot-dev/example] CVE-31: note keyed by identifier | Opened PR #99 upgrading foo to 1.2.3. |
-| [SOU-32](https://linear.app/sourcebot/issue/SOU-32/test) | 2 | Backlog | [sourcebot-dev/example] CVE-32: pipe \| in title | No patched \| release exists yet; re-check tomorrow. |
+| [SOU-32](https://linear.app/sourcebot/issue/SOU-32/test) | 2 | Backlog | [sourcebot-dev/example] CVE-32: pipe \| in title | No patched \| release \\\| exists yet; re-check tomorrow. |
 | [SOU-33](https://linear.app/sourcebot/issue/SOU-33/test) | 3 | Backlog | [sourcebot-dev/example] CVE-33: no note |  |
 | [SOU-34](https://linear.app/sourcebot/issue/SOU-34/test) | 4 | Backlog | [sourcebot-dev/example] CVE-34: note keyed by UUID | Skipped: dependency already patched on main. |'
+EXPECTED_SUMMARY+="
+| [SOU-35](https://linear.app/sourcebot/issue/SOU-35/test) | 5 | Backlog | [sourcebot-dev/example] CVE-35: truncated long note | ${LONG_NOTE:0:500}… |"
 
 assert_equals \
-  "renders the results table with flattened, escaped agent notes" \
+  "renders the results table with flattened, escaped, truncated agent notes" \
   "$("$RENDER_SCRIPT" "$RENDER_ISSUES_FILE" "$RENDER_NOTES_DIR")" \
   "$EXPECTED_SUMMARY"
+
+if "$RENDER_SCRIPT" "$RENDER_NOTES_DIR/does-not-exist.json" "$RENDER_NOTES_DIR" >/dev/null 2>&1; then
+  echo "FAIL: fails loudly instead of rendering an empty table when the issues file is missing"
+  exit 1
+fi
 
 assert_json \
   "maps Linear on-call assignees to GitHub reviewers" \
@@ -479,14 +500,22 @@ assert_workflow_contains \
   "hands issue metadata to the remediation job through an artifact" \
   'name: cve-remediation-issues'
 assert_workflow_contains \
+  "uploads the issue metadata from the discovery job" \
+  'name: Upload issue metadata for the remediation summary'
+assert_workflow_contains \
+  "downloads the issue metadata in the remediation job" \
+  'name: Download issue metadata'
+assert_workflow_contains \
   "prompts Claude with the notes location for the run summary" \
   'cve-remediation-notes/<LINEAR-IDENTIFIER>.md'
 assert_workflow_contains \
   "renders the remediation results table after the agent runs" \
   '.cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh'
-assert_workflow_contains \
-  "reports remediation results even when the agent step fails" \
-  'if: always()'
+if ! grep -A1 -- '- name: Report remediation results' "$WORKFLOW_FILE" | grep -Fq 'if: always()'; then
+  echo "FAIL: reports remediation results even when the agent step fails"
+  echo "Expected the 'Report remediation results' step to run with 'if: always()'"
+  exit 1
+fi
 assert_workflow_contains \
   "includes the agent notes column in the results table" \
   '| Linear issue | Priority | Status | Title | Notes |' \

--- a/.github/workflows/_cve-remediation.yml
+++ b/.github/workflows/_cve-remediation.yml
@@ -67,6 +67,7 @@ jobs:
           issues=$(jq -c --argjson max "$MAX_ISSUES" '.[0:$max]' <<<"$all_issues")
           issue_ids=$(jq -c 'map(.id)' <<<"$issues")
           issue_count=$(jq 'length' <<<"$issues")
+          printf '%s\n' "$issues" > "$RUNNER_TEMP/cve-remediation-issues.json"
 
           if ((issue_count > 0)); then
             has_issues=true
@@ -93,11 +94,17 @@ jobs:
               echo "Claude was not started."
             else
               echo
-              echo '| Linear issue | Priority | Status | Title |'
-              echo '| --- | ---: | --- | --- |'
-              jq -r '.[] | "| [\(.identifier)](\(.url)) | \(.priority) | \(.status) | \(.title | gsub("\\|"; "\\\\|")) |"' <<<"$issues"
+              echo "The processed issues, along with any notes recorded by the agent, are listed in the remediation job summary."
             fi
           } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload issue metadata for the remediation summary
+        if: steps.discover.outputs.has_issues == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: cve-remediation-issues
+          path: ${{ runner.temp }}/cve-remediation-issues.json
+          retention-days: 7
 
   remediate:
     name: Remediate CVEs with Claude
@@ -124,8 +131,18 @@ jobs:
           sparse-checkout: |
             .github/prompts/cve-remediation-system.md
             .github/cve-reviewers.json
+            .github/scripts
           path: .cve-remediation-workflow
           persist-credentials: false
+
+      - name: Download issue metadata
+        uses: actions/download-artifact@v4
+        with:
+          name: cve-remediation-issues
+          path: ${{ runner.temp }}
+
+      - name: Prepare agent notes directory
+        run: mkdir -p "$RUNNER_TEMP/cve-remediation-notes"
 
       - name: Configure read-only Linear MCP
         env:
@@ -157,6 +174,8 @@ jobs:
             ${{ needs.discover.outputs.issue_ids }}
 
             This is an unattended run. Inspect every supplied issue through the read-only Linear MCP server, follow the system instructions, and open or update pull requests only for complete, verified remediations.
+
+            For each issue, you may optionally record a short note (one or two sentences) describing the outcome by writing it to `${{ runner.temp }}/cve-remediation-notes/<LINEAR-IDENTIFIER>.md` (for example, `SOU-123.md`). Notes are shown next to each issue in the workflow run summary. Leave a note whenever the outcome would otherwise be unclear, especially when you decide not to open or update a pull request.
           claude_args: |
             --append-system-prompt-file "${{ github.workspace }}/.cve-remediation-workflow/.github/prompts/cve-remediation-system.md"
             --strict-mcp-config
@@ -166,3 +185,16 @@ jobs:
             --tools "Bash,Read,Edit,Write,Glob,Grep"
             --allowedTools "Read,Edit,Write,Glob,Grep,Bash(git *),Bash(gh pr *),Bash(yarn *),Bash(npm *),Bash(npx *),Bash(pnpm *),Bash(bun *),Bash(go *),Bash(cargo *),Bash(uv *),Bash(pytest *),Bash(python -m pytest *),Bash(make *),Bash(just *),mcp__linear__get_issue,mcp__linear__list_comments"
             --disallowedTools "Bash(gh pr merge *),Bash(git push *--force*),Bash(npm publish *),Bash(yarn npm publish *),Bash(pnpm publish *),Bash(cargo publish *)"
+
+      - name: Report remediation results
+        if: always()
+        env:
+          ISSUES_FILE: ${{ runner.temp }}/cve-remediation-issues.json
+          NOTES_DIR: ${{ runner.temp }}/cve-remediation-notes
+        run: |
+          set -euo pipefail
+          {
+            echo "## CVE remediation results"
+            echo
+            .cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh "$ISSUES_FILE" "$NOTES_DIR"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/_cve-remediation.yml
+++ b/.github/workflows/_cve-remediation.yml
@@ -141,8 +141,11 @@ jobs:
           name: cve-remediation-issues
           path: ${{ runner.temp }}
 
-      - name: Prepare agent notes directory
-        run: mkdir -p "$RUNNER_TEMP/cve-remediation-notes"
+      - name: Prepare remediation summary inputs
+        run: |
+          set -euo pipefail
+          mkdir -p "$RUNNER_TEMP/cve-remediation-notes"
+          cp .cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh "$RUNNER_TEMP/render-cve-remediation-summary.sh"
 
       - name: Configure read-only Linear MCP
         env:
@@ -196,5 +199,5 @@ jobs:
           {
             echo "## CVE remediation results"
             echo
-            .cve-remediation-workflow/.github/scripts/render-cve-remediation-summary.sh "$ISSUES_FILE" "$NOTES_DIR"
+            "$RUNNER_TEMP/render-cve-remediation-summary.sh" "$ISSUES_FILE" "$NOTES_DIR"
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added a notes column to the nightly CVE remediation run summary that the agent can write per-issue outcome notes into. [#1620](https://github.com/sourcebot-dev/sourcebot/pull/1620)
+
 ## [5.1.10] - 2026-08-27
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Added
-- Added a notes column to the nightly CVE remediation run summary that the agent can write per-issue outcome notes into. [#1620](https://github.com/sourcebot-dev/sourcebot/pull/1620)
-
 ## [5.1.10] - 2026-08-27
 
 ### Fixed


### PR DESCRIPTION
## Problem

The nightly CVE remediation run summary only shows the table of discovered issues, rendered by the `discover` job **before** Claude runs. When the agent decides not to open a PR for an issue (as in the latest nightly run), nothing in the run summary explains what happened - the run is completely opaque.

## Changes

- **Moved the issue table to a post-agent step** in the `remediate` job (`if: always()`), and added a **Notes** column the agent can optionally populate. The `discover` job summary keeps the counts and now points at the remediation job summary for the table.
- **Notes mechanism**: the workflow creates `$RUNNER_TEMP/cve-remediation-notes/`, and the task prompt tells the agent it may write a short per-issue note to `<LINEAR-IDENTIFIER>.md` (UUID-named files work as a fallback), especially when it decides not to open or update a PR.
- **New `render-cve-remediation-summary.sh`** renders the results table from the discovered issue metadata plus the note files: notes are flattened to a single line, trimmed, truncated at 500 characters, and pipe-escaped; titles keep their existing pipe escaping.
- **Issue metadata is handed to the `remediate` job via an artifact** (`cve-remediation-issues`) instead of a job output, because identifiers contain the Linear team key and job outputs containing secret values are blocked by redaction (the existing `needs.discover.outputs.issues` guard in the tests still holds).
- **Tests**: `test-cve-remediation.sh` now functionally tests the renderer (identifier- and UUID-keyed notes, pipe/newline escaping, missing note) and asserts the workflow wiring (artifact handoff, notes prompt, `if: always()` reporting step, Notes column).

## Verification

- `.github/scripts/test-cve-remediation.sh` - all tests pass
- `.github/scripts/test-vulnerability-triage.sh` - all tests pass
- Both workflow files parse as valid YAML

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VsjLedntEDA6nHFmfYYHAQ

---
_Generated by [Claude Code](https://claude.ai/code/session_01VsjLedntEDA6nHFmfYYHAQ)_

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to GitHub Actions scripts and workflow reporting; they do not touch application runtime, auth, or data paths.
> 
> **Overview**
> The CVE remediation workflow **moves the issue table out of the discover job** and renders it **after the Claude agent runs**, so the run summary can reflect what actually happened—not just what was queued.
> 
> A new **`render-cve-remediation-summary.sh`** builds a Markdown table (Linear link, priority, status, title, **Notes**) from discovered issue JSON plus optional per-issue note files. Notes are looked up by Linear identifier or issue UUID, flattened to one line, truncated at 500 characters, and pipe-escaped. The discover job now only reports counts and points readers to the remediation job summary; it **uploads issue metadata as the `cve-remediation-issues` artifact** instead of passing rich metadata through job outputs (avoids secret redaction on identifiers).
> 
> The remediate job **downloads that artifact**, creates `cve-remediation-notes/`, **copies the renderer to `$RUNNER_TEMP` before the agent step**, and instructs Claude to write optional outcome notes to `<LINEAR-IDENTIFIER>.md`. A **`Report remediation results` step with `if: always()`** appends the table to the job summary even when the agent fails.
> 
> **`test-cve-remediation.sh`** adds functional tests for the renderer and workflow assertions for artifact handoff, notes prompt, snapshot ordering, and always-on reporting.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96897b220ec55a5dbc2a97e7de9ad9e7bbc4499c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
The CVE remediation run summary previously showed only the issues discovered before the agent ran, so skipped or unresolved outcomes were invisible. It now renders after the agent runs and includes an optional Notes column that records what happened for each issue.

- The issue table moved from the `discover` job summary to a post-agent reporting step in the `remediate` job that runs `if: always()`; the discover summary keeps only the counts and points to the new location.
- The agent can write a short per-issue note to `$RUNNER_TEMP/cve-remediation-notes/<LINEAR-IDENTIFIER>.md`, falling back to the issue's UUID.
- A new renderer script flattens note whitespace, truncates notes at 500 characters, pipe-escapes title and note cells, and fails loudly when the issues file is missing or malformed; it's copied to `$RUNNER_TEMP` before the agent starts so the agent can't modify or delete it.
- Issue metadata reaches the `remediate` job via artifact upload instead of a job output, because identifiers contain the Linear team key and would be blocked by secret redaction.
- Tests cover identifier- and UUID-keyed notes, pipe and backslash escaping, missing notes, note truncation, snapshot ordering before the agent step, and the workflow wiring.

<sup>Written for commit 96897b220ec55a5dbc2a97e7de9ad9e7bbc4499c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sourcebot-dev/sourcebot/pull/1620?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a remediation results summary to the CVE workflow with issue links, priorities, statuses, titles, and optional outcome notes.
  - Remediation agents can provide per-issue notes displayed in the final Markdown summary.
  - Results are reported even when remediation encounters an error.

- **Improvements**
  - Preserved discovered CVE issue details across workflow stages for reliable reporting.
  - Added validation, truncation, and safe formatting for notes and special characters.
  - Improved handling of missing or invalid remediation inputs.
  - Added temporary artifact storage to support consistent results reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->