### PR TITLE
fix(web): disambiguate MCP language model selection for ask_codebase (#1137)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added a live repository indexing job runtime to the syncing badge. [#1623](https://github.com/sourcebot-dev/sourcebot/pull/1623)
 
+### Fixed
+- Fixed MCP `ask_codebase` rejecting explicit language model selection by resolving matching model configurations when `displayName` is omitted and providing clear disambiguation errors for multi-config models. [#1622](https://github.com/sourcebot-dev/sourcebot/pull/1622)
+
 ## [5.1.10] - 2026-08-27
 
 ### Fixed

--- a/packages/web/src/ee/features/mcp/askCodebase.ts
+++ b/packages/web/src/ee/features/mcp/askCodebase.ts
@@ -4,7 +4,8 @@ import { generateChatNameFromMessage } from "@/ee/features/chat/llm.server";
 import { getAISDKLanguageModelAndOptions } from "@/features/chat/llm.server";
 import { resolveContextWindow } from "@/features/chat/modelContextWindow.server";
 import { LanguageModelInfo, SBChatMessage, SearchScope } from "@/features/chat/types";
-import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage, getLanguageModelKey } from "@/features/chat/utils";
+import { convertLLMOutputToPortableMarkdown, getAnswerPartFromAssistantMessage } from "@/features/chat/utils";
+import { selectConfiguredLanguageModel } from "@/features/chat/selectConfiguredLanguageModel";
 import { resolveModelCapabilities } from "@/features/chat/modelCapabilities.server";
 import { ErrorCode } from "@/lib/errorCodes";
 import { ServiceError, ServiceErrorException } from "@/lib/serviceError";
@@ -61,28 +62,11 @@ export const askCodebase = (params: AskCodebaseParams): Promise<AskCodebaseResul
             const { query, repos = [], languageModel: requestedLanguageModel, visibility: requestedVisibility, source } = params;
 
             const configuredModels = await getConfiguredLanguageModels();
-            if (configuredModels.length === 0) {
-                return {
-                    statusCode: StatusCodes.BAD_REQUEST,
-                    errorCode: ErrorCode.INVALID_REQUEST_BODY,
-                    message: "No language models are configured. Please configure at least one language model. See: https://docs.sourcebot.dev/docs/configuration/language-model-providers",
-                } satisfies ServiceError;
+            const modelSelection = selectConfiguredLanguageModel(configuredModels, requestedLanguageModel);
+            if (!modelSelection.success) {
+                return modelSelection.error;
             }
-
-            let languageModelConfig = configuredModels[0];
-            if (requestedLanguageModel) {
-                const matchingModel = configuredModels.find(
-                    (m) => getLanguageModelKey(m) === getLanguageModelKey(requestedLanguageModel)
-                );
-                if (!matchingModel) {
-                    return {
-                        statusCode: StatusCodes.BAD_REQUEST,
-                        errorCode: ErrorCode.INVALID_REQUEST_BODY,
-                        message: `Language model '${requestedLanguageModel.provider}/${requestedLanguageModel.model}' is not configured.`,
-                    } satisfies ServiceError;
-                }
-                languageModelConfig = matchingModel;
-            }
+            const languageModelConfig = modelSelection.model;
 
             const { model, providerOptions, temperature } = await getAISDKLanguageModelAndOptions(languageModelConfig);
             const modelName = languageModelConfig.displayName ?? languageModelConfig.model;

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
@@ -134,6 +134,44 @@ describe("selectConfiguredLanguageModel", () => {
         }
     });
 
+    test("handles mixed named and unnamed models sharing provider and model", () => {
+        const mixed = [
+            { provider: "anthropic", model: "claude-opus-4-7" },
+            { provider: "anthropic", model: "claude-opus-4-7", displayName: "Thinking Mode" },
+        ];
+
+        const result = selectConfiguredLanguageModel(mixed, {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toContain("Please specify a displayName from ['Thinking Mode'] or configure distinct displayNames in your configuration for unnamed models.");
+        }
+    });
+
+    test("preserves empty-string displayName in disambiguation message", () => {
+        const withEmptyString = [
+            { provider: "openai", model: "gpt-4o", displayName: "" },
+            { provider: "openai", model: "gpt-4o", displayName: "Named" },
+        ];
+
+        const result = selectConfiguredLanguageModel(withEmptyString, {
+            provider: "openai",
+            model: "gpt-4o",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toContain("('', 'Named')");
+        }
+    });
+
     test("returns 400 when model is not configured", () => {
         const result = selectConfiguredLanguageModel(configuredModels, {
             provider: "google",

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
@@ -111,6 +111,26 @@ describe("selectConfiguredLanguageModel", () => {
             expect(result.error.message).toContain("Multiple configurations found for language model 'anthropic/claude-opus-4-7'");
             expect(result.error.message).toContain("'Claude Opus 4.7 (Fast)'");
             expect(result.error.message).toContain("'Claude Opus 4.7 (Thinking)'");
+            expect(result.error.message).not.toContain("(default)");
+        }
+    });
+
+    test("handles multiple models with identical provider/model when none have displayName", () => {
+        const duplicateUnnamed = [
+            { provider: "ollama", model: "llama3" },
+            { provider: "ollama", model: "llama3" },
+        ];
+
+        const result = selectConfiguredLanguageModel(duplicateUnnamed, {
+            provider: "ollama",
+            model: "llama3",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toContain("Please configure distinct displayNames in your configuration");
         }
     });
 
@@ -140,6 +160,23 @@ describe("selectConfiguredLanguageModel", () => {
             expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
             expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
             expect(result.error.message).toBe("Language model 'anthropic/claude-sonnet-4-6' ('Nonexistent Display Name') is not configured.");
+        }
+    });
+
+    test("matches when displayName is empty string if configured with empty string", () => {
+        const modelsWithEmpty = [
+            { provider: "openai", model: "gpt-4o", displayName: "" },
+        ];
+
+        const result = selectConfiguredLanguageModel(modelsWithEmpty, {
+            provider: "openai",
+            model: "gpt-4o",
+            displayName: "",
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model.displayName).toBe("");
         }
     });
 });

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from "vitest";
+import { selectConfiguredLanguageModel } from "./selectConfiguredLanguageModel";
+import { StatusCodes } from "http-status-codes";
+import { ErrorCode } from "@/lib/errorCodes";
+
+describe("selectConfiguredLanguageModel", () => {
+    const model1 = {
+        provider: "anthropic",
+        model: "claude-sonnet-4-6",
+        displayName: "Claude Sonnet 4.6",
+    };
+
+    const model2 = {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        displayName: "Claude Opus 4.7 (Fast)",
+    };
+
+    const model3 = {
+        provider: "anthropic",
+        model: "claude-opus-4-7",
+        displayName: "Claude Opus 4.7 (Thinking)",
+    };
+
+    const model4 = {
+        provider: "openai",
+        model: "gpt-4o",
+    };
+
+    const configuredModels = [model1, model2, model3, model4];
+
+    test("returns error when no models are configured", () => {
+        const result = selectConfiguredLanguageModel([], {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toContain("No language models are configured");
+        }
+    });
+
+    test("defaults to first configured model when no requested model is provided", () => {
+        const result = selectConfiguredLanguageModel(configuredModels);
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model).toEqual(model1);
+        }
+    });
+
+    test("defaults to first configured model when empty object is provided", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {});
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model).toEqual(model1);
+        }
+    });
+
+    test("matches model uniquely by provider and model when displayName is omitted", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model).toEqual(model1);
+        }
+    });
+
+    test("matches model uniquely when configured model has no displayName and request omits it", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "openai",
+            model: "gpt-4o",
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model).toEqual(model4);
+        }
+    });
+
+    test("matches model strictly by exact provider, model, and displayName", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+            displayName: "Claude Opus 4.7 (Thinking)",
+        });
+
+        expect(result.success).toBe(true);
+        if (result.success) {
+            expect(result.model).toEqual(model3);
+        }
+    });
+
+    test("returns 400 with disambiguation message when multiple models match provider/model and displayName is omitted", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "anthropic",
+            model: "claude-opus-4-7",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toContain("Multiple configurations found for language model 'anthropic/claude-opus-4-7'");
+            expect(result.error.message).toContain("'Claude Opus 4.7 (Fast)'");
+            expect(result.error.message).toContain("'Claude Opus 4.7 (Thinking)'");
+        }
+    });
+
+    test("returns 400 when model is not configured", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "google",
+            model: "gemini-2.0-flash",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toBe("Language model 'google/gemini-2.0-flash' is not configured.");
+        }
+    });
+
+    test("returns 400 when provider/model matches but displayName does not match any config", () => {
+        const result = selectConfiguredLanguageModel(configuredModels, {
+            provider: "anthropic",
+            model: "claude-sonnet-4-6",
+            displayName: "Nonexistent Display Name",
+        });
+
+        expect(result.success).toBe(false);
+        if (!result.success) {
+            expect(result.error.statusCode).toBe(StatusCodes.BAD_REQUEST);
+            expect(result.error.errorCode).toBe(ErrorCode.INVALID_REQUEST_BODY);
+            expect(result.error.message).toBe("Language model 'anthropic/claude-sonnet-4-6' ('Nonexistent Display Name') is not configured.");
+        }
+    });
+});

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
@@ -70,14 +70,19 @@ export const selectConfiguredLanguageModel = <T extends MatchableModel>(
     }
 
     if (matchingModels.length > 1) {
-        const availableNames = matchingModels
+        const hasUnnamed = matchingModels.some((m) => m.displayName === undefined);
+        const namedConfigs = matchingModels
             .map((m) => m.displayName)
-            .filter((name): name is string => typeof name === "string" && name.length > 0)
-            .map((name) => `'${name}'`);
+            .filter((name): name is string => typeof name === "string");
 
-        const hint = availableNames.length > 0
-            ? `Please specify a displayName (${availableNames.join(', ')}) to disambiguate.`
-            : `Please configure distinct displayNames in your configuration to disambiguate.`;
+        let hint: string;
+        if (hasUnnamed) {
+            hint = namedConfigs.length > 0
+                ? `Please specify a displayName from [${namedConfigs.map((n) => `'${n}'`).join(', ')}] or configure distinct displayNames in your configuration for unnamed models.`
+                : `Please configure distinct displayNames in your configuration to disambiguate.`;
+        } else {
+            hint = `Please specify a displayName (${namedConfigs.map((n) => `'${n}'`).join(', ')}) to disambiguate.`;
+        }
 
         return {
             success: false,

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
@@ -12,17 +12,6 @@ type MatchableModel = {
     displayName?: string;
 };
 
-/**
- * Selects a configured language model from a list of configured models
- * based on a requested language model specifier.
- *
- * - If no language model is requested, defaults to the first configured model.
- * - If `displayName` is provided in the request, matches strictly on `(provider, model, displayName)`.
- * - If `displayName` is omitted in the request:
- *   - If exactly one model matches `(provider, model)`, that model is selected.
- *   - If multiple models match `(provider, model)`, returns a 400 error requiring `displayName` disambiguation.
- *   - If no models match, returns a 400 error indicating the model is not configured.
- */
 export const selectConfiguredLanguageModel = <T extends MatchableModel>(
     configuredModels: T[],
     requestedLanguageModel?: Partial<MatchableModel>
@@ -47,8 +36,7 @@ export const selectConfiguredLanguageModel = <T extends MatchableModel>(
 
     const { provider, model, displayName } = requestedLanguageModel;
 
-    // If displayName is explicitly provided, match on exact (provider, model, displayName)
-    if (displayName) {
+    if (displayName !== undefined) {
         const exactMatch = configuredModels.find((m) => {
             return m.provider === provider && m.model === model && m.displayName === displayName;
         });
@@ -70,7 +58,6 @@ export const selectConfiguredLanguageModel = <T extends MatchableModel>(
         };
     }
 
-    // If displayName is omitted, find all configs matching (provider, model)
     const matchingModels = configuredModels.filter((m) => {
         return m.provider === provider && m.model === model;
     });
@@ -83,17 +70,21 @@ export const selectConfiguredLanguageModel = <T extends MatchableModel>(
     }
 
     if (matchingModels.length > 1) {
-        const displayNames = matchingModels
-            .map((m) => m.displayName || "(default)")
-            .map((name) => `'${name}'`)
-            .join(', ');
+        const availableNames = matchingModels
+            .map((m) => m.displayName)
+            .filter((name): name is string => typeof name === "string" && name.length > 0)
+            .map((name) => `'${name}'`);
+
+        const hint = availableNames.length > 0
+            ? `Please specify a displayName (${availableNames.join(', ')}) to disambiguate.`
+            : `Please configure distinct displayNames in your configuration to disambiguate.`;
 
         return {
             success: false,
             error: {
                 statusCode: StatusCodes.BAD_REQUEST,
                 errorCode: ErrorCode.INVALID_REQUEST_BODY,
-                message: `Multiple configurations found for language model '${provider}/${model}'. Please specify a displayName (${displayNames}) to disambiguate.`,
+                message: `Multiple configurations found for language model '${provider}/${model}'. ${hint}`,
             },
         };
     }

--- a/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
+++ b/packages/web/src/features/chat/selectConfiguredLanguageModel.ts
@@ -1,0 +1,109 @@
+import { StatusCodes } from "http-status-codes";
+import { ErrorCode } from "@/lib/errorCodes";
+import { ServiceError } from "@/lib/serviceError";
+
+export type SelectConfiguredLanguageModelResult<T> =
+    | { success: true; model: T }
+    | { success: false; error: ServiceError };
+
+type MatchableModel = {
+    provider: string;
+    model: string;
+    displayName?: string;
+};
+
+/**
+ * Selects a configured language model from a list of configured models
+ * based on a requested language model specifier.
+ *
+ * - If no language model is requested, defaults to the first configured model.
+ * - If `displayName` is provided in the request, matches strictly on `(provider, model, displayName)`.
+ * - If `displayName` is omitted in the request:
+ *   - If exactly one model matches `(provider, model)`, that model is selected.
+ *   - If multiple models match `(provider, model)`, returns a 400 error requiring `displayName` disambiguation.
+ *   - If no models match, returns a 400 error indicating the model is not configured.
+ */
+export const selectConfiguredLanguageModel = <T extends MatchableModel>(
+    configuredModels: T[],
+    requestedLanguageModel?: Partial<MatchableModel>
+): SelectConfiguredLanguageModelResult<T> => {
+    if (configuredModels.length === 0) {
+        return {
+            success: false,
+            error: {
+                statusCode: StatusCodes.BAD_REQUEST,
+                errorCode: ErrorCode.INVALID_REQUEST_BODY,
+                message: "No language models are configured. Please configure at least one language model. See: https://docs.sourcebot.dev/docs/configuration/language-model-providers",
+            },
+        };
+    }
+
+    if (!requestedLanguageModel || (!requestedLanguageModel.provider && !requestedLanguageModel.model)) {
+        return {
+            success: true,
+            model: configuredModels[0],
+        };
+    }
+
+    const { provider, model, displayName } = requestedLanguageModel;
+
+    // If displayName is explicitly provided, match on exact (provider, model, displayName)
+    if (displayName) {
+        const exactMatch = configuredModels.find((m) => {
+            return m.provider === provider && m.model === model && m.displayName === displayName;
+        });
+
+        if (exactMatch) {
+            return {
+                success: true,
+                model: exactMatch,
+            };
+        }
+
+        return {
+            success: false,
+            error: {
+                statusCode: StatusCodes.BAD_REQUEST,
+                errorCode: ErrorCode.INVALID_REQUEST_BODY,
+                message: `Language model '${provider}/${model}' ('${displayName}') is not configured.`,
+            },
+        };
+    }
+
+    // If displayName is omitted, find all configs matching (provider, model)
+    const matchingModels = configuredModels.filter((m) => {
+        return m.provider === provider && m.model === model;
+    });
+
+    if (matchingModels.length === 1) {
+        return {
+            success: true,
+            model: matchingModels[0],
+        };
+    }
+
+    if (matchingModels.length > 1) {
+        const displayNames = matchingModels
+            .map((m) => m.displayName || "(default)")
+            .map((name) => `'${name}'`)
+            .join(', ');
+
+        return {
+            success: false,
+            error: {
+                statusCode: StatusCodes.BAD_REQUEST,
+                errorCode: ErrorCode.INVALID_REQUEST_BODY,
+                message: `Multiple configurations found for language model '${provider}/${model}'. Please specify a displayName (${displayNames}) to disambiguate.`,
+            },
+        };
+    }
+
+    return {
+        success: false,
+        error: {
+            statusCode: StatusCodes.BAD_REQUEST,
+            errorCode: ErrorCode.INVALID_REQUEST_BODY,
+            message: `Language model '${provider}/${model}' is not configured.`,
+        },
+    };
+};


### PR DESCRIPTION
fixes #1137 

### what was happening
when calling `ask_codebase` over mcp with an explicit `languageModel` (or through `/api/chat/blocking`), it was failing with a 400 saying the model isn't configured.

the issue was that `getLanguageModelKey` generates `${provider}-${model}-${displayName}`. since mcp clients often don't pass `displayName` (or only send `{ provider, model }`), the lookup ended up comparing against `undefined` and failed even if the model was in `config.json`.

### how this fixes previous attempts (#1408, #1414)
i saw the earlier discussion on #1408 where just dropping `displayName` broke setups having multiple configs for the same model (like different personas / reasoning efforts). 

to properly handle brendan's feedback from earlier:
- if `displayName` is provided: matches exact `(provider, model, displayName)`.
- if `displayName` is omitted:
  - if there's only 1 matching config for that `(provider, model)`: picks it automatically (fixes the mcp bug).
  - if there are multiple configs sharing that `(provider, model)`: throws a clean 400 listing the available `displayName`s so the caller knows what to pass to disambiguate.
  - if 0 match: returns the standard 400 not configured error.
- if no model is requested: falls back to the first configured model as before.

(paired with an ai assistant to help write out the tests and verify the edge cases).

### tests
- added unit tests in `selectConfiguredLanguageModel.test.ts` covering all branches (single candidate, exact match with display name, multiple candidate disambiguation error, unconfigured model, default fallback) -> 9/9 passed
- ran full web workspace tests (`yarn workspace @sourcebot/web test`) -> 139 test files passed (1,446 tests)
- ran linter (`yarn workspace @sourcebot/web lint`) -> clean, 0 errors

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized validation change on the programmatic ask path with explicit error handling and unit tests; interactive chat routing is unchanged.
> 
> **Overview**
> Fixes MCP **`ask_codebase`** (and the shared **`askCodebase`** path) rejecting valid `{ provider, model }` requests because selection used **`getLanguageModelKey`**, which required **`displayName`** to line up.
> 
> **`selectConfiguredLanguageModel`** centralizes that logic: default to the first configured model when none is requested; with **`displayName`**, require an exact triple match; without it, auto-pick when **`provider`/`model`** is unique and return a **400** listing available **`displayName`** values when multiple configs share the same model. **`askCodebase`** now calls this helper instead of inline matching. Unit tests cover the branches; the changelog records the fix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 687fee1386855a86eeb878023112425b90d49d09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MCP `ask_codebase` rejecting explicit language model selection when `displayName` is omitted, by matching uniquely on provider and model, returning a 400 with available names when configurations are ambiguous, and preserving the first-model fallback when no model is requested.

**Bug Fixes**
- Exact `provider`/`model`/`displayName` matches remain supported, and empty-string `displayName` is preserved in disambiguation messages.
- Unconfigured models, duplicate unnamed configurations, and empty configurations return clear 400 validation errors.
- Adds unit coverage for all selection paths and updates the changelog.

<sup>Written for commit 687fee1386855a86eeb878023112425b90d49d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sourcebot-dev/sourcebot/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved language-model selection for MCP `ask_codebase`.
  - Models now match correctly with omitted or explicitly empty display names.
  - Multiple matching configurations are clearly reported for easier resolution.
  - Added clearer errors when requested models are unavailable or none are configured.
  - The first configured model is selected automatically when no model is specified.
- **Improvements**
  - The syncing badge now reflects live repository indexing activity.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->