### PR TITLE
fix(auth): preserve intended URL through login redirects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- Preserved search and Ask URLs through login redirects. [#1650](https://github.com/sourcebot-dev/sourcebot/pull/1650)
+
 ## [5.1.12] - 2026-09-10
 
 ### Changed

--- a/packages/web/src/app/(app)/chat/components/shareChatPopover/shareSettings.tsx
+++ b/packages/web/src/app/(app)/chat/components/shareChatPopover/shareSettings.tsx
@@ -17,7 +17,8 @@ import { ChatVisibility } from "@sourcebot/db";
 import { Tooltip, TooltipContent, TooltipTrigger } from "@/components/ui/tooltip";
 import { Info, Link2Icon, Loader2, Lock, X } from "lucide-react";
 import Link from "next/link";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
+import { createLoginUrl } from "@/lib/authRedirect";
 import { useCallback, useState } from "react";
 import { captureEvent } from "@/hooks/useCaptureEvent";
 
@@ -48,6 +49,8 @@ export const ShareSettings = ({
     const [removingUserIds, setRemovingUserIds] = useState<Set<string>>(new Set());
     const { toast } = useToast();
     const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const loginHref = createLoginUrl(`${pathname}?${searchParams.toString()}`);
     const isAuthenticated = !!currentUser;
 
     const handleCopyLink = useCallback(async () => {
@@ -217,7 +220,7 @@ export const ShareSettings = ({
             </Select>
             {!isAuthenticated && (
                 <p className="text-xs text-muted-foreground mt-2">
-                    <Link href={`/login?callbackUrl=${encodeURIComponent(pathname)}`} className="underline">Sign in</Link> to change chat visibility.
+                    <Link href={loginHref} className="underline">Sign in</Link> to change chat visibility.
                 </p>
             )}
             <Separator className="-mx-4 w-auto my-4" />

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -38,6 +38,7 @@ import { getConfiguredLanguageModelsInfo } from "@/features/chat/utils.server";
 import { NavigationGuardProvider } from "next-navigation-guard";
 import { getRepositorySyncCounts } from "@/features/repos/repositorySyncCounts.server";
 import { getConnectionSyncCounts } from "@/features/connections/connectionSyncCounts.server";
+import { createLoginUrl, normalizeCallbackUrl, REQUEST_PATH_HEADER } from "@/lib/authRedirect";
 
 interface LayoutProps {
     children: React.ReactNode;
@@ -60,6 +61,7 @@ export default async function Layout(props: LayoutProps) {
 
     const session = await auth();
     const anonymousAccessEnabled = await isAnonymousAccessEnabled();
+    const requestHeaders = await headers();
 
     let role: OrgRole | null = null;
 
@@ -111,9 +113,9 @@ export default async function Layout(props: LayoutProps) {
         if (!anonymousAccessEnabled) {
             const ssoEntitlement = await hasEntitlement("sso");
             if (ssoEntitlement && env.AUTH_EE_GCP_IAP_ENABLED && env.AUTH_EE_GCP_IAP_AUDIENCE) {
-                return <GcpIapAuth callbackUrl="/" />;
+                return <GcpIapAuth callbackUrl={normalizeCallbackUrl(requestHeaders.get(REQUEST_PATH_HEADER))} />;
             } else {
-                redirect('/login');
+                redirect(createLoginUrl(requestHeaders.get(REQUEST_PATH_HEADER)));
             }
         }
     }
@@ -144,16 +146,18 @@ export default async function Layout(props: LayoutProps) {
                 return (
                     <div className="min-h-screen flex items-center justify-center p-6">
                         <LogoutEscapeHatch className="absolute top-0 right-0 p-6" />
-                        <ConnectAccountsCard linkedAccounts={linkedAccounts} callbackUrl="/" />
+                        <ConnectAccountsCard
+                            linkedAccounts={linkedAccounts}
+                            callbackUrl={normalizeCallbackUrl(requestHeaders.get(REQUEST_PATH_HEADER))}
+                        />
                     </div>
                 )
             }
         }
     }
 
-    const headersList = await headers();
     const cookieStore = await cookies()
-    const userAgent = headersList.get('user-agent');
+    const userAgent = requestHeaders.get('user-agent');
     const { isMobile } = userAgent ? getSelectorsByUserAgent(userAgent) : { isMobile: false };
 
     if (isMobile && !cookieStore.has(MOBILE_UNSUPPORTED_SPLASH_SCREEN_DISMISSED_COOKIE_NAME)) {

--- a/packages/web/src/app/components/authMethodSelector.tsx
+++ b/packages/web/src/app/components/authMethodSelector.tsx
@@ -10,6 +10,7 @@ import { ProviderButton } from "@/app/components/providerButton";
 import { AuthSecurityNotice } from "@/app/components/authSecurityNotice";
 import Link from "next/link";
 import { useIdentityProviders } from "@/features/auth/useIdentityProviders";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
 interface AuthMethodSelectorProps {
     callbackUrl?: string;
@@ -27,6 +28,7 @@ export const AuthMethodSelector = ({
     hideSecurityNotice = false
 }: AuthMethodSelectorProps) => {
     const providers = useIdentityProviders();
+    const safeCallbackUrl = normalizeCallbackUrl(callbackUrl);
 
     const onSignInWithOauth = useCallback((provider: string) => {
         // Call the optional analytics callback first
@@ -35,10 +37,10 @@ export const AuthMethodSelector = ({
         signIn(
             provider,
             {
-                redirectTo: callbackUrl ?? "/",
+                redirectTo: safeCallbackUrl,
             }
         );
-    }, [callbackUrl, onProviderClick]);
+    }, [onProviderClick, safeCallbackUrl]);
 
     // Separate OAuth providers from special auth methods
     const oauthProviders = providers.filter(p => p.purpose === "sso" &&
@@ -80,13 +82,13 @@ export const AuthMethodSelector = ({
                         </div>
                     ] : []),
                     ...(hasMagicLink ? [
-                        <MagicLinkForm key="magic-link" callbackUrl={callbackUrl} context={context} />
+                        <MagicLinkForm key="magic-link" callbackUrl={safeCallbackUrl} context={context} />
                     ] : []),
                     ...(hasCredentials ? [
-                        <CredentialsForm key="credentials" callbackUrl={callbackUrl} context={context} />
+                        <CredentialsForm key="credentials" callbackUrl={safeCallbackUrl} context={context} />
                     ] : [])
                 ]}
             />
         </>
     );
-}; 
+};

--- a/packages/web/src/app/login/components/loginForm.tsx
+++ b/packages/web/src/app/login/components/loginForm.tsx
@@ -7,6 +7,7 @@ import { AuthMethodSelector } from "@/app/components/authMethodSelector";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useIdentityProviders } from "@/features/auth/useIdentityProviders";
 import Link from "next/link";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
 interface LoginFormProps {
     callbackUrl?: string;
@@ -20,14 +21,7 @@ export const LoginForm = ({ callbackUrl, error, context, isAnonymousAccessEnable
     const captureEvent = useCaptureEvent();
     const providers = useIdentityProviders();
 
-    const safeCallbackUrl = useMemo(() => {
-        if (!callbackUrl) return "/";
-        // Allow only relative paths that start with "/" but not "//" (protocol-relative URLs)
-        if (callbackUrl.startsWith("/") && !callbackUrl.startsWith("//")) {
-            return callbackUrl;
-        }
-        return "/";
-    }, [callbackUrl]);
+    const safeCallbackUrl = useMemo(() => normalizeCallbackUrl(callbackUrl), [callbackUrl]);
 
     const errorMessage = useMemo(() => {
         if (!error) {
@@ -90,7 +84,7 @@ export const LoginForm = ({ callbackUrl, error, context, isAnonymousAccessEnable
                     </div>
                 )}
                 <AuthMethodSelector
-                    callbackUrl={callbackUrl}
+                    callbackUrl={safeCallbackUrl}
                     context={context}
                     onProviderClick={handleProviderClick}
                     securityNoticeClosable={true}
@@ -99,11 +93,11 @@ export const LoginForm = ({ callbackUrl, error, context, isAnonymousAccessEnable
                 <p className="text-sm text-muted-foreground mt-8">
                     {context === "login" ?
                         <>
-                            Don&apos;t have an account? <Link className="underline" href={callbackUrl ? `/signup?callbackUrl=${encodeURIComponent(callbackUrl)}` : "/signup"}>Sign up</Link>
+                            Don&apos;t have an account? <Link className="underline" href={`/signup?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`}>Sign up</Link>
                         </>
                     :
                         <>
-                            Already have an account? <Link className="underline" href={callbackUrl ? `/login?callbackUrl=${encodeURIComponent(callbackUrl)}` : "/login"}>Sign in</Link>
+                            Already have an account? <Link className="underline" href={`/login?callbackUrl=${encodeURIComponent(safeCallbackUrl)}`}>Sign in</Link>
                         </>
                     }
                 </p>

--- a/packages/web/src/app/login/components/magicLinkForm.tsx
+++ b/packages/web/src/app/login/components/magicLinkForm.tsx
@@ -11,6 +11,7 @@ import { useState } from "react";
 import { Loader2 } from "lucide-react";
 import useCaptureEvent from "@/hooks/useCaptureEvent";
 import { useRouter } from "next/navigation";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
 const magicLinkSchema = z.object({
     email: z.string().email(),
@@ -25,6 +26,7 @@ export const MagicLinkForm = ({ callbackUrl, context }: MagicLinkFormProps) => {
     const captureEvent = useCaptureEvent();
     const [isLoading, setIsLoading] = useState(false);
     const router = useRouter();
+    const safeCallbackUrl = normalizeCallbackUrl(callbackUrl);
 
     const magicLinkForm = useForm<z.infer<typeof magicLinkSchema>>({
         resolver: zodResolver(magicLinkSchema),
@@ -37,11 +39,11 @@ export const MagicLinkForm = ({ callbackUrl, context }: MagicLinkFormProps) => {
         setIsLoading(true);
         captureEvent("wa_login_with_magic_link", {});
 
-        signIn("nodemailer", { email: values.email, redirect: false, redirectTo: callbackUrl ?? "/" })
+        signIn("nodemailer", { email: values.email, redirect: false, redirectTo: safeCallbackUrl })
             .then(() => {
                 setIsLoading(false);
 
-                router.push("/login/verify?email=" + encodeURIComponent(values.email));
+                router.push(`/login/verify?email=${encodeURIComponent(values.email)}&callbackUrl=${encodeURIComponent(safeCallbackUrl)}`);
             })
             .catch((error) => {
                 console.error("Error signing in", error);

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -6,6 +6,7 @@ import { SINGLE_TENANT_ORG_ID } from "@/lib/constants";
 import { __unsafePrisma } from "@/prisma";
 import { env } from "@sourcebot/shared";
 import { isAnonymousAccessEnabled } from "@/lib/entitlements";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
 interface LoginProps {
     searchParams: Promise<{
@@ -16,9 +17,10 @@ interface LoginProps {
 
 export default async function Login(props: LoginProps) {
     const searchParams = await props.searchParams;
+    const callbackUrl = normalizeCallbackUrl(searchParams.callbackUrl);
     const session = await auth();
     if (session) {
-        return redirect("/");
+        return redirect(callbackUrl);
     }
 
     const org = await __unsafePrisma.org.findUnique({ where: { id: SINGLE_TENANT_ORG_ID } });
@@ -32,7 +34,7 @@ export default async function Login(props: LoginProps) {
         <div className="flex flex-col min-h-screen bg-backgroundSecondary">
             <div className="flex-1 flex flex-col items-center p-4 sm:p-12 w-full">
                 <LoginForm
-                    callbackUrl={searchParams.callbackUrl}
+                    callbackUrl={callbackUrl}
                     error={searchParams.error}
                     context="login"
                     isAnonymousAccessEnabled={anonymousAccessEnabled}

--- a/packages/web/src/app/login/verify/page.tsx
+++ b/packages/web/src/app/login/verify/page.tsx
@@ -1,11 +1,20 @@
 import { auth } from "@/auth";
 import { redirect } from "next/navigation";
 import { VerifyForm } from "./verifyForm";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
-export default async function VerifyPage() {
+interface VerifyPageProps {
+    searchParams: Promise<{
+        callbackUrl?: string;
+    }>;
+}
+
+export default async function VerifyPage({ searchParams }: VerifyPageProps) {
+    const { callbackUrl: rawCallbackUrl } = await searchParams;
+    const callbackUrl = normalizeCallbackUrl(rawCallbackUrl);
     const session = await auth();
     if (session) {
-        return redirect("/");
+        return redirect(callbackUrl);
     }
 
     return <VerifyForm />;

--- a/packages/web/src/app/login/verify/verifyForm.tsx
+++ b/packages/web/src/app/login/verify/verifyForm.tsx
@@ -14,12 +14,14 @@ import useCaptureEvent from "@/hooks/useCaptureEvent"
 import { Footer } from "@/app/components/footer"
 import { SOURCEBOT_SUPPORT_EMAIL } from "@/lib/constants"
 import { Redirect } from "@/app/components/redirect"
+import { normalizeCallbackUrl } from "@/lib/authRedirect"
 
 function VerifyPageContent() {
     const [value, setValue] = useState("")
     const [isVerifying, setIsVerifying] = useState(false)
     const searchParams = useSearchParams()
     const email = searchParams.get("email")
+    const callbackUrl = normalizeCallbackUrl(searchParams.get("callbackUrl"))
     const captureEvent = useCaptureEvent();
 
     const handleSubmit = useCallback((code: string) => {
@@ -31,11 +33,12 @@ function VerifyPageContent() {
         const url = new URL("/api/auth/callback/nodemailer", window.location.origin)
         url.searchParams.set("token", code)
         url.searchParams.set("email", email)
+        url.searchParams.set("callbackUrl", callbackUrl)
         // Use a full-page navigation (not router.push) so the auth callback's
         // session cookie + 302 redirect are applied by the browser, and the
         // one-time token isn't consumed twice by a client-side RSC navigation.
         window.location.href = url.toString()
-    }, [email, isVerifying])
+    }, [callbackUrl, email, isVerifying])
 
     // Auto-submit once the full 6-digit code is entered. Pass the new value
     // directly rather than reading `value`, which hasn't been committed yet.

--- a/packages/web/src/app/signup/page.tsx
+++ b/packages/web/src/app/signup/page.tsx
@@ -6,6 +6,7 @@ import { createLogger, env } from "@sourcebot/shared";
 import { SINGLE_TENANT_ORG_ID } from "@/lib/constants";
 import { __unsafePrisma } from "@/prisma";
 import { isAnonymousAccessEnabled } from "@/lib/entitlements";
+import { normalizeCallbackUrl } from "@/lib/authRedirect";
 
 const logger = createLogger('signup-page');
 
@@ -18,10 +19,11 @@ interface LoginProps {
 
 export default async function Signup(props: LoginProps) {
     const searchParams = await props.searchParams;
+    const callbackUrl = normalizeCallbackUrl(searchParams.callbackUrl);
     const session = await auth();
     if (session) {
         logger.info("Session found in signup page, redirecting to home");
-        return redirect("/");
+        return redirect(callbackUrl);
     }
 
     const org = await __unsafePrisma.org.findUnique({ where: { id: SINGLE_TENANT_ORG_ID } });
@@ -35,7 +37,7 @@ export default async function Signup(props: LoginProps) {
         <div className="flex flex-col min-h-screen bg-backgroundSecondary">
             <div className="flex-1 flex flex-col items-center p-4 sm:p-12 w-full">
                 <LoginForm
-                    callbackUrl={searchParams.callbackUrl}
+                    callbackUrl={callbackUrl}
                     error={searchParams.error}
                     context="signup"
                     isAnonymousAccessEnabled={anonymousAccessEnabled}

--- a/packages/web/src/ee/features/chat/components/chatThread/signInPromptBanner.tsx
+++ b/packages/web/src/ee/features/chat/components/chatThread/signInPromptBanner.tsx
@@ -4,7 +4,8 @@ import { Button } from '@/components/ui/button';
 import { captureEvent } from '@/hooks/useCaptureEvent';
 import { X } from 'lucide-react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useSearchParams } from 'next/navigation';
+import { createLoginUrl } from '@/lib/authRedirect';
 import { useState, useEffect } from 'react';
 
 const DISMISSED_KEY = 'sb.chat-sign-in-prompt-dismissed';
@@ -25,6 +26,8 @@ export const SignInPromptBanner = ({
     isTurnInProgress,
 }: SignInPromptBannerProps) => {
     const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const loginHref = createLoginUrl(`${pathname}?${searchParams.toString()}`);
     const [isDismissed, setIsDismissed] = useState(true); // Start as true to avoid flash
     const [hasDisplayedEventFired, setHasDisplayedEventFired] = useState(false);
 
@@ -76,7 +79,7 @@ export const SignInPromptBanner = ({
                     asChild
                     onClick={handleSignInClick}
                 >
-                    <Link href={`/login?callbackUrl=${encodeURIComponent(pathname)}`}>
+                    <Link href={loginHref}>
                         Sign in
                     </Link>
                 </Button>

--- a/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.tsx
+++ b/packages/web/src/ee/features/chat/mcp/components/connectorsMenu.tsx
@@ -22,7 +22,8 @@ import { isServiceError } from "@/lib/utils";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangleIcon, CableIcon, Loader2Icon, PlusCircleIcon, PlusIcon, RefreshCwIcon, SettingsIcon, SparklesIcon } from "lucide-react";
 import Link from "next/link";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { createLoginUrl } from "@/lib/authRedirect";
 import { useEffect, useRef, useState } from "react";
 import { useSlate } from "slate-react";
 import { Editor } from "slate";
@@ -118,9 +119,10 @@ export const ConnectorsMenu = ({
     const queryClient = useQueryClient();
     const router = useRouter();
     const pathname = usePathname();
+    const searchParams = useSearchParams();
     const { toast } = useToast();
     const isOwner = useRole() === OrgRole.OWNER;
-    const loginHref = `/login?callbackUrl=${encodeURIComponent(pathname)}`;
+    const loginHref = createLoginUrl(`${pathname}?${searchParams.toString()}`);
 
     const { data: servers = [], error, isError, isLoading, refetch } = useQuery({
         queryKey: mcpQueryKeys.serversWithStatus,

--- a/packages/web/src/features/chat/components/chatBox/loginDialog.tsx
+++ b/packages/web/src/features/chat/components/chatBox/loginDialog.tsx
@@ -8,7 +8,7 @@ import {
     DialogTitle,
 } from "@/components/ui/dialog";
 import { AuthMethodSelector } from "@/app/components/authMethodSelector";
-import { usePathname } from "next/navigation";
+import { usePathname, useSearchParams } from "next/navigation";
 
 interface LoginDialogProps {
     isOpen: boolean;
@@ -20,6 +20,8 @@ export const LoginDialog = ({
     onOpenChange,
 }: LoginDialogProps) => {
     const pathname = usePathname();
+    const searchParams = useSearchParams();
+    const callbackUrl = `${pathname}?${searchParams.toString()}`;
 
     return (
         <Dialog open={isOpen} onOpenChange={onOpenChange}>
@@ -33,7 +35,7 @@ export const LoginDialog = ({
                 <div className="mt-4">
                     <AuthMethodSelector
                         context="login"
-                        callbackUrl={pathname}
+                        callbackUrl={callbackUrl}
                         hideSecurityNotice={true}
                     />
                 </div>

--- a/packages/web/src/lib/authRedirect.test.ts
+++ b/packages/web/src/lib/authRedirect.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { createLoginUrl, normalizeCallbackUrl } from './authRedirect';
+
+describe('normalizeCallbackUrl', () => {
+    it('preserves a relative path and query string', () => {
+        expect(normalizeCallbackUrl('/search?query=auth%20flow&isRegexEnabled=true'))
+            .toBe('/search?query=auth%20flow&isRegexEnabled=true');
+    });
+
+    it('rejects external and protocol-relative URLs', () => {
+        expect(normalizeCallbackUrl('https://evil.example.com/login')).toBe('/');
+        expect(normalizeCallbackUrl('//evil.example.com/login')).toBe('/');
+        expect(normalizeCallbackUrl('search?query=auth')).toBe('/');
+    });
+
+    it('rejects malformed callback values', () => {
+        expect(normalizeCallbackUrl('\\\\evil.example.com')).toBe('/');
+        expect(normalizeCallbackUrl(undefined)).toBe('/');
+    });
+});
+
+describe('createLoginUrl', () => {
+    it('encodes the complete callback URL', () => {
+        expect(createLoginUrl('/chat/thread-1?status=error&message=try%20again'))
+            .toBe('/login?callbackUrl=%2Fchat%2Fthread-1%3Fstatus%3Derror%26message%3Dtry%2520again');
+    });
+});

--- a/packages/web/src/lib/authRedirect.ts
+++ b/packages/web/src/lib/authRedirect.ts
@@ -1,0 +1,37 @@
+export const REQUEST_PATH_HEADER = 'x-sourcebot-request-path';
+
+const CALLBACK_URL_ORIGIN = 'https://sourcebot.invalid';
+
+/**
+ * Return a same-origin relative URL suitable for use as an auth callback.
+ *
+ * Callback URLs can come from query parameters, so they must be validated at
+ * every boundary where they are consumed. Fragments are intentionally kept
+ * out of server-generated callback URLs because browsers do not send them to
+ * the server.
+ */
+export function normalizeCallbackUrl(callbackUrl: unknown): string {
+    if (
+        typeof callbackUrl !== 'string' ||
+        callbackUrl.length === 0 ||
+        !callbackUrl.startsWith('/') ||
+        callbackUrl.startsWith('//')
+    ) {
+        return '/';
+    }
+
+    try {
+        const url = new URL(callbackUrl, CALLBACK_URL_ORIGIN);
+        if (url.origin !== CALLBACK_URL_ORIGIN) {
+            return '/';
+        }
+
+        return `${url.pathname}${url.search}`;
+    } catch {
+        return '/';
+    }
+}
+
+export function createLoginUrl(callbackUrl: unknown): string {
+    return `/login?callbackUrl=${encodeURIComponent(normalizeCallbackUrl(callbackUrl))}`;
+}

--- a/packages/web/src/middleware/authenticatedPage.tsx
+++ b/packages/web/src/middleware/authenticatedPage.tsx
@@ -2,6 +2,8 @@ import { withAuth, withOptionalAuth } from "./withAuth";
 import { isServiceError } from "@/lib/utils";
 import { Org, OrgRole, PrismaClient, UserWithAccounts } from "@sourcebot/db";
 import { redirect } from "next/navigation";
+import { headers } from "next/headers";
+import { createLoginUrl, REQUEST_PATH_HEADER } from "@/lib/authRedirect";
 
 type RequiredPageAuthContext = {
     user: UserWithAccounts;
@@ -77,7 +79,8 @@ export function authenticatedPage<
             const result = await withOptionalAuth(async (ctx) => ctx);
 
             if (isServiceError(result)) {
-                redirect('/login');
+                const requestHeaders = await headers();
+                redirect(createLoginUrl(requestHeaders.get(REQUEST_PATH_HEADER)));
             }
 
             return fn(result as AuthContextFor<O>, props);
@@ -85,7 +88,8 @@ export function authenticatedPage<
             const result = await withAuth(async (ctx) => ctx);
 
             if (isServiceError(result)) {
-                redirect('/login');
+                const requestHeaders = await headers();
+                redirect(createLoginUrl(requestHeaders.get(REQUEST_PATH_HEADER)));
             }
 
             const requiredOpts = opts as RequiredAuthOptions | undefined;

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -1,6 +1,7 @@
 import { StatusCodes } from 'http-status-codes';
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { REQUEST_PATH_HEADER } from './lib/authRedirect';
 
 /**
  * As part of our original SaaS effort in April 2025, we introduced
@@ -36,5 +37,12 @@ export async function proxy(request: NextRequest) {
         return NextResponse.redirect(url, StatusCodes.MOVED_PERMANENTLY);
     }
 
-    return NextResponse.next();
+    const requestHeaders = new Headers(request.headers);
+    requestHeaders.set(REQUEST_PATH_HEADER, `${request.nextUrl.pathname}${request.nextUrl.search}`);
+
+    return NextResponse.next({
+        request: {
+            headers: requestHeaders,
+        },
+    });
 }


### PR DESCRIPTION
Fixes #1649

## Summary
- Preserve the original path and query string when auth guards send users to login.
- Keep search and Ask/chat URLs across OAuth, credentials, magic-link, and email-code flows.
- Validate callback URLs as same-origin relative paths.

## Verification
- `yarn workspace @sourcebot/web test src/lib/authRedirect.test.ts --run`
- `yarn workspace @sourcebot/web exec tsc --noEmit`
- `yarn workspace @sourcebot/web lint`

No visual changes.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches authentication redirect boundaries across login guards and callback URL handling; validation reduces open-redirect risk but mis-handled callbacks could still send users to the wrong page after sign-in.
> 
> **Overview**
> Fixes login redirects dropping query strings so users return to the same search or Ask/chat URL after signing in.
> 
> Introduces **`normalizeCallbackUrl`** and **`createLoginUrl`** in `authRedirect.ts` (with unit tests) to keep only safe same-origin relative paths and reject open-redirect targets. The edge **`proxy`** now stamps **`x-sourcebot-request-path`** with the current path and search; the app layout, auth middleware, GCP IAP, and account-linking flows use that value when sending users to login or post-auth callbacks.
> 
> Login, signup, magic-link verification, OAuth/credentials flows, and in-app sign-in links (chat share, banners, MCP connectors, login dialog) now pass the full **`pathname?query`** through **`callbackUrl`** instead of path-only or `/`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b6b0b934a2c80fa44eadd371d5dd6841379af900. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1649. Auth guards now preserve the original path and query string when redirecting to login, so users land back on the page they intended after authenticating instead of the home page. Callback URLs are now validated as same-origin relative paths before use to prevent open redirects.

**Bug Fixes**

- Adds `normalizeCallbackUrl` and `createLoginUrl` helpers with unit tests in `packages/web/src/lib/authRedirect.ts`.
- Captures the intended URL server-side via the `x-sourcebot-request-path` header set in `proxy.ts` and read by the app layout and authenticated page middleware.
- Applies the same normalizing logic to the login, signup, magic-link verification, and in-page sign-in prompt and dialog flows.
- Already-authenticated users visiting `/login` or `/signup` are now redirected to the requested URL instead of `/`.

<sup>Written for commit b6b0b934a2c80fa44eadd371d5dd6841379af900. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/sourcebot-dev/sourcebot/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Preserved the current page and search parameters when signing in, using magic links, verifying accounts, or creating an account.
  - Returned users to their original destination after authentication instead of always sending them to the home page.
  - Improved login redirects from chat, sharing, connector, and account-linking flows.
  - Prevented unsafe or external callback URLs from being used.

- **Tests**
  - Added coverage for preserving valid callback URLs and rejecting unsafe redirect destinations.

- **Documentation**
  - Documented the updated login redirect behavior in the unreleased changelog.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->